### PR TITLE
Pin shared-workflow actions to release commit SHAs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,7 +33,7 @@ jobs:
           persist-credentials: false
 
       - name: Login to GCS
-        uses: grafana/shared-workflows/actions/login-to-gcs@main
+        uses: grafana/shared-workflows/actions/login-to-gcs@6a97ef28077dbb66da3582aad604aef980cd1787 # login-to-gcs/v0.3.0
         id: login-to-gcs
         with:
           # login-to-gcs only accepts 'dev' or 'prod', map 'ops' accordingly
@@ -70,7 +70,7 @@ jobs:
           find guides -type f
 
       - name: Push files to GCS
-        uses: grafana/shared-workflows/actions/push-to-gcs@push-to-gcs/v0.3.0
+        uses: grafana/shared-workflows/actions/push-to-gcs@0527786f572985731b4bde3684d82567abe8e979 # push-to-gcs/v0.3.0
         with:
           bucket: interactive-learning-${{ github.event.inputs.environment }}
           path: guides


### PR DESCRIPTION
## Summary
- Pin `login-to-gcs` action from `@main` to `@6a97ef28077dbb66da3582aad604aef980cd1787` (`login-to-gcs/v0.3.0`)
- Pin `push-to-gcs` action from `@push-to-gcs/v0.3.0` to `@0527786f572985731b4bde3684d82567abe8e979` (`push-to-gcs/v0.3.0`)

Fixes the two `unpinned-uses` high-severity findings reported by [zizmor](https://github.com/woodruffw/zizmor).

## Test plan
- [ ] Verify zizmor no longer reports `unpinned-uses` errors for `deploy.yml`
- [ ] Run a test deployment to `dev` to confirm the pinned actions still work correctly


Made with [Cursor](https://cursor.com)