### PR TITLE
adds Chris as codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -30,3 +30,4 @@
 /tour-of-visualizations/ @moxious
 /transform-data/ @imatwawana
 /welcome-to-play/ @Jayclifford345
+/.cursor/commands/build-interactive-lj/ @chri2547


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single-line CODEOWNERS change that only affects GitHub review routing and has no runtime impact.
> 
> **Overview**
> Adds `@chri2547` as the code owner for `/.cursor/commands/build-interactive-lj/` in `.github/CODEOWNERS`, ensuring reviews for changes under that command are automatically requested from Chris.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 930e0ee5f290b70cbf994e93dab0fea17c271fcc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->