### PR TITLE
Add interactive content for `visualization-traces` learning journey

### DIFF
--- a/visualization-traces-lj/add-traces-panel/content.json
+++ b/visualization-traces-lj/add-traces-panel/content.json
@@ -4,14 +4,22 @@
   "blocks": [
     {
       "type": "markdown",
-      "content": "The traces panel visualizes response from the Tempo data source. The traces visualization shows a trace span, icons for associated logs, and opens a detailed view when you select a span.\n\nTo add a Traces panel to a dashboard, complete the following steps:"
+      "content": "Traces visualizations let you follow a request as it traverses the services in your infrastructure. The traces visualization displays traces data in a diagram that allows you to easily interpret it. Traces visualizations currently render one trace traversal based on the traceID used in TraceQL or using a variable.\n\nTo add a Traces panel to a dashboard, complete the following steps:"
     },
     {
-      "type": "interactive",
-      "action": "highlight",
-      "reftarget": "[data-testid='data-testid CanvasGridAddActions add-panel']",
-      "content": "While viewing a dashboard in edit mode, click **Add panel**.",
-      "requirements": ["exists-reftarget"]
+      "type": "multistep",
+      "content": "While viewing a dashboard in edit mode, click the **+** button in the sidebar, then click the **Panel** card to add a new panel.",
+      "requirements": ["exists-reftarget"],
+      "steps": [
+        {
+          "action": "highlight",
+          "reftarget": "[data-testid='data-testid Dashboard Sidebar new button']"
+        },
+        {
+          "action": "highlight",
+          "reftarget": "[data-testid='data-testid sidebar add new panel']"
+        }
+      ]
     },
     {
       "type": "markdown",
@@ -43,7 +51,7 @@
     {
       "type": "interactive",
       "action": "highlight",
-      "reftarget": "label[for*='option-traceql']",
+      "reftarget": "label[for^='option-traceql-']",
       "content": "In the query editor, click the **TraceQL** query type tab.",
       "requirements": ["exists-reftarget"]
     },
@@ -72,6 +80,10 @@
     {
       "type": "markdown",
       "content": "In the next milestone, you'll arrange the order of the panels in the dashboard and test it."
+    },
+    {
+      "type": "markdown",
+      "content": "**More to explore (optional)**\n\nAt this point in your journey, you can explore the following paths:\n\n- [Traces](/docs/grafana-cloud/visualizations/panels-visualizations/visualizations/traces/)"
     }
   ]
 }

--- a/visualization-traces-lj/add-traces-table/content.json
+++ b/visualization-traces-lj/add-traces-table/content.json
@@ -4,7 +4,7 @@
   "blocks": [
     {
       "type": "markdown",
-      "content": "TraceQL is a query language designed for searching and filtering traces within Grafana Cloud. It enables you to write expressions that specify criteria to locate specific traces.\n\nIn this milestone, you'll write a TraceQL query using the Search query builder that visualizes a list of traces in a table.\n\nTo write a TraceQL query, perform the following steps:"
+      "content": "TraceQL is a query language designed for searching and filtering traces within Grafana Cloud. It enables you to write expressions that specify criteria to locate specific traces. A basic TraceQL query consists of key-value pairs that filter traces, ensuring only those matching the defined criteria are included in the results.\n\nIn this milestone, you'll write a TraceQL query using the Search query builder that visualizes a list of traces in a table.\n\nTo write a TraceQL query, perform the following steps:"
     },
     {
       "type": "interactive",
@@ -23,15 +23,6 @@
       "reftarget": "[data-testid='data-testid RefreshPicker run button']",
       "content": "Click **Refresh** to update the list of traces in the table.",
       "requirements": ["exists-reftarget"]
-    },
-    {
-      "type": "interactive",
-      "action": "formfill",
-      "reftarget": "input[data-testid='data-testid Panel editor option pane field input Title']",
-      "targetvalue": "Traces Table",
-      "content": "On the right of the page, under **Panel options**, enter a panel **Title**.\n\nThe title appears at the top of the panel.",
-      "requirements": ["exists-reftarget"],
-      "doIt": false
     },
     {
       "type": "interactive",
@@ -57,7 +48,15 @@
     },
     {
       "type": "markdown",
+      "content": "**Did you know?** If you're using Grafana Enterprise or Grafana Cloud, you can save queries for reuse across panels and dashboards. Click **Save query** to save your current query, or use the **Saved queries** drop-down menu to reuse a previously saved query."
+    },
+    {
+      "type": "markdown",
       "content": "In the next milestone you'll add a dashboard variable."
+    },
+    {
+      "type": "markdown",
+      "content": "**More to explore (optional)**\n\nAt this point in your journey, you can explore the following paths:\n\n- [TraceQL](/docs/tempo/latest/traceql/#construct-a-traceql-query)\n- [Investigate traces using Search query builder](/docs/grafana-cloud/connect-externally-hosted/data-sources/tempo/query-editor/traceql-search/)\n- [Query tracing data](/docs/grafana-cloud/send-data/traces/traces-query-editor/)"
     }
   ]
 }

