### PR TITLE
Shared: added snippets

### DIFF
--- a/shared/index.json
+++ b/shared/index.json
@@ -7,5 +7,54 @@
       "url": "https://interactive-learning.grafana.net/guides/shared/templates/tutorial-datasources"
     }
   ],
-  "snippets": []
+  "snippets": [
+    {
+      "id": "nav-menu-item-click",
+      "title": "Navigation Menu Item Click",
+      "description": "A single block snippet for clicking items in the left navigation menu. Requires navmenu-open.",
+      "url": "https://interactive-learning.grafana.net/guides/shared/snippets/nav-menu-item-click"
+    },
+    {
+      "id": "datasource-picker",
+      "title": "Data Source Picker",
+      "description": "A single block snippet for selecting a datasource using the standard data source picker input.",
+      "url": "https://interactive-learning.grafana.net/guides/shared/snippets/datasource-picker"
+    },
+    {
+      "id": "run-query-button",
+      "title": "Run Query Button",
+      "description": "A single block snippet for clicking the Run query button in Explore and query editors.",
+      "url": "https://interactive-learning.grafana.net/guides/shared/snippets/run-query-button"
+    },
+    {
+      "id": "code-mode-toggle",
+      "title": "Code Mode Toggle",
+      "description": "A single block snippet for switching to Code mode in query editors (Prometheus, Loki, SQL, etc.).",
+      "url": "https://interactive-learning.grafana.net/guides/shared/snippets/code-mode-toggle"
+    },
+    {
+      "id": "query-textarea-formfill",
+      "title": "Query Textarea Formfill",
+      "description": "A single block snippet for entering queries into the code editor textarea.",
+      "url": "https://interactive-learning.grafana.net/guides/shared/snippets/query-textarea-formfill"
+    },
+    {
+      "id": "multistep-save-dashboard",
+      "title": "Multistep: Save Dashboard",
+      "description": "A multistep snippet for saving a dashboard: click Save Dashboard, enter name, click Save.",
+      "url": "https://interactive-learning.grafana.net/guides/shared/snippets/multistep-save-dashboard"
+    },
+    {
+      "id": "multistep-datasource-picker",
+      "title": "Multistep: Datasource Picker",
+      "description": "A multistep snippet for selecting a datasource: click picker, then select the datasource.",
+      "url": "https://interactive-learning.grafana.net/guides/shared/snippets/multistep-datasource-picker"
+    },
+    {
+      "id": "guided-hover-and-click",
+      "title": "Guided: Hover to Reveal and Click",
+      "description": "A guided snippet for hover-to-reveal interactions: hover over an item to reveal buttons, then click.",
+      "url": "https://interactive-learning.grafana.net/guides/shared/snippets/guided-hover-and-click"
+    }
+  ]
 }

--- a/shared/snippets/code-mode-toggle.json
+++ b/shared/snippets/code-mode-toggle.json
@@ -1,0 +1,20 @@
+{
+  "id": "code-mode-toggle",
+  "title": "Code Mode Toggle",
+  "blocks": [
+    {
+      "type": "interactive",
+      "action": "highlight",
+      "reftarget": "div[data-testid='QueryEditorModeToggle'] label[for^='option-code-radiogroup']",
+      "content": "Switch to **Code** mode to write queries directly.",
+      "tooltip": "Code mode allows you to write queries directly as text, giving you full control over the query syntax.",
+      "requirements": [
+        "exists-reftarget"
+      ]
+    }
+  ],
+  "match": {
+    "urlPrefix": [],
+    "tags": []
+  }
+}

--- a/shared/snippets/datasource-picker.json
+++ b/shared/snippets/datasource-picker.json
@@ -1,0 +1,21 @@
+{
+  "id": "datasource-picker",
+  "title": "Data Source Picker",
+  "blocks": [
+    {
+      "type": "interactive",
+      "action": "formfill",
+      "reftarget": "input[data-testid='data-testid Select a data source-input']",
+      "content": "Select the datasource.",
+      "targetvalue": "datasource-name",
+      "tooltip": "Select the datasource from the picker.",
+      "requirements": [
+        "exists-reftarget"
+      ]
+    }
+  ],
+  "match": {
+    "urlPrefix": [],
+    "tags": []
+  }
+}

--- a/shared/snippets/guided-hover-and-click.json
+++ b/shared/snippets/guided-hover-and-click.json
@@ -1,0 +1,28 @@
+{
+  "id": "guided-hover-and-click",
+  "title": "Guided: Hover to Reveal and Click",
+  "blocks": [
+    {
+      "type": "guided",
+      "content": "Hover over the item to reveal action buttons, then click.",
+      "stepTimeout": 45000,
+      "skippable": true,
+      "steps": [
+        {
+          "action": "hover",
+          "reftarget": "div[data-row-id='item-id']",
+          "tooltip": "Hover over the item to reveal action buttons."
+        },
+        {
+          "action": "highlight",
+          "reftarget": "div[data-row-id='item-id'] button:nth-of-type(1)",
+          "tooltip": "Click the action button."
+        }
+      ]
+    }
+  ],
+  "match": {
+    "urlPrefix": [],
+    "tags": []
+  }
+}

