### PR TITLE
Fix k8s-cpu tutorial to target specific namespace

### DIFF
--- a/k8s-cpu/content.json
+++ b/k8s-cpu/content.json
@@ -22,9 +22,9 @@
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "a[data-testid='data-testid Data link']:nth-match(1)",
+          "reftarget": "a[data-testid='data-testid Data link'][href^='/a/grafana-k8s-app/navigation/namespace/'][href*='/quickpizza']",
           "requirements": ["exists-reftarget"],
-          "content": "Select the first namespace in the list to open its detail view."
+          "content": "Select the quickpizza namespace in the list to open its detail view."
         },
         {
           "type": "interactive",


### PR DESCRIPTION
Changed to target specific namespace in Grafana Play instead of first one in list.