### PR TITLE
Change match condition from 'and' to 'or'

### DIFF
--- a/index.json
+++ b/index.json
@@ -189,7 +189,7 @@
       "description": "Hands-on guide: Learn how to enable the Block Editor for first-time authors.",
       "type": "interactive",
       "match": {
-        "and": [
+        "or": [
           { "urlPrefix": "/d/ja6hlhh/welcome-to-learn-grafana" },
           { "urlPrefix": "/plugins/grafana-pathfinder-app" }
         ]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small config-only change that broadens when a single interactive guide is shown; low risk aside from potentially triggering the guide on more pages than intended.
> 
> **Overview**
> Updates `index.json` so the "Interactive Guide: Enable Block Editor" rule matches when *either* of its `urlPrefix` conditions applies (`and` → `or`), widening where the guide will be surfaced.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0b9dc09fa4cc537b48e2d417913b1f956881ceb7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->