### PR TITLE
STEP 2: checkout validation scripts from main only

### DIFF
--- a/.github/workflows/validate-html.yml
+++ b/.github/workflows/validate-html.yml
@@ -19,6 +19,16 @@ jobs:
         persist-credentials: false
         submodules: false
       
+    - name: Checkout validation scripts from main
+      uses: actions/checkout@v4
+      with:
+        ref: main
+        sparse-checkout: |
+          .github/scripts/
+        sparse-checkout-cone-mode: false
+        path: .github-trusted
+        persist-credentials: false
+      
     - name: Find all unstyled.html files
       id: find-html-files
       run: |
@@ -61,7 +71,7 @@ jobs:
               continue
             fi
             
-            python3 .github/scripts/validate_html.py "$file" syntax 2>&1
+            python3 .github-trusted/.github/scripts/validate_html.py "$file" syntax 2>&1
             
             if [ $? -eq 0 ]; then
               echo "✅ $file is valid HTML"
@@ -101,7 +111,7 @@ jobs:
             echo "🔍 Checking structure of: $file"
             
             # Check HTML structure
-            python3 .github/scripts/validate_html.py "$file" structure 2>&1
+            python3 .github-trusted/.github/scripts/validate_html.py "$file" structure 2>&1
             
             if [ $? -ne 0 ]; then
               echo "❌ Structure validation failed for $file"

--- a/.github/workflows/validate-json.yml
+++ b/.github/workflows/validate-json.yml
@@ -18,6 +18,16 @@ jobs:
         persist-credentials: false
         submodules: false
       
+    - name: Checkout validation scripts from main
+      uses: actions/checkout@v4
+      with:
+        ref: main
+        sparse-checkout: |
+          .github/scripts/
+        sparse-checkout-cone-mode: false
+        path: .github-trusted
+        persist-credentials: false
+      
     - name: Validate index.json
       run: |
         echo "Validating index.json for well-formed JSON..."
@@ -29,7 +39,7 @@ jobs:
         fi
         
         # Validate JSON using the validation script
-        python3 .github/scripts/validate_json.py index.json
+        python3 .github-trusted/.github/scripts/validate_json.py index.json
         
         if [ $? -eq 0 ]; then
           echo "🎉 All validations passed! index.json is well-formed and properly structured."


### PR DESCRIPTION
This implements the actual security fix identified by Voinot. By checking out validation scripts from the trusted main branch, we prevent PRs from modifying their own validation logic.

Currently, both workflows check out the entire PR branch and run validation scripts from that branch. A malicious contributor could:

- Modify `.github/scripts/validate_html.py` or `validate_json.py` to always return success
- Bypass all validation checks
- Inject malicious code into HTML/JSON files

## Solution: Two-Checkout Strategy

Both workflows will use a two-step checkout:

1. **First checkout**: PR code being tested (current behavior) - into workspace root
2. **Second checkout**: Validation scripts from `main` branch - into `.github-trusted/`
3. **Execute**: Run validation scripts from `.github-trusted/` against files from workspace root

✅ Validation scripts are always from trusted main branch
✅ PRs cannot modify their own validation logic
✅ Code being tested still comes from PR (as expected)
✅ Clear audit trail of which validation version was used