### PR TITLE
Author guidance exists-reftarget

### DIFF
--- a/.cursor/action-types-reference.mdc
+++ b/.cursor/action-types-reference.mdc
@@ -45,19 +45,15 @@ User wants to teach workflow:
 | `image`       | Embedded image                       | src, alt                          |
 | `video`       | Embedded video                       | src, provider                     |
 
-## Essential Requirements Pattern
+## Requirements Pattern
 
-```json
-{
-  "requirements": ["exists-reftarget"]
-}
-```
-
-Add based on context:
+Add requirements based on context:
 - Navigation elements: `"navmenu-open"`
 - Page-specific: `"on-page:/path"`
 - Admin actions: `"is-admin"`
 - Data source: `"has-datasource:type"`
+
+> **Note**: `exists-reftarget` is automatically applied for all DOM actions—you don't need to add it manually.
 
 ## Common Patterns
 
@@ -67,7 +63,7 @@ Add based on context:
   "type": "interactive",
   "action": "highlight",
   "reftarget": "a[data-testid='data-testid Nav menu item'][href='/dashboards']",
-  "requirements": ["navmenu-open", "exists-reftarget"],
+  "requirements": ["navmenu-open"],
   "content": "Click Dashboards"
 }
 ```

--- a/.cursor/ai-guide-reference.mdc
+++ b/.cursor/ai-guide-reference.mdc
@@ -53,7 +53,7 @@ Quick reference for AI generating interactive Grafana guides.
   "type": "interactive",
   "action": "highlight",
   "reftarget": "a[data-testid='data-testid Nav menu item'][href='/dashboards']",
-  "requirements": ["navmenu-open", "exists-reftarget"],
+  "requirements": ["navmenu-open"],
   "content": "Click Dashboards"
 }
 ```
@@ -64,7 +64,6 @@ Quick reference for AI generating interactive Grafana guides.
   "type": "interactive",
   "action": "button",
   "reftarget": "Save & test",
-  "requirements": ["exists-reftarget"],
   "content": "Save the configuration"
 }
 ```
@@ -76,7 +75,6 @@ Quick reference for AI generating interactive Grafana guides.
   "action": "formfill",
   "reftarget": "input[id='basic-settings-name']",
   "targetvalue": "my-value",
-  "requirements": ["exists-reftarget"],
   "content": "Enter the name"
 }
 ```
@@ -118,11 +116,12 @@ Quick reference for AI generating interactive Grafana guides.
 
 | Context | Requirements |
 |---------|-------------|
-| Any DOM action | `exists-reftarget` |
-| Navigation menu | `navmenu-open`, `exists-reftarget` |
-| Page-specific | `on-page:/path`, `exists-reftarget` |
-| Admin action | `is-admin`, `exists-reftarget` |
-| Data source | `has-datasource:name`, `exists-reftarget` |
+| Navigation menu | `navmenu-open` |
+| Page-specific | `on-page:/path` |
+| Admin action | `is-admin` |
+| Data source | `has-datasource:name` |
+
+> **Note**: `exists-reftarget` is automatically applied for all DOM actions—you don't need to add it manually.
 
 ## Selector Best Practices
 
@@ -139,7 +138,6 @@ Quick reference for AI generating interactive Grafana guides.
 ## AI Quality Checklist
 
 Before generating a guide:
-- [ ] Include `exists-reftarget` for all DOM actions
 - [ ] Add `navmenu-open` for navigation elements
 - [ ] Use stable selectors (data-testid, button text)
 - [ ] Provide clear, action-focused content

--- a/.cursor/best-practices.mdc
+++ b/.cursor/best-practices.mdc
@@ -21,10 +21,11 @@ language, not discourse & concepts. Rely on links for concepts.
 
 ### Include requirements wherever possible
 
-* Every DOM interaction needs `exists-reftarget`
 * Navigation elements need `navmenu-open`
 * Page-specific actions need `on-page:/path`
 * Be aware of what roles a given feature needs; Admin features need `is-admin` or appropriate role requirements
+
+**Note**: The `exists-reftarget` requirement is automatically applied by the plugin for all DOM interactions, so you don't need to add it manually.
 
 ### Connect Requirements and Objectives
 

