### PR TITLE
Add review-apply/content.json for adaptive metrics

### DIFF
--- a/adaptive-metrics-review-apply/content.json
+++ b/adaptive-metrics-review-apply/content.json
@@ -97,10 +97,6 @@
     {
       "type": "markdown",
       "content": "{{< admonition type=\"note\" >}}\nApplying a rule from its expanded view doesn't display a confirmation dialog box.\n{{< /admonition >}}\n\nIn the next milestone, you'll learn how to create aggregation and drop rules."
-    }
-  ],
-  "match": {
-    "urlPrefix": [],
-    "tags": []
-  }
+     }
+    ]
 }


### PR DESCRIPTION
I think some of these selector ids will be broken; specifically those that prompted me to select from a populated list, because i don't know what happens if the user doesn't have a populated list. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation/content-only addition with no runtime logic changes; main risk is brittle UI selectors causing the walkthrough to fail in some environments.
> 
> **Overview**
> Adds a new `adaptive-metrics-review-apply/content.json` walkthrough that guides users through reviewing rule recommendations in Adaptive Metrics and applying selected recommendations.
> 
> The flow includes UI interaction steps (nav to Adaptive Metrics, open Rules tab, optional filtering, choosing recommendation types, expanding a row for details, and applying/confirming changes) plus a note about confirmation behavior when applying from expanded view.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e564064c964a41fe31c491fa5a1c695f1d2732ef. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->