### PR TITLE
Add myself as a CODEOWNER

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,7 +3,7 @@
 # The last matching rule wins.
 
 # Global fallback - core maintainers
-* @moxious @Jayclifford345 @simonprickett @tomglenn
+* @moxious @Jayclifford345 @simonprickett @tomglenn @jdbaldry
 
 # Infrastructure and documentation
 /.cursor/ @moxious @Jayclifford345 @tomglenn


### PR DESCRIPTION
Maintainer party 🥳

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Administrative change only; it affects review assignment/approval routing but not runtime code or behavior.
> 
> **Overview**
> Updates `.github/CODEOWNERS` to include `@jdbaldry` in the global fallback (core maintainers) ownership rule, expanding default review/approval coverage for any paths not matched by more specific entries.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 83d443d6d5882414b95e3f66d2e7ff180ffe020e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->