--- a/.cursor/requirements-quick-reference.mdc
+++ b/.cursor/requirements-quick-reference.mdc
@@ -9,40 +9,41 @@ alwaysApply: true
 
 Requirements are JSON arrays. All must pass:
 ```json
-"requirements": ["navmenu-open", "exists-reftarget", "on-page:/dashboards"]
+"requirements": ["navmenu-open", "on-page:/dashboards"]
 ```
 
 ## Essential Requirements
 
 | Requirement          | When to Use                                     |
 |----------------------|-------------------------------------------------|
-| `exists-reftarget`   | **Always** for DOM actions (highlight, formfill)|
 | `navmenu-open`       | Navigation menu interactions                    |
 | `on-page:/path`      | Page-specific actions                           |
 | `is-admin`           | Admin-only features                             |
 | `has-datasource:X`   | Data source dependent actions                   |
 | `has-plugin:id`      | Plugin dependent features                       |
 
+> **Note**: `exists-reftarget` is automatically applied by the plugin for all DOM interactions—you don't need to add it manually.
+
 ## Common Combinations
 
 **Navigation elements:**
 ```json
-"requirements": ["navmenu-open", "exists-reftarget"]
+"requirements": ["navmenu-open"]
 ```
 
 **Dashboard page actions:**
 ```json
-"requirements": ["on-page:/dashboard", "exists-reftarget"]
+"requirements": ["on-page:/dashboard"]
 ```
 
 **Admin actions:**
 ```json
-"requirements": ["is-admin", "on-page:/admin", "exists-reftarget"]
+"requirements": ["is-admin", "on-page:/admin"]
 ```
 
 **Data source actions:**
 ```json
-"requirements": ["has-datasource:prometheus", "exists-reftarget"]
+"requirements": ["has-datasource:prometheus"]
 ```
 
 ## Objectives (Auto-Completion)
@@ -60,7 +61,7 @@ Use for:
 ## All Requirement Types
 
 ### Fixed (no arguments)
-- `exists-reftarget`, `navmenu-open`, `form-valid`
+- `exists-reftarget` *(auto-applied—no need to add manually)*, `navmenu-open`, `form-valid`
 - `is-admin`, `is-editor`, `is-logged-in`
 - `has-datasources`, `dashboard-exists`
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,12 +78,13 @@ All guides use JSON format exclusively:
 
 ## Essential Rules
 
-1. **Always include `exists-reftarget`** for DOM interactions
-2. **Use `navmenu-open`** for navigation menu elements
-3. **Include page requirements** for page-specific actions
-4. **Use stable selectors** - prefer `data-testid` over CSS classes
-5. **Add tooltips** for educational value
-6. **Make steps skippable** where appropriate
+1. **Use `navmenu-open`** for navigation menu elements
+2. **Include page requirements** for page-specific actions
+3. **Use stable selectors** - prefer `data-testid` over CSS classes
+4. **Add tooltips** for educational value
+5. **Make steps skippable** where appropriate
+
+> **Note**: `exists-reftarget` is automatically applied for all DOM interactions—you don't need to add it manually.
 
 ## Block Types
 
@@ -120,7 +121,6 @@ Explain interface → highlight with doIt: false
 
 ### Requirements Selection
 ```
-DOM interaction → exists-reftarget
 Navigation element → navmenu-open
 Page-specific → on-page:/path
 Admin feature → is-admin

--- a/docs/interactive-types.md
+++ b/docs/interactive-types.md
@@ -24,7 +24,7 @@ This guide explains the supported interactive types, when to use each, what `ref
   "type": "interactive",
   "action": "highlight",
   "reftarget": "a[data-testid='data-testid Nav menu item'][href='/dashboards']",
-  "requirements": ["navmenu-open", "exists-reftarget"],
+  "requirements": ["navmenu-open"],
   "content": "Open Dashboards"
 }
 ```
@@ -42,7 +42,6 @@ This guide explains the supported interactive types, when to use each, what `ref
   "type": "interactive",
   "action": "button",
   "reftarget": "Save & test",
-  "requirements": ["exists-reftarget"],
   "content": "Save the data source"
 }
 ```
@@ -62,7 +61,6 @@ This guide explains the supported interactive types, when to use each, what `ref
   "action": "formfill",
   "reftarget": "input[id='connection-url']",
   "targetvalue": "http://prometheus:9090",
