### PR TITLE
docs: added workflow suggestion tips

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,23 @@ an interactive tutorial like that!
 don't get rate limited
 2. Sign in with your Grafana account after getting access
 3. **Open in Cursor** - This repo is Cursor-enabled with AI guidance
-4. **Create a tutorial** - Use the `/write My First Tutorial` command to start a new tutorial, giving it a name.
+4. **Create a tutorial** - Use the `/new` command to start a new tutorial, giving it a name.
 5. **See an example** - Check out `first-dashboard/unstyled.html` for a complete working example
 6. **Get help** - Use `/lint`, `/check`, and `/attack` commands to Cursor for validation and testing of what you're writing as you go.
+
+## Authoring workflow / testing your tutorial in Pathfinder
+
+There are several ways to be able to test your interactive tutorials before setting them live. Depending on your set-up it will alter your workflow or dictate what options are available to you.
+
+1. Enable dev mode in Pathfinder. You do this by navigating to the configuration page in Pathfinder and appending the `dev=true` query parameter to your URL. In your Grafana instance the full path should be: `{instance}/plugins/grafana-pathfinder-app?page=configuration&dev=true`
+2. This will show a Dev Mode checkbox in the configuration page. Ensure it is checked then save your settings. The page will automatically refresh.
+3. This will enable the Dev Mode tools in Pathfinder which you can find under the 'Recommendations' tab.
+4. One of the tools is the 'Tutorial Tester'. Here you will see two tabs where you can enter a URL to load up in Pathfinder. The main difference between the two is the 'GitHub' tab has additional validation steps to help guide you to the right path and doesn't expect the `unstyled.html` suffix, where the 'Other' tab is free-form and lets you enter any path which ends in `unstyled.html`.
+5. For what URL to put in, you have two choices:
+  - Either create a GitHub branch in this repo and push your changes as you make updates.
+  - OR run a local server which is serving your interactive tutorials. VSCode / Cursor have an extension called [Live Server authored by Ritwick Dey](https://marketplace.cursorapi.com/items/?itemName=ritwickdey.LiveServer) which makes this exceptionally easy. Just open this repo in Cursor and in the bottom right you click 'Go Live'. Open the local server in your browser (it should open automatically) and you can navigate to any `unstyled.html` tutorial, copy the link and open it in your Pathfinder instance.
+- In Pathfinder there is a refresh button, so as you make changes to your tutorial you don't have to refresh your Grafana Cloud window, just click the refresh button to see your changes immediately.
+- Iterate on your Interactive Tutorial, and once it is complete commit the changes to the branch and open a Pull Request so it can be merged into `main` and set live in production!
 
 ## Ask Cursor Questions in Dev Loop
 


### PR DESCRIPTION
## Problem

Currently there are no human-facing docs which provide a recommended workflow for authoring interactive tutorials.

## Solution

This PR adds documentation for a recommended workflow, especially by using the local server feature added in this PR in the pathfinder repo: https://github.com/grafana/grafana-pathfinder-app/pull/236

