### PR TITLE
fix deploy process for JSON-only guides

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,19 +46,23 @@ jobs:
           # Copy index.json
           cp index.json guides/
           
-          # Copy all directories containing unstyled.html (these are tutorials)
-          find . -name "unstyled.html" -type f | while read -r file; do
-            dir=$(dirname "$file")
-            # Skip if in current directory or excluded folders
-            if [[ "$dir" != "." && "$dir" != "./docs"* ]]; then
+          # Copy all tutorial directories (containing unstyled.html OR content.json)
+          # must sort and read -r unique to avoid duplicates
+          find . \( -name "unstyled.html" -o -name "content.json" \) -type f \
+            | sed 's|/[^/]*$||' \
+            | sort -u \
+            | while read -r dir; do
+            # Skip excluded folders
+            if [[ "$dir" != "." && "$dir" != "./docs"* && "$dir" != "./shared"* ]]; then
               mkdir -p "guides/$dir"
+              # Copy both files; if one is missing, error gets ignored and it's fine.
               cp "$dir"/*.html "guides/$dir/" 2>/dev/null || true
               cp "$dir"/*.json "guides/$dir/" 2>/dev/null || true
             fi
           done
-          
+
           echo "Files to deploy:"
-          find guides -type f | head -50
+          find guides -type f
 
       - name: Push files to GCS
         uses: grafana/shared-workflows/actions/push-to-gcs@push-to-gcs/v0.3.0


### PR DESCRIPTION
## Problem

The deploy workflow at `.github/workflows/deploy.yml` only discovers tutorials by finding unstyled.html (line 50). JSON-only guides like tour-of-visualizations/ are never deployed.

Marie [here](https://raintank-corp.slack.com/archives/C08VB4WC64R/p1768305493202579) noted that the "tour of visualizations" guide isn't working on Play. Root cause was this was a "JSON-only" guide, and script was looking for unstyled.html only so this guide was never deployed to CDN.  It worked pre-CDN, and when we migrated to CDN it broke.

## Solution

Update the find command to match either unstyled.html or content.json, then deduplicate directories.

## Post-Merge

Need to re-run deploy to CDN job