--- a/visualization-traces-lj/add-variable/content.json
+++ b/visualization-traces-lj/add-variable/content.json
@@ -4,7 +4,7 @@
   "blocks": [
     {
       "type": "markdown",
-      "content": "Grafana dashboard variables let you create dynamic and interactive views of your tracing data. Instead of having a static dashboard, variables let you filter, drill down, and explore your traces without manually editing queries.\n\nIn this milestone, you'll add a dashboard variable that allows you to filter and explore trace spans based on specific trace IDs.\n\nTo add a dashboard variable, complete the following steps:"
+      "content": "Grafana dashboard variables let you create dynamic and interactive views of your tracing data. Instead of having a static dashboard that always shows the same information, variables let you filter, drill down, and explore your traces without having to manually edit queries or create multiple dashboards.\n\nDashboard variables transform your traces dashboards from static reports into powerful, interactive investigative tools, significantly improving your ability to understand, monitor, and troubleshoot distributed systems.\n\nIn this milestone, you'll add a dashboard variable that allows you to filter and explore trace spans based on specific trace IDs.\n\nTo add a dashboard variable, complete the following steps:"
     },
     {
       "type": "interactive",
@@ -27,22 +27,19 @@
     },
     {
       "type": "markdown",
-      "content": "In the **Name** field of the **General** section enter `traceId`."
+      "content": "In the **Name** field of the **Custom variable** modal, enter `traceId`."
     },
     {
       "type": "markdown",
-      "content": "In the **Label** field, enter `Trace ID`."
-    },
-    {
-      "type": "interactive",
-      "action": "button",
-      "reftarget": "Save",
-      "content": "Click **Save**.\n\n`Trace ID` appears above the panel.",
-      "requirements": ["exists-reftarget"]
+      "content": "In the **Label** field, enter `Trace ID`.\n\n`Trace ID` appears above the panel."
     },
     {
       "type": "markdown",
       "content": "In the next milestone, you'll add a traces panel that populates with trace details."
+    },
+    {
+      "type": "markdown",
+      "content": "**More to explore (optional)**\n\nAt this point in your journey, you can explore the following paths:\n\n- [Variables](/docs/grafana-cloud/visualizations/dashboards/variables/)"
     }
   ]
 }

--- a/visualization-traces-lj/add-visualization/content.json
+++ b/visualization-traces-lj/add-visualization/content.json
@@ -4,7 +4,7 @@
   "blocks": [
     {
       "type": "markdown",
-      "content": "A dashboard is a set of one or more panels organized and arranged into one or more rows. Grafana ships with a variety of panels making it easy to construct the right queries and customize the visualization.\n\nTo create a dashboard and add a visualization, complete the following steps:"
+      "content": "A Grafana dashboard is a set of one or more panels, organized and arranged into one or more rows, that provide an at-a-glance view of related information. These panels are created using components that query and transform raw data from a data source into visualizations.\n\nA data source can be an SQL database, Grafana Loki, Grafana Mimir, or an API endpoint. It can even be a basic CSV file. Data source plugins take a query you want answered, retrieve the data from the data source, and reconcile the differences between the data model of the data source and the data model of Grafana dashboards.\n\nTo create a dashboard and add a visualization, complete the following steps:"
     },
     {
       "type": "markdown",
@@ -66,6 +66,10 @@
     {
       "type": "markdown",
       "content": "In your next milestone, you'll use the Query Builder to write a TraceQL query that generates a list of traces."
+    },
+    {
+      "type": "markdown",
+      "content": "**More to explore (optional)**\n\nAt this point in your journey, you can explore the following paths:\n\n- [Grafana dashboard best practices](/docs/grafana-cloud/visualizations/dashboards/build-dashboards/best-practices/)\n- [Visualizations](/docs/grafana/latest/panels-visualizations/visualizations/)"
     }
   ]
 }