--- a/shared/snippets/multistep-datasource-picker.json
+++ b/shared/snippets/multistep-datasource-picker.json
@@ -1,0 +1,27 @@
+{
+  "id": "multistep-datasource-picker",
+  "title": "Multistep: Datasource Picker",
+  "blocks": [
+    {
+      "type": "multistep",
+      "content": "Click on the **datasource picker**, then select the datasource.",
+      "requirements": ["exists-reftarget"],
+      "steps": [
+        {
+          "action": "highlight",
+          "reftarget": "input[data-testid='data-testid Select a data source']",
+          "tooltip": "Click to open the datasource picker."
+        },
+        {
+          "action": "button",
+          "reftarget": "datasource-name",
+          "tooltip": "Select the datasource."
+        }
+      ]
+    }
+  ],
+  "match": {
+    "urlPrefix": [],
+    "tags": []
+  }
+}

--- a/shared/snippets/multistep-save-dashboard.json
+++ b/shared/snippets/multistep-save-dashboard.json
@@ -1,0 +1,29 @@
+{
+  "id": "multistep-save-dashboard",
+  "title": "Multistep: Save Dashboard",
+  "blocks": [
+    {
+      "type": "multistep",
+      "content": "Click **Save Dashboard**, name the dashboard, and click **Save**.",
+      "steps": [
+        {
+          "action": "button",
+          "reftarget": "Save Dashboard"
+        },
+        {
+          "action": "formfill",
+          "reftarget": "input[aria-label='Save dashboard title field']",
+          "targetvalue": "Dashboard Name"
+        },
+        {
+          "action": "button",
+          "reftarget": "Save"
+        }
+      ]
+    }
+  ],
+  "match": {
+    "urlPrefix": [],
+    "tags": []
+  }
+}

--- a/shared/snippets/nav-menu-item-click.json
+++ b/shared/snippets/nav-menu-item-click.json
@@ -1,0 +1,20 @@
+{
+  "id": "nav-menu-item-click",
+  "title": "Navigation Menu Item Click",
+  "blocks": [
+    {
+      "type": "interactive",
+      "action": "highlight",
+      "reftarget": "a[data-testid='data-testid Nav menu item'][href='/path/here']",
+      "content": "Click **Menu Item** in the navigation menu.",
+      "requirements": [
+        "navmenu-open",
+        "exists-reftarget"
+      ]
+    }
+  ],
+  "match": {
+    "urlPrefix": [],
+    "tags": []
+  }
+}

--- a/shared/snippets/query-textarea-formfill.json
+++ b/shared/snippets/query-textarea-formfill.json
@@ -1,0 +1,21 @@
+{
+  "id": "query-textarea-formfill",
+  "title": "Query Textarea Formfill",
+  "blocks": [
+    {
+      "type": "interactive",
+      "action": "formfill",
+      "reftarget": "textarea.inputarea",
+      "content": "Enter your query in the code editor.",
+      "targetvalue": "@@clear@@your_query_here",
+      "tooltip": "Enter your query in the editor.",
+      "requirements": [
+        "exists-reftarget"
+      ]
+    }
+  ],
+  "match": {
+    "urlPrefix": [],
+    "tags": []
+  }
+}

--- a/shared/snippets/run-query-button.json
+++ b/shared/snippets/run-query-button.json
@@ -1,0 +1,20 @@
+{
+  "id": "run-query-button",
+  "title": "Run Query Button",
+  "blocks": [
+    {
+      "type": "interactive",
+      "action": "highlight",
+      "reftarget": "button[data-testid='data-testid RefreshPicker run button']",
+      "content": "Click the **Run query** button to execute the query.",
+      "tooltip": "Execute your query to see the results.",
+      "requirements": [
+        "exists-reftarget"
+      ]
+    }
+  ],
+  "match": {
+    "urlPrefix": [],
+    "tags": []
+  }
+}


### PR DESCRIPTION
This pull request adds a collection of reusable interactive snippet definitions for common UI actions in Grafana, such as clicking navigation items, selecting data sources, running queries, and saving dashboards. These snippets are now referenced in the shared index and defined in individual JSON files, making them available for use in interactive learning guides.

The most important changes include:

**Addition of snippet references to the shared index:**

* Updated `shared/index.json` to include references to eight new interactive and multistep snippets, each with a title, description, and URL.

**New interactive snippet definitions:**

* Added `nav-menu-item-click.json` for highlighting and clicking navigation menu items.
* Added `datasource-picker.json` for selecting a data source using the standard picker input.
* Added `run-query-button.json` for highlighting and clicking the Run Query button.
* Added `code-mode-toggle.json` for switching to code mode in query editors.
* Added `query-textarea-formfill.json` for entering queries into the code editor textarea.

**New multistep and guided snippet definitions:**

* Added `multistep-save-dashboard.json` for the multistep process of saving a dashboard (button click, form fill, save).
* Added `multistep-datasource-picker.json` for the multistep process of selecting a datasource (open picker, select datasource).
* Added `guided-hover-and-click.json` for guided interactions involving hover-to-reveal and click actions.