-  "requirements": ["exists-reftarget"],
   "content": "Set URL"
 }
 ```
@@ -114,7 +112,6 @@ Use `validateInput: true` to require the input to match a pattern:
   "type": "interactive",
   "action": "hover",
   "reftarget": "div[data-testid='table-row']",
-  "requirements": ["exists-reftarget"],
   "content": "Hover over the row to reveal action buttons"
 }
 ```
@@ -191,7 +188,6 @@ Use `validateInput: true` to require the input to match a pattern:
     {
       "action": "hover",
       "reftarget": ".gf-form:has([data-testid='prometheus-type']) label > svg",
-      "requirements": ["exists-reftarget"],
       "tooltip": "The **Performance** section contains advanced settings."
     },
     {

--- a/docs/requirements-reference.md
+++ b/docs/requirements-reference.md
@@ -35,12 +35,13 @@ This comprehensive guide covers all supported requirements for interactive guide
 
 **Purpose**: Verifies the target element specified in `reftarget` exists on the page.
 
+> **Note**: This requirement is automatically applied by the plugin for all DOM interactions. You don't need to add it manually—it's included here for reference.
+
 ```json
 {
   "type": "interactive",
   "action": "button",
   "reftarget": "Save dashboard",
-  "requirements": ["exists-reftarget"],
   "content": "Save your dashboard changes."
 }
 ```
@@ -397,7 +398,7 @@ Requirements can be combined in arrays. **All requirements must pass** for the e
   "type": "interactive",
   "action": "button",
   "reftarget": "Delete user",
-  "requirements": ["is-admin", "on-page:/admin/users", "exists-reftarget"],
+  "requirements": ["is-admin", "on-page:/admin/users"],
   "content": "Remove the selected user."
 }
 ```
@@ -406,18 +407,20 @@ Requirements can be combined in arrays. **All requirements must pass** for the e
 
 **Navigation actions**:
 ```json
-"requirements": ["navmenu-open", "exists-reftarget"]
+"requirements": ["navmenu-open"]
 ```
 
 **Admin actions**:
 ```json
-"requirements": ["is-admin", "on-page:/admin", "exists-reftarget"]
+"requirements": ["is-admin", "on-page:/admin"]
 ```
 
 **Data source actions**:
 ```json
-"requirements": ["has-datasource:prometheus", "on-page:/explore", "exists-reftarget"]
+"requirements": ["has-datasource:prometheus", "on-page:/explore"]
 ```
+
+> **Note**: `exists-reftarget` is automatically applied to all DOM actions, so it doesn't need to be included in these combinations.
 
 ---
 
@@ -433,7 +436,6 @@ Objectives use the same syntax as requirements but serve a different purpose:
   "type": "interactive",
   "action": "button",
   "reftarget": "Install plugin",
-  "requirements": ["exists-reftarget"],
   "objectives": ["has-plugin:grafana-clock-panel"],
   "content": "Install the clock panel plugin."
 }
@@ -454,7 +456,7 @@ Objectives use the same syntax as requirements but serve a different purpose:
 
 ### Syntax Rules
 
-- Fixed types (`is-admin`, `is-logged-in`, `is-editor`, `exists-reftarget`, `navmenu-open`, `has-datasources`, `dashboard-exists`, `form-valid`) cannot have arguments
+- Fixed types (`is-admin`, `is-logged-in`, `is-editor`, `exists-reftarget` *(auto-applied)*, `navmenu-open`, `has-datasources`, `dashboard-exists`, `form-valid`) cannot have arguments
 - Parameterized types require an argument after the colon
 - Path arguments (e.g., `on-page:`) should start with `/`
 - Version arguments should be semver format (e.g., `11.0.0`)


### PR DESCRIPTION
Remove `exists-reftarget` recommendation from author guidance.

The `exists-reftarget` check is now automatically applied by the plugin for all DOM interactions, making manual inclusion redundant for authors.

---
[Slack Thread](https://raintank-corp.slack.com/archives/C08VB4WC64R/p1770288349972129?thread_ts=1770288349.972129&cid=C08VB4WC64R)

<p><a href="https://cursor.com/background-agent?bcId=bc-1f7c1113-94ee-5ec0-8ed4-74717ca15bbf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1f7c1113-94ee-5ec0-8ed4-74717ca15bbf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

