### PR TITLE
Fix tutorial typos and casing

### DIFF
--- a/first-dashboard/content.json
+++ b/first-dashboard/content.json
@@ -1,10 +1,10 @@
 {
   "id": "first-dashboard",
-  "title": "Make your First Dashboard (JSON)",
+  "title": "Make your first dashboard (JSON)",
   "blocks": [
     {
       "type": "markdown",
-      "content": "# Make your First Dashboard\n\nIn this tutorial, we'll make your first dashboard, of Grafana news. To do this, we'll learn the following parts of Grafana in sequence:\n\n- Installing plugins to get access to data (in our case, RSS feeds)\n- Creating data sources, so we have something to visualize\n- Creating a dashboard that uses that datasource\n- Setting up basic Alerting"
+      "content": "# Make your first dashboard\n\nIn this tutorial, we'll make your first dashboard, of Grafana news. To do this, we'll learn the following parts of Grafana in sequence:\n\n- Installing plugins to get access to data (in our case, RSS feeds)\n- Creating data sources, so we have something to visualize\n- Creating a dashboard that uses that data source\n- Setting up basic Alerting"
     },
     {
       "type": "markdown",
@@ -49,18 +49,18 @@
           "reftarget": "Install",
           "requirements": ["is-admin"],
           "hint": "You'll need to be logged in, and an administrator",
-          "content": "Click the Install Button"
+          "content": "Click the Install button"
         }
       ]
     },
     {
       "type": "markdown",
-      "content": "## Step 2: Create a Datasource\n\nA datasource lets us specify which feed we want to use, so we can query it in a dashboard."
+      "content": "## Step 2: Create a data source\n\nA data source lets us specify which feed we want to use, so we can query it in a dashboard."
     },
     {
       "type": "section",
       "id": "create-datasource",
-      "title": "Create a Datasource",
+      "title": "Create a data source",
       "requirements": ["navmenu-open", "has-plugin:volkovlabs-rss-datasource"],
       "objectives": ["has-datasource:volkovlabs-rss-datasource"],
       "blocks": [
@@ -113,12 +113,12 @@
     },
     {
       "type": "markdown",
-      "content": "## Step 3: Create a Dashboard\n\nIn this section, we'll use the datasource we created to create a visualization."
+      "content": "## Step 3: Create a dashboard\n\nIn this section, we'll use the data source we created to create a visualization."
     },
     {
       "type": "section",
       "id": "create-dashboard",
-      "title": "Create a Dashboard",
+      "title": "Create a dashboard",
       "requirements": ["has-datasource:volkovlabs-rss-datasource"],
       "blocks": [
         {


### PR DESCRIPTION
Fix typos and title case errors in the "Make your first dashboard" tutorial.

---
[Slack Thread](https://raintank-corp.slack.com/archives/C08VB4WC64R/p1765403240617039?thread_ts=1765403240.617039&cid=C08VB4WC64R)

<a href="https://cursor.com/background-agent?bcId=bc-d2e43c02-97e2-4471-a210-43487d9c19b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d2e43c02-97e2-4471-a210-43487d9c19b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