--- a/visualization-traces-lj/test-dashboard/content.json
+++ b/visualization-traces-lj/test-dashboard/content.json
@@ -8,7 +8,7 @@
     },
     {
       "type": "markdown",
-      "content": "While in dashboard edit mode, hover your cursor over the traces table panel until you see a move cursor.\n\nClick and drag the traces table and place it above the traces panel.\n\n**Tip:** You aren't required to change the order of the panels, but having the traces table above the traces panel makes working with the dashboard more intuitive for users."
+      "content": "While in dashboard edit mode, hover your cursor over the traces table panel until you see a move cursor.\n\nClick and drag the traces table and place it above the traces panel.\n\n**Did you know?** You aren't required to change the order of the panels, but having the traces table above the traces panel makes working with the dashboard a bit more intuitive for users."
     },
     {
       "type": "markdown",

--- a/visualization-traces-lj/time-range-refresh/content.json
+++ b/visualization-traces-lj/time-range-refresh/content.json
@@ -4,7 +4,7 @@
   "blocks": [
     {
       "type": "markdown",
-      "content": "You can define the time span for which data is displayed in the visualization. For instance, if the current time is 1 PM and you set a time range of 1 hour, the visualization will show data from 12 PM to 1 PM.\n\nAdditionally, you can enable automatic data refresh for the visualization. The refresh interval determines how frequently the data is updated.\n\n**Tip:** Choose the slowest refresh interval that meets your requirements. Selecting a faster interval when data changes infrequently can degrade dashboard performance.\n\nTo configure a visualization time range and refresh interval, complete the following steps:"
+      "content": "You can define the time span for which data is displayed in the visualization. For instance, if the current time is 1 PM and you set a time range of 1 hour, the visualization will show data from 12 PM to 1 PM. A variety of predefined time ranges are available for selection.\n\nAdditionally, you can enable automatic data refresh for the visualization. The refresh interval determines how frequently the data is updated. For example, setting a 1-minute refresh interval means that the data updates every minute. You can choose from multiple refresh intervals based on your specific needs.\n\n**Tip:** Choose the slowest refresh interval that meets your requirements. If near real-time updates are unnecessary, opt for a 1-minute or longer refresh interval. Selecting a faster interval when data changes infrequently can degrade dashboard performance.\n\nTo configure a visualization time range and refresh interval, complete the following steps:"
     },
     {
       "type": "interactive",
@@ -31,15 +31,12 @@
       "content": "Select a refresh interval from the options (for example, **1m**, **5m**, or **Off**)."
     },
     {
-      "type": "interactive",
-      "action": "button",
-      "reftarget": "Save",
-      "content": "Click **Save** to save the dashboard so that other users can view it.",
-      "requirements": ["exists-reftarget"]
+      "type": "markdown",
+      "content": "Congratulations! You've completed this milestone and are ready to finish your journey."
     },
     {
       "type": "markdown",
-      "content": "Congratulations! You've completed this milestone and are ready to finish your journey."
+      "content": "**More to explore (optional)**\n\nAt this point in your journey, you can explore the following paths:\n\n- [Common time range controls](/docs/grafana-cloud/visualizations/dashboards/use-dashboards/#common-time-range-controls)\n- [Refresh dashboard](/docs/grafana-cloud/visualizations/dashboards/use-dashboards/#refresh-dashboard)\n- [Troubleshoot dashboards](/docs/grafana-cloud/visualizations/dashboards/troubleshoot-dashboards)"
     }
   ]
 }


### PR DESCRIPTION
### Summary

This PR adds interactive content (`content.json` files) for the "Visualize traces" learning journey, enabling "Show me" and "Do it" buttons in Grafana Pathfinder.

### Changes

| Milestone | File | Interactive Blocks | Description |
|-----------|------|-------------------|-------------|
| Create a dashboard and add a visualization | `add-visualization/content.json` | 4 | Data source picker, visualization type selection |
| Write TraceQL query | `add-traces-table/content.json` | 5 | Search tab, refresh, panel title, save, back to dashboard |
| Add a dashboard variable | `add-variable/content.json` | 3 | Edit button, add variable, save |
| Add Traces panel to dashboard | `add-traces-panel/content.json` | 5 | Add panel, data source, visualization picker, TraceQL tab, save |
| Configure time range and refresh | `time-range-refresh/content.json` | 3 | Time picker, refresh interval, save |
| Reorder and test dashboard | `test-dashboard/content.json` | 0 | All markdown (manual drag/drop instructions) |

### Docs updates

Updated `website/content/docs/learning-journeys/visualization-traces/add-variable/index.md`:
- Changed "click **Settings**" → "click **Edit**" (UI changed)
- Removed "Click the **Variables** tab" step (no longer in UI)
- Changed "Click **Back to dashboard**" → "Click **Save**"

### Selector patterns used

- `data-testid` selectors for stable targeting (e.g., `[data-testid='data-testid Edit dashboard button']`)
- `label[for*='...']` pattern for radio button tabs (Search, TraceQL)
- `input[data-testid='data-testid Select a data source']` for data source picker
- `button` action for text-based buttons (Save, Add variable, Back to dashboard)

### Testing

- ✅ JSON validation passed
- ✅ All highlights working correctly in Pathfinder Block Editor
- ✅ Show me / Do it buttons functional
- ✅ Selectors verified against current Grafana Cloud UI

### Related

- Learning journey: `/docs/learning-journeys/visualization-traces/`
- Repos affected: `interactive-tutorials`, `website`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Content-only additions (new JSON tutorial assets) with no production code or data-path changes; main risk is selector drift causing tutorial steps to fail in the UI.
> 
> **Overview**
> Adds a new set of Pathfinder interactive tutorial definitions for the `visualization-traces` learning journey, covering dashboard creation, building a TraceQL table, adding a `traceId` variable, adding a Traces panel driven by `${traceId}`, and configuring time range/refresh.
> 
> The new `content.json` files include targeted UI selectors (`data-testid`, `label[for*]`, and button text) to enable **Show me** highlights and limited **Do it** actions, plus a manual-only milestone for reordering panels and validating the resulting dashboard behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a15dec315c107f39b31a4290944fe406ae435bc9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->