### PR TITLE
Reverse improvements made whilst iterating on interactive guides in the website

### DIFF
--- a/drilldown-logs-lj/add-log-dashboard/content.json
+++ b/drilldown-logs-lj/add-log-dashboard/content.json
@@ -7,33 +7,38 @@
       "content": "Dashboards give you an at-a-glance view of your data and let you track metrics through different visualizations.\n\nTo add a Logs Drilldown visualization to a dashboard, complete the following steps:"
     },
     {
-      "type": "multistep",
-      "content": "On the toolbar at the top of the Explore page, click **Add > Add to dashboard**, then click **Open dashboard**.\n\nOn the **Add panel to dashboard** dialog box, you can choose to add the visualization to a new dashboard or an existing dashboard.",
-      "steps": [
+      "type": "section",
+      "blocks": [
         {
-          "action": "highlight",
-          "reftarget": "div[data-testid='data-testid Explore'] button:nth-match(4)"
+          "type": "multistep",
+          "content": "On the toolbar at the top of the Explore page, click **Add > Add to dashboard**, then click **Open dashboard**.\n\nOn the **Add panel to dashboard** dialog box, you can choose to add the visualization to a new dashboard or an existing dashboard.",
+          "steps": [
+            {
+              "action": "highlight",
+              "reftarget": "div[data-testid='data-testid Explore'] button:nth-match(4)"
+            },
+            {
+              "action": "highlight",
+              "reftarget": "[role='menuitem']:contains('Add to dashboard')"
+            },
+            {
+              "action": "button",
+              "reftarget": "Open dashboard"
+            }
+          ]
         },
         {
+          "type": "interactive",
           "action": "highlight",
-          "reftarget": "[role='menuitem']:contains('Add to dashboard')"
+          "reftarget": "button[data-testid='data-testid Save dashboard button']",
+          "content": "Click **Save dashboard** located in the upper-right of the page.",
+          "requirements": ["exists-reftarget"]
         },
         {
-          "action": "button",
-          "reftarget": "Open dashboard"
+          "type": "markdown",
+          "content": "Enter a title and description for your dashboard, select a folder if applicable, and click **Save**."
         }
       ]
-    },
-    {
-      "type": "interactive",
-      "action": "highlight",
-      "reftarget": "button[data-testid='data-testid Save dashboard button']",
-      "content": "Click **Save dashboard** located in the upper-right of the page.",
-      "requirements": ["exists-reftarget"]
-    },
-    {
-      "type": "markdown",
-      "content": "Enter a title and description for your dashboard, select a folder if applicable, and click **Save**."
     }
   ]
 }

--- a/drilldown-logs-lj/business-value-log-metrics/content.json
+++ b/drilldown-logs-lj/business-value-log-metrics/content.json
@@ -1,0 +1,10 @@
+{
+  "id": "drilldown-logs-business-value",
+  "title": "The value of Logs Drilldown",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "Grafana Logs Drilldown is a query-less experience for browsing logs stored in Grafana Loki. You can easily retrieve your logs by clicking through the user interface to filter and explore logs without writing LogQL queries.\n\nWith Logs Drilldown, you can:\n\n- Easily find logs and log volumes for all of your services, without writing LogQL queries.\n- Effortlessly filter logs based on their labels, fields, or patterns.\n- Drill into your data using volume and text patterns.\n- Uncover related logs and monitor changes over time.\n- Browse automatic visualizations of your log data based on its characteristics.\n- Automatically detect log volume spikes and text patterns."
+    }
+  ]
+}

--- a/drilldown-logs-lj/end-journey/content.json
+++ b/drilldown-logs-lj/end-journey/content.json
@@ -1,0 +1,10 @@
+{
+  "id": "drilldown-logs-end-journey",
+  "title": "Destination reached!",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "Congratulations on completing this journey! Job well done!\n\nWe hope you've enjoyed traveling with us as you:\n\n- Navigated to Logs Drilldown\n- Searched for and filtered specific logs you want to investigate\n- Learned how to drill down into a log and investigate related logs\n- Added a log visualization to a dashboard"
+    }
+  ]
+}

--- a/drilldown-logs-lj/labels-and-fields/content.json
+++ b/drilldown-logs-lj/labels-and-fields/content.json
@@ -7,62 +7,67 @@
       "content": "You can analyze and investigate the data and spot log trends and patterns. Reviewing related logs also provides a broader understanding of what's happening in your application.\n\nYou use **Labels** and **Fields** to filter logs. Labels are key-value pairs attached to each log line when it's ingested into Loki. Fields are key-value pairs parsed from the log line and useful for filtering logs in finer detail.\n\nTo filter the logs with labels and fields, perform the following steps:"
     },
     {
-      "type": "interactive",
-      "action": "highlight",
-      "reftarget": "a[data-testid='data-testid tab-labels']",
-      "content": "Click the **Labels** tab to show log visualizations for the labels attached to your log lines.\n\nThe following example shows all the available labels for a service.",
-      "requirements": ["exists-reftarget"]
-    },
-    {
-      "type": "image",
-      "src": "/media/docs/learning-journey/logs-drilldown/logs-label-v2.png",
-      "alt": "Logs Drilldown showing labels for a specific service"
-    },
-    {
-      "type": "interactive",
-      "action": "highlight",
-      "reftarget": "a[aria-label='Select detected_level']",
-      "content": "Look for an interesting label and click the **Select** button to view the log visualization for that label.\n\nUsing the error example from the previous milestone, the `deployment_environment` label is selected, which shows the error breakdown by environment.",
-      "requirements": ["exists-reftarget"],
-      "doIt": false
-    },
-    {
-      "type": "image",
-      "src": "/media/docs/learning-journey/logs-drilldown/log-specific-label-v2.png",
-      "alt": "Logs Drilldown showing a specific label"
-    },
-    {
-      "type": "interactive",
-      "action": "highlight",
-      "reftarget": "button:contains('Include')",
-      "content": "To include logs for a specific label value, find the value you want and click **Include**.\n\nUsing the error example from the previous milestone, the `prod` value is the only value included.",
-      "requirements": ["exists-reftarget"],
-      "doIt": false
-    },
-    {
-      "type": "image",
-      "src": "/media/docs/learning-journey/logs-drilldown/log-specific-value.png",
-      "alt": "Logs Drilldown showing a specific label value included"
-    },
-    {
-      "type": "interactive",
-      "action": "highlight",
-      "reftarget": "a[data-testid='data-testid tab-fields']",
-      "content": "Repeat the process for the **Fields** tab to further refine your filters.\n\nIn the following example, the `protocol` field is selected, and only the `HTTP/2.0` value is included.",
-      "requirements": ["exists-reftarget"]
-    },
-    {
-      "type": "image",
-      "src": "/media/docs/learning-journey/logs-drilldown/logs-specific-field.png",
-      "alt": "Logs Drilldown showing a specific field"
-    },
-    {
-      "type": "interactive",
-      "action": "highlight",
-      "reftarget": "a[data-testid='data-testid tab-logs']",
-      "content": "Click the **Logs** tab again and investigate the log volumes and log entries related to the filters you set.\n\nUsing the same error example, you should only see error logs specific to production where the protocol is `HTTP/2.0`.",
-      "requirements": ["exists-reftarget"],
-      "doIt": false
+      "type": "section",
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "a[data-testid='data-testid tab-labels']",
+          "content": "Click the **Labels** tab to show log visualizations for the labels attached to your log lines.\n\nThe following example shows all the available labels for a service.",
+          "requirements": ["exists-reftarget"]
+        },
+        {
+          "type": "image",
+          "src": "/media/docs/learning-journey/logs-drilldown/logs-label-v2.png",
+          "alt": "Logs Drilldown showing labels for a specific service"
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "a[aria-label='Select detected_level']",
+          "content": "Look for an interesting label and click the **Select** button to view the log visualization for that label.\n\nUsing the error example from the previous milestone, the `deployment_environment` label is selected, which shows the error breakdown by environment.",
+          "requirements": ["exists-reftarget"],
+          "doIt": false
+        },
+        {
+          "type": "image",
+          "src": "/media/docs/learning-journey/logs-drilldown/log-specific-label-v2.png",
+          "alt": "Logs Drilldown showing a specific label"
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "button:contains('Include')",
+          "content": "To include logs for a specific label value, find the value you want and click **Include**.\n\nUsing the error example from the previous milestone, the `prod` value is the only value included.",
+          "requirements": ["exists-reftarget"],
+          "doIt": false
+        },
+        {
+          "type": "image",
+          "src": "/media/docs/learning-journey/logs-drilldown/log-specific-value.png",
+          "alt": "Logs Drilldown showing a specific label value included"
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "a[data-testid='data-testid tab-fields']",
+          "content": "Repeat the process for the **Fields** tab to further refine your filters.\n\nIn the following example, the `protocol` field is selected, and only the `HTTP/2.0` value is included.",
+          "requirements": ["exists-reftarget"]
+        },
+        {
+          "type": "image",
+          "src": "/media/docs/learning-journey/logs-drilldown/logs-specific-field.png",
+          "alt": "Logs Drilldown showing a specific field"
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "a[data-testid='data-testid tab-logs']",
+          "content": "Click the **Logs** tab again and investigate the log volumes and log entries related to the filters you set.\n\nUsing the same error example, you should only see error logs specific to production where the protocol is `HTTP/2.0`.",
+          "requirements": ["exists-reftarget"],
+          "doIt": false
+        }
+      ]
     },
     {
       "type": "markdown",

--- a/drilldown-logs-lj/log-patterns/content.json
+++ b/drilldown-logs-lj/log-patterns/content.json
@@ -7,40 +7,45 @@
       "content": "Log patterns let you work with groups of similar log lines. You can hide log patterns that are noisy, or focus only on the patterns that are most useful.\n\nGrafana Logs Drilldown proactively visualizes your log volume data per detected pattern, broken down in various ways. At a glance you can immediately spot spikes or other changes.\n\nTo filter the logs with log patterns, perform the following steps:"
     },
     {
-      "type": "markdown",
-      "content": "To start your filters from scratch, remove all filter selections above the **Logs** tab."
-    },
-    {
-      "type": "interactive",
-      "action": "highlight",
-      "reftarget": "a[data-testid='data-testid tab-patterns']",
-      "content": "Click the **Patterns** tab to show the log patterns that Logs Drilldown automatically detected.",
-      "requirements": ["exists-reftarget"]
-    },
-    {
-      "type": "markdown",
-      "content": "Identify a pattern that matches the type of logs you're interested in viewing."
-    },
-    {
-      "type": "markdown",
-      "content": "Click the **Include** button for the pattern.\n\nUsing the example from the previous milestone, the pattern `The flag is <_>` is selected."
-    },
-    {
-      "type": "image",
-      "src": "/media/docs/learning-journey/logs-drilldown/log-patterns-v2.png",
-      "alt": "Logs Drilldown showing patterns for a specific service"
-    },
-    {
-      "type": "interactive",
-      "action": "highlight",
-      "reftarget": "a[data-testid='data-testid tab-logs']",
-      "content": "Click the **Logs** tab again and investigate the log entries related to the log pattern you set.\n\nSince the example pattern included has a regex expression, the log entries both include `The flag is green` and `The flag is red`.",
-      "requirements": ["exists-reftarget"]
-    },
-    {
-      "type": "image",
-      "src": "/media/docs/learning-journey/logs-drilldown/log-lines-pattern.png",
-      "alt": "Logs Drilldown showing logs from a log pattern"
+      "type": "section",
+      "blocks": [
+        {
+          "type": "markdown",
+          "content": "To start your filters from scratch, remove all filter selections above the **Logs** tab."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "a[data-testid='data-testid tab-patterns']",
+          "content": "Click the **Patterns** tab to show the log patterns that Logs Drilldown automatically detected.",
+          "requirements": ["exists-reftarget"]
+        },
+        {
+          "type": "markdown",
+          "content": "Identify a pattern that matches the type of logs you're interested in viewing."
+        },
+        {
+          "type": "markdown",
+          "content": "Click the **Include** button for the pattern.\n\nUsing the example from the previous milestone, the pattern `The flag is <_>` is selected."
+        },
+        {
+          "type": "image",
+          "src": "/media/docs/learning-journey/logs-drilldown/log-patterns-v2.png",
+          "alt": "Logs Drilldown showing patterns for a specific service"
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "a[data-testid='data-testid tab-logs']",
+          "content": "Click the **Logs** tab again and investigate the log entries related to the log pattern you set.\n\nSince the example pattern included has a regex expression, the log entries both include `The flag is green` and `The flag is red`.",
+          "requirements": ["exists-reftarget"]
+        },
+        {
+          "type": "image",
+          "src": "/media/docs/learning-journey/logs-drilldown/log-lines-pattern.png",
+          "alt": "Logs Drilldown showing logs from a log pattern"
+        }
+      ]
     },
     {
       "type": "markdown",

--- a/drilldown-logs-lj/open-logs-explore/content.json
+++ b/drilldown-logs-lj/open-logs-explore/content.json
@@ -7,32 +7,37 @@
       "content": "Explore is your starting point for querying and analyzing your data in Grafana. You can run ad-hoc queries, explore your data through visualizations, and investigate issues.\n\nTo open a log visualization in Explore, complete the following steps:"
     },
     {
-      "type": "markdown",
-      "content": "Hover your cursor over the log you want to open in Explore."
-    },
-    {
-      "type": "image",
-      "src": "/media/docs/learning-journey/logs-drilldown/logs-explore.png",
-      "alt": "Image shows navigating to Explore"
-    },
-    {
-      "type": "multistep",
-      "content": "On the **Log volume** panel, click the **Menu** icon and click **Explore**.\n\nWhen the Explore page opens, you'll see the query view. If needed, you can edit the query.",
-      "steps": [
+      "type": "section",
+      "blocks": [
         {
-          "action": "highlight",
-          "reftarget": "button[data-testid*='Panel menu Log volume']"
+          "type": "markdown",
+          "content": "Hover your cursor over the log you want to open in Explore."
         },
         {
-          "action": "highlight",
-          "reftarget": "a[data-testid='data-testid Panel menu item Explore']"
+          "type": "image",
+          "src": "/media/docs/learning-journey/logs-drilldown/logs-explore.png",
+          "alt": "Image shows navigating to Explore"
+        },
+        {
+          "type": "multistep",
+          "content": "On the **Log volume** panel, click the **Menu** icon and click **Explore**.\n\nWhen the Explore page opens, you'll see the query view. If needed, you can edit the query.",
+          "steps": [
+            {
+              "action": "highlight",
+              "reftarget": "button[data-testid*='Panel menu Log volume']"
+            },
+            {
+              "action": "highlight",
+              "reftarget": "a[data-testid='data-testid Panel menu item Explore']"
+            }
+          ]
+        },
+        {
+          "type": "image",
+          "src": "/media/docs/learning-journey/logs-drilldown/logs-query.png",
+          "alt": "Image shows log metric open in Explore"
         }
       ]
-    },
-    {
-      "type": "image",
-      "src": "/media/docs/learning-journey/logs-drilldown/logs-query.png",
-      "alt": "Image shows log metric open in Explore"
     },
     {
       "type": "markdown",

--- a/drilldown-logs-lj/search-logs/content.json
+++ b/drilldown-logs-lj/search-logs/content.json
@@ -7,34 +7,39 @@
       "content": "If you are already familiar with your logs and know the structure, you can quickly spot anomalies or errors by searching for specific keywords.\n\nTo search the logs, perform the following steps:"
     },
     {
-      "type": "markdown",
-      "content": "On the **Logs** tab, review the **Log volume** dashboard and click the log legend to filter it by log level.\n\nThe following example shows the `error` log level selected and all error logs listed."
-    },
-    {
-      "type": "image",
-      "src": "/media/docs/learning-journey/logs-drilldown/log-errors-v2.png",
-      "alt": "Logs Drilldown dashboard showing error logs only"
-    },
-    {
-      "type": "interactive",
-      "action": "highlight",
-      "reftarget": "div[data-testid='input-wrapper'] input:nth-match(1)",
-      "content": "To search for specific error logs, type a text query in the **Search in log lines** field.\n\nThe following example shows search results for all error logs containing the word `red`.",
-      "requirements": ["exists-reftarget"],
-      "doIt": false
-    },
-    {
-      "type": "image",
-      "src": "/media/docs/learning-journey/logs-drilldown/log-lines-v2.png",
-      "alt": "Logs Drilldown showing error logs for a specific query"
-    },
-    {
-      "type": "interactive",
-      "action": "highlight",
-      "reftarget": "button[data-testid='data-testid TimePicker Open Button']",
-      "content": "If necessary, use the time picker located in the upper-right of the page to adjust the time range.",
-      "requirements": ["exists-reftarget"],
-      "doIt": false
+      "type": "section",
+      "blocks": [
+        {
+          "type": "markdown",
+          "content": "On the **Logs** tab, review the **Log volume** dashboard and click the log legend to filter it by log level.\n\nThe following example shows the `error` log level selected and all error logs listed."
+        },
+        {
+          "type": "image",
+          "src": "/media/docs/learning-journey/logs-drilldown/log-errors-v2.png",
+          "alt": "Logs Drilldown dashboard showing error logs only"
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "div[data-testid='input-wrapper'] input:nth-match(1)",
+          "content": "To search for specific error logs, type a text query in the **Search in log lines** field.\n\nThe following example shows search results for all error logs containing the word `red`.",
+          "requirements": ["exists-reftarget"],
+          "doIt": false
+        },
+        {
+          "type": "image",
+          "src": "/media/docs/learning-journey/logs-drilldown/log-lines-v2.png",
+          "alt": "Logs Drilldown showing error logs for a specific query"
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "button[data-testid='data-testid TimePicker Open Button']",
+          "content": "If necessary, use the time picker located in the upper-right of the page to adjust the time range.",
+          "requirements": ["exists-reftarget"],
+          "doIt": false
+        }
+      ]
     },
     {
       "type": "markdown",

--- a/drilldown-logs-lj/view-logs/content.json
+++ b/drilldown-logs-lj/view-logs/content.json
@@ -7,53 +7,50 @@
       "content": "Logs form one of the pillars of observability, along with metrics, traces, and profiles. In its simplest definition, logs let you know what's happening to your application.\n\nIn this milestone, you're going to view service logs stored in Loki.\n\nTo view logs for a service, complete the following steps:"
     },
     {
-      "type": "multistep",
-      "content": "On the Grafana Cloud home page, open the navigation menu and click **Drilldown > Logs**.\n\nThe Logs Drilldown Overview page shows log visualizations and log samples for all the services in your selected Loki instance.",
-      "steps": [
+      "type": "section",
+      "blocks": [
         {
+          "type": "interactive",
           "action": "highlight",
-          "reftarget": "a[data-testid='data-testid Nav menu item'][href='/drilldown']"
+          "reftarget": "a[data-testid='data-testid Nav menu item'][href='/a/grafana-lokiexplore-app/explore']",
+          "requirements": ["navmenu-open", "exists-reftarget"],
+          "content": "On the Grafana Cloud home page, open the navigation menu and click **Drilldown > Logs**.\n\nThe Logs Drilldown Overview page shows log visualizations and log samples for all the services in your selected Loki instance."
         },
         {
+          "type": "interactive",
           "action": "highlight",
-          "reftarget": "a[data-testid='data-testid Nav menu item'][href='/a/grafana-lokiexplore-app/explore']"
+          "reftarget": "label[data-testid*='Data source']",
+          "content": "If you have multiple Loki data sources, click the **Data source** dropdown menu at the top of the page and select the data source you want to query.",
+          "requirements": ["exists-reftarget"],
+          "doIt": false
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "input[data-testid='data-testid search-services-input']",
+          "content": "If you have multiple services, you can view logs per service by using the **service** dropdown field to search for the service by name.",
+          "requirements": ["exists-reftarget"],
+          "doIt": false
+        },
+        {
+          "type": "image",
+          "src": "/media/docs/learning-journey/logs-drilldown/log-services.png",
+          "alt": "Logs Drilldown page for multiple services"
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "a[data-testid='data-testid button-select-service']:first-of-type",
+          "content": "Select the service you want to view by clicking **Show logs**.\n\nGrafana displays the **Logs** tab of the service details page.",
+          "requirements": ["exists-reftarget"],
+          "doIt": false
+        },
+        {
+          "type": "image",
+          "src": "/media/docs/learning-journey/logs-drilldown/logs-detail-page.png",
+          "alt": "Logs Drilldown detail page for a specific service"
         }
-      ],
-      "requirements": ["navmenu-open"]
-    },
-    {
-      "type": "interactive",
-      "action": "highlight",
-      "reftarget": "label[data-testid*='Data source']",
-      "content": "If you have multiple Loki data sources, click the **Data source** dropdown menu at the top of the page and select the data source you want to query.",
-      "requirements": ["exists-reftarget"],
-      "doIt": false
-    },
-    {
-      "type": "interactive",
-      "action": "highlight",
-      "reftarget": "input[data-testid='data-testid search-services-input']",
-      "content": "If you have multiple services, you can view logs per service by using the **service** dropdown field to search for the service by name.",
-      "requirements": ["exists-reftarget"],
-      "doIt": false
-    },
-    {
-      "type": "image",
-      "src": "/media/docs/learning-journey/logs-drilldown/log-services.png",
-      "alt": "Logs Drilldown page for multiple services"
-    },
-    {
-      "type": "interactive",
-      "action": "highlight",
-      "reftarget": "a[data-testid='data-testid button-select-service']:first-of-type",
-      "content": "Select the service you want to view by clicking **Show logs**.\n\nGrafana displays the **Logs** tab of the service details page.",
-      "requirements": ["exists-reftarget"],
-      "doIt": false
-    },
-    {
-      "type": "image",
-      "src": "/media/docs/learning-journey/logs-drilldown/logs-detail-page.png",
-      "alt": "Logs Drilldown detail page for a specific service"
+      ]
     },
     {
       "type": "markdown",

--- a/drilldown-metrics-lj/add-metric-dashboard/content.json
+++ b/drilldown-metrics-lj/add-metric-dashboard/content.json
@@ -7,38 +7,43 @@
       "content": "Dashboards help you create a curated set of visualizations that you can reference for ongoing monitoring.\n\nTo add a Metrics Drilldown visualization to a dashboard, complete the following steps:"
     },
     {
-      "type": "multistep",
-      "content": "On the toolbar at the top of the Explore page, click **Add > Add to dashboard**, then click **Open dashboard**.",
-      "steps": [
+      "type": "section",
+      "blocks": [
         {
-          "action": "highlight",
-          "reftarget": "div[data-testid='data-testid Explore'] button:nth-match(4)"
+          "type": "multistep",
+          "content": "On the toolbar at the top of the Explore page, click **Add > Add to dashboard**, then click **Open dashboard**.",
+          "steps": [
+            {
+              "action": "highlight",
+              "reftarget": "div[data-testid='data-testid Explore'] button:nth-match(4)"
+            },
+            {
+              "action": "highlight",
+              "reftarget": "[role='menuitem']:contains('Add to dashboard')"
+            },
+            {
+              "action": "button",
+              "reftarget": "Open dashboard"
+            }
+          ],
+          "requirements": ["exists-reftarget"]
         },
         {
-          "action": "highlight",
-          "reftarget": "[role='menuitem']:contains('Add to dashboard')"
+          "type": "markdown",
+          "content": "On the **Add panel to dashboard** dialog box, perform one of the following:\n\n- To add the visualization to a new dashboard, click **New dashboard**.\n- To add the visualization to an existing dashboard, click **Existing dashboard** and select a dashboard from the list.\n\nThe visualization appears in a dashboard."
         },
         {
-          "action": "button",
-          "reftarget": "Open dashboard"
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "button[data-testid='data-testid Save dashboard button']",
+          "content": "Click **Save dashboard** located in the upper-right of the page.",
+          "requirements": ["exists-reftarget"]
+        },
+        {
+          "type": "markdown",
+          "content": "Enter a title and description for your dashboard, select a folder if applicable, and click **Save**."
         }
-      ],
-      "requirements": ["exists-reftarget"]
-    },
-    {
-      "type": "markdown",
-      "content": "On the **Add panel to dashboard** dialog box, perform one of the following:\n\n- To add the visualization to a new dashboard, click **New dashboard**.\n- To add the visualization to an existing dashboard, click **Existing dashboard** and select a dashboard from the list.\n\nThe visualization appears in a dashboard."
-    },
-    {
-      "type": "interactive",
-      "action": "highlight",
-      "reftarget": "button[data-testid='data-testid Save dashboard button']",
-      "content": "Click **Save dashboard** located in the upper-right of the page.",
-      "requirements": ["exists-reftarget"]
-    },
-    {
-      "type": "markdown",
-      "content": "Enter a title and description for your dashboard, select a folder if applicable, and click **Save**."
+      ]
     }
   ]
 }

--- a/drilldown-metrics-lj/analyze-data/content.json
+++ b/drilldown-metrics-lj/analyze-data/content.json
@@ -7,49 +7,54 @@
       "content": "Once your metrics are filtered, analyze the data to spot trends and correlations. Reviewing related metrics provides a broader understanding of your system's performance.\n\nHaving a good understanding of your baseline metric performance at this stage makes it easy to recognize and pinpoint unusual behavior.\n\nTo analyze the data, perform the following steps:"
     },
     {
-      "type": "markdown",
-      "content": "Review the panels and identify a metric of interest.\n\nIn the following example, the `node_cpu_online` and `node_cpu_guest_seconds` metrics show little variation, making them less interesting to analyze. The `node_cpu_seconds_total` and `node_cpu_usage_seconds_total` metrics, which exhibit more change, are more valuable to explore."
-    },
-    {
-      "type": "image",
-      "src": "/media/docs/learning-journey/metrics-drilldown/cpu-usage.png",
-      "alt": "Metrics Drilldown dashboards showing CPU performance"
-    },
-    {
-      "type": "interactive",
-      "action": "highlight",
-      "reftarget": "button[data-testid='select-action-asserts:resource:threshold']",
-      "content": "For a more detailed view of any metric, click **Select** in the visualization.",
-      "requirements": ["exists-reftarget"],
-      "doIt": false
-    },
-    {
-      "type": "interactive",
-      "action": "highlight",
-      "reftarget": "button[data-testid='data-testid TimePicker Open Button']",
-      "content": "If necessary, use the **time picker** located in the upper-right of the page to adjust the time range.",
-      "requirements": ["exists-reftarget"],
-      "doIt": false
-    },
-    {
-      "type": "markdown",
-      "content": "Continue your investigation by reviewing the **Breakdown** tab and the **Related metrics** tab."
-    },
-    {
-      "type": "interactive",
-      "action": "highlight",
-      "reftarget": "button[data-testid='data-testid Tab Breakdown']",
-      "content": "**Breakdown**: Shows time series visualizations for each of the label-value pairs for the selected metric. You can further drill down on each label and click **Add to filter** to add the label-value pair into your filters. You can also change the **View** from grid to rows.",
-      "requirements": ["exists-reftarget"],
-      "doIt": false
-    },
-    {
-      "type": "interactive",
-      "action": "highlight",
-      "reftarget": "button[data-testid='data-testid Tab Related metrics']",
-      "content": "**Related metrics**: Shows related metrics with relevant key words. You can repeat the drilldown process for any related metric.",
-      "requirements": ["exists-reftarget"],
-      "doIt": false
+      "type": "section",
+      "blocks": [
+        {
+          "type": "markdown",
+          "content": "Review the panels and identify a metric of interest.\n\nIn the following example, the `node_cpu_online` and `node_cpu_guest_seconds` metrics show little variation, making them less interesting to analyze. The `node_cpu_seconds_total` and `node_cpu_usage_seconds_total` metrics, which exhibit more change, are more valuable to explore."
+        },
+        {
+          "type": "image",
+          "src": "/media/docs/learning-journey/metrics-drilldown/cpu-usage.png",
+          "alt": "Metrics Drilldown dashboards showing CPU performance"
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "button[data-testid='select-action-asserts:resource:threshold']",
+          "content": "For a more detailed view of any metric, click **Select** in the visualization.",
+          "requirements": ["exists-reftarget"],
+          "doIt": false
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "button[data-testid='data-testid TimePicker Open Button']",
+          "content": "If necessary, use the **time picker** located in the upper-right of the page to adjust the time range.",
+          "requirements": ["exists-reftarget"],
+          "doIt": false
+        },
+        {
+          "type": "markdown",
+          "content": "Continue your investigation by reviewing the **Breakdown** tab and the **Related metrics** tab."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "button[data-testid='data-testid Tab Breakdown']",
+          "content": "**Breakdown**: Shows time series visualizations for each of the label-value pairs for the selected metric. You can further drill down on each label and click **Add to filter** to add the label-value pair into your filters. You can also change the **View** from grid to rows.",
+          "requirements": ["exists-reftarget"],
+          "doIt": false
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "button[data-testid='data-testid Tab Related metrics']",
+          "content": "**Related metrics**: Shows related metrics with relevant key words. You can repeat the drilldown process for any related metric.",
+          "requirements": ["exists-reftarget"],
+          "doIt": false
+        }
+      ]
     },
     {
       "type": "markdown",

--- a/drilldown-metrics-lj/business-value-drilldown-metrics/content.json
+++ b/drilldown-metrics-lj/business-value-drilldown-metrics/content.json
@@ -1,0 +1,10 @@
+{
+  "id": "drilldown-metrics-business-value",
+  "title": "The value of Metrics Drilldown",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "Grafana Metrics Drilldown is a query-less experience for browsing **Prometheus-compatible** metrics. Quickly find related metrics with just a few simple clicks, without needing to write PromQL queries to retrieve metrics.\n\nWith Metrics Drilldown, you can:\n\n- Easily segment metrics based on their labels, so you can immediately spot anomalies and identify issues.\n- Automatically display the optimal visualization for each metric type (gauge vs. counter, for example) without manual setup.\n- Uncover related metrics relevant to the one you're viewing.\n- \u201cExplore in a drawer\u201d - overlay additional content on your dashboard without losing your current view.\n- View a history of user steps when navigating through metrics and their filters.\n- Seamlessly pivot to related telemetry, including log data."
+    }
+  ]
+}

--- a/drilldown-metrics-lj/end-journey/content.json
+++ b/drilldown-metrics-lj/end-journey/content.json
@@ -1,0 +1,10 @@
+{
+  "id": "drilldown-metrics-end-journey",
+  "title": "Destination reached!",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "Congratulations on completing this journey! Job well done!\n\nWe hope you've enjoyed traveling with us as you:\n\n- Navigated to Metrics Drilldown\n- Searched for and filtered specific metrics you want to investigate\n- Learned how to drill down into a metric and investigate related metrics\n- Added a metric visualization to a dashboard"
+    }
+  ]
+}

--- a/drilldown-metrics-lj/open-metrics-explore/content.json
+++ b/drilldown-metrics-lj/open-metrics-explore/content.json
@@ -7,37 +7,42 @@
       "content": "Explore is your starting point for querying and analyzing data in Grafana. It lets you run queries, visualize results, and build understanding of your data before creating dashboards.\n\nTo open a metric visualization in Explore, complete the following steps:"
     },
     {
-      "type": "markdown",
-      "content": "Hover your cursor over the metric you want to open in Explore."
-    },
-    {
-      "type": "image",
-      "src": "/media/docs/learning-journey/metrics-drilldown/open-explore.png",
-      "alt": "Image shows navigating to Explore"
-    },
-    {
-      "type": "multistep",
-      "content": "Click the **Menu** icon, then click **Explore**.",
-      "steps": [
+      "type": "section",
+      "blocks": [
         {
-          "action": "highlight",
-          "reftarget": "button[data-testid='data-testid Panel menu asserts:resource:threshold']"
+          "type": "markdown",
+          "content": "Hover your cursor over the metric you want to open in Explore."
         },
         {
-          "action": "highlight",
-          "reftarget": "button[data-testid='data-testid Panel menu item Explore']"
+          "type": "image",
+          "src": "/media/docs/learning-journey/metrics-drilldown/open-explore.png",
+          "alt": "Image shows navigating to Explore"
+        },
+        {
+          "type": "multistep",
+          "content": "Click the **Menu** icon, then click **Explore**.",
+          "steps": [
+            {
+              "action": "highlight",
+              "reftarget": "button[title='Menu']:nth-match(1)"
+            },
+            {
+              "action": "highlight",
+              "reftarget": "button[data-testid='data-testid Panel menu item Explore']"
+            }
+          ],
+          "requirements": ["exists-reftarget"]
+        },
+        {
+          "type": "markdown",
+          "content": "When the metrics visualization opens, you'll see the query view. If needed, you can edit the query."
+        },
+        {
+          "type": "image",
+          "src": "/media/docs/learning-journey/metrics-drilldown/open-explore-1.png",
+          "alt": "Image shows metric open in Explore"
         }
-      ],
-      "requirements": ["exists-reftarget"]
-    },
-    {
-      "type": "markdown",
-      "content": "When the metrics visualization opens, you'll see the query view. If needed, you can edit the query."
-    },
-    {
-      "type": "image",
-      "src": "/media/docs/learning-journey/metrics-drilldown/open-explore-1.png",
-      "alt": "Image shows metric open in Explore"
+      ]
     },
     {
       "type": "markdown",

--- a/drilldown-metrics-lj/search-metrics/content.json
+++ b/drilldown-metrics-lj/search-metrics/content.json
@@ -7,39 +7,36 @@
       "content": "Use metrics search and filtering to narrow your data and focus on specific systems, services, or time frames. This targeted approach is an important first step in effectively using Metrics Drilldown.\n\nTo search and filter metrics, complete the following steps:"
     },
     {
-      "type": "multistep",
-      "content": "On the Grafana Cloud home page, open the navigation menu and click **Drilldown > Metrics**.",
-      "steps": [
+      "type": "section",
+      "blocks": [
         {
+          "type": "interactive",
           "action": "highlight",
-          "reftarget": "a[data-testid='data-testid Nav menu item'][href='/drilldown']"
+          "reftarget": "a[data-testid='data-testid Nav menu item'][href='/a/grafana-metricsdrilldown-app/drilldown']",
+          "requirements": ["navmenu-open", "exists-reftarget"],
+          "content": "On the Grafana Cloud home page, open the navigation menu and click **Drilldown > Metrics**."
         },
         {
+          "type": "markdown",
+          "content": "If you see a **Let's start** button, click it."
+        },
+        {
+          "type": "interactive",
           "action": "highlight",
-          "reftarget": "a[data-testid='data-testid Nav menu item'][href='/a/grafana-metricsdrilldown-app/drilldown']"
+          "reftarget": "input[data-testid='data-testid Dashboard template variables Variable Value DropDown value link text grafanacloud-prom-input']",
+          "content": "Select the **data source** you want to query.\n\nThe Metrics Drilldown interface containing a visualization for each metric appears.",
+          "requirements": ["exists-reftarget"],
+          "doIt": false
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "input[placeholder='Filter by label values']",
+          "content": "Use one of the following methods to reduce the number of metrics you see:\n\n- Select a filter in the **Filter by label values** field.\n- Enter a search expression in the **Search metrics** field and press **Enter**.\n\nFor example, enter `cpu`. The metrics that match the search or filter expression appear.",
+          "requirements": ["exists-reftarget"],
+          "doIt": false
         }
-      ],
-      "requirements": ["navmenu-open"]
-    },
-    {
-      "type": "markdown",
-      "content": "If you see a **Let's start** button, click it."
-    },
-    {
-      "type": "interactive",
-      "action": "highlight",
-      "reftarget": "input[data-testid='data-testid Dashboard template variables Variable Value DropDown value link text grafanacloud-prom-input']",
-      "content": "Select the **data source** you want to query.\n\nThe Metrics Drilldown interface containing a visualization for each metric appears.",
-      "requirements": ["exists-reftarget"],
-      "doIt": false
-    },
-    {
-      "type": "interactive",
-      "action": "highlight",
-      "reftarget": "input[placeholder='Filter by label values']",
-      "content": "Use one of the following methods to reduce the number of metrics you see:\n\n- Select a filter in the **Filter by label values** field.\n- Enter a search expression in the **Search metrics** field and press **Enter**.\n\nFor example, enter `cpu`. The metrics that match the search or filter expression appear.",
-      "requirements": ["exists-reftarget"],
-      "doIt": false
+      ]
     },
     {
       "type": "markdown",

--- a/drilldown-traces-lj/business-value-drilldown-traces/content.json
+++ b/drilldown-traces-lj/business-value-drilldown-traces/content.json
@@ -1,0 +1,14 @@
+{
+  "id": "drilldown-traces-business-value",
+  "title": "The value of Traces Drilldown",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "Distributed traces provide a way to monitor applications by tracking requests across services. Traces record the details of a request to help understand why an issue is or was happening.\n\nGrafana Traces Drilldown helps you visualize insights from your Tempo traces data. Using the app, you can:\n\n* Use Rate, Errors, and Duration (RED) metrics derived from traces to investigate issues\n* Uncover related issues and monitor changes over time\n* Browse automatic visualizations of your data based on its characteristics\n* Do all of this without writing TraceQL queries"
+    },
+    {
+      "type": "markdown",
+      "content": "Tracing is best used for analyzing the performance of your system, identifying bottlenecks, monitoring latency, and providing a complete picture of requests processing.\n\n- Decrease mean time to repair and mean time to identify an issue by pinpointing exactly where errors or latency are occurring within a transaction across multiple services.\n- Optimize bottlenecks and long-running code by visualizing the path and duration of requests. Tracing can help identify bottleneck operations and long-running pieces of code that could benefit from optimization.\n- Detect issues with generated metrics. Tracing generates metrics related to request rate, error rate, and duration of requests. You can set alerts against these high-level signals to detect problems.\n- Seamless telemetry correlation. Use tracing in conjunction with logs and metrics for a comprehensive view of events over time, during an active incident, or for root-cause analysis. Tracing shows relationships between services and dependencies.\n- Monitor compliance with policies. Business policy adherence ensures that services are correctly isolated using generated metrics and generated service graphs."
+    }
+  ]
+}

--- a/drilldown-traces-lj/end-journey/content.json
+++ b/drilldown-traces-lj/end-journey/content.json
@@ -1,0 +1,10 @@
+{
+  "id": "drilldown-traces-end-journey",
+  "title": "Destination reached!",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "Congratulations on completing this journey! Job well done!\n\nWe hope you've enjoyed traveling with us as you:\n\n- Navigated to Traces Drilldown and viewed the distribution of trace span durations\n- Identified and reviewed the details of the slowest traces\n- Viewed the details of a trace span to identify the root cause of latency"
+    }
+  ]
+}

--- a/drilldown-traces-lj/view-distribution/content.json
+++ b/drilldown-traces-lj/view-distribution/content.json
@@ -11,42 +11,39 @@
       "content": "To view the distribution of trace span durations, complete the following steps:"
     },
     {
-      "type": "multistep",
-      "content": "On the Grafana Cloud home page, open the navigation menu and click **Drilldown > Traces**.",
-      "steps": [
+      "type": "section",
+      "blocks": [
         {
+          "type": "interactive",
           "action": "highlight",
-          "reftarget": "a[data-testid='data-testid Nav menu item'][href='/drilldown']"
+          "reftarget": "a[data-testid='data-testid Nav menu item'][href='/a/grafana-exploretraces-app/']",
+          "requirements": ["navmenu-open", "exists-reftarget"],
+          "content": "On the Grafana Cloud home page, open the navigation menu and click **Drilldown > Traces**."
         },
         {
+          "type": "interactive",
           "action": "highlight",
-          "reftarget": "a[data-testid='data-testid Nav menu item'][href='/a/grafana-exploretraces-app/']"
+          "reftarget": "input[data-testid*='Dashboard template variables Variable Value DropDown value link text']",
+          "content": "Select the data source you want to explore. The Traces Drilldown user interface appears.",
+          "doIt": false,
+          "requirements": ["exists-reftarget"]
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "label:contains('All spans')",
+          "content": "On the **Filters** toolbar, click **All spans**.",
+          "requirements": ["exists-reftarget"]
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "section[data-testid='data-testid Panel header Histogram by duration']",
+          "content": "Click the **Histogram by duration** panel. The panel moves to the center of the page.",
+          "doIt": false,
+          "requirements": ["exists-reftarget"]
         }
-      ],
-      "requirements": ["navmenu-open"]
-    },
-    {
-      "type": "interactive",
-      "action": "highlight",
-      "reftarget": "input[data-testid*='Dashboard template variables Variable Value DropDown value link text']",
-      "content": "Select the data source you want to explore. The Traces Drilldown user interface appears.",
-      "doIt": false,
-      "requirements": ["exists-reftarget"]
-    },
-    {
-      "type": "interactive",
-      "action": "highlight",
-      "reftarget": "label:contains('All spans')",
-      "content": "On the **Filters** toolbar, click **All spans**.",
-      "requirements": ["exists-reftarget"]
-    },
-    {
-      "type": "interactive",
-      "action": "highlight",
-      "reftarget": "section[data-testid='data-testid Panel header Histogram by duration']",
-      "content": "Click the **Histogram by duration** panel. The panel moves to the center of the page.",
-      "doIt": false,
-      "requirements": ["exists-reftarget"]
+      ]
     },
     {
       "type": "markdown",

--- a/github-data-source-lj/advantages-github-datasource/content.json
+++ b/github-data-source-lj/advantages-github-datasource/content.json
@@ -1,0 +1,10 @@
+{
+  "id": "github-data-source-advantages",
+  "title": "Advantages of the GitHub data source",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "The GitHub data source plugin brings powerful repository monitoring capabilities directly into your Grafana environment. This integration eliminates the need to switch between different tools and platforms to understand your development workflow performance.\n\nUnlike standalone GitHub analytics tools, the GitHub data source plugin integrates seamlessly with your existing observability stack. This means you can correlate development metrics with application performance, infrastructure health, and business metrics in a single unified view.\n\nWith the GitHub data source, you can:\n\n- Create real-time dashboards displaying repository activity and trends\n- Set up alerts for critical events like stale pull requests or high issue volumes\n- Build comprehensive views combining development metrics with application performance\n- Track long-term trends in repository health and team productivity\n- Monitor multiple repositories from a centralized location\n- Leverage Grafana's powerful visualization capabilities for development data\n- Share development insights with stakeholders through Grafana's sharing features\n\nThe plugin connects directly to the GitHub API, ensuring you have access to the most current repository data. It supports both public and private repositories, making it suitable for organizations of any size."
+    }
+  ]
+}

--- a/github-data-source-lj/business-value/content.json
+++ b/github-data-source-lj/business-value/content.json
@@ -1,0 +1,28 @@
+{
+  "id": "github-data-source-business-value",
+  "title": "The case for observability",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "IT systems are complicated. There are nodes, pods, services, system resources - sometimes thousands of them - all connected in a complex web of relationships. And when things go wrong, it can be very difficult to determine the root cause and fix it quickly. Consider the following:\n\n- Slow performance in an application might be caused by heavy load, or it could be a memory leak or even a hardware error. Monitoring your infrastructure allows you to find the root cause quickly and accurately.\n- Running out of disk space can be a disaster for any environment. Understanding that there's a problem before it becomes a problem enables you to prevent it.\n- When applications or services are co-located, being able to identify hotspots and conflicts between them can help you redistribute the load properly.\n\nAnd time is of the essence. System downtime can be very expensive. If you run customer-facing applications such as e-commerce site or a financial institution, every minute of downtime costs you money. Some estimates put the average cost of downtime at $5,600 per minute. If you are a large retailer, this cost can be much more. Even if you're not running a commercial service, downtime can have impact. If you can't turn on your lights because your home automation is having problems, it's still a real issue."
+    },
+    {
+      "type": "markdown",
+      "content": "## Enter...observability"
+    },
+    {
+      "type": "video",
+      "src": "https://www.youtube.com/embed/TQur9GJHIIQ",
+      "provider": "youtube",
+      "title": "What is observability?"
+    },
+    {
+      "type": "markdown",
+      "content": "Observability is the process of making a system's internal state more transparent. Systems are made observable by the data they produce, which in turn helps you to determine if your infrastructure or application is healthy and functioning normally."
+    },
+    {
+      "type": "markdown",
+      "content": "Observability is a holistic approach to understanding and managing complex systems. It involves collecting data from all parts of the system to create a deep understanding of the system's internal workings and how these interact with each other. Observability focuses on understanding and interpreting data to make the system's behavior and performance as transparent as possible. It also requires a means of making the data easily available for humans to interpret.\n\nAn observability system enables system operators, DevOps practitioners, and site reliability engineers to ask questions across the information gathered. These are questions that are not anticipated in advance, but rather questions that arise due to unexpected or novel events within a system."
+    }
+  ]
+}

--- a/github-data-source-lj/config-github-datasource/content.json
+++ b/github-data-source-lj/config-github-datasource/content.json
@@ -4,47 +4,64 @@
   "blocks": [
     {
       "type": "markdown",
-      "content": "In this milestone, you configure your GitHub data source with authentication credentials and test the connection."
+      "content": "In this milestone, you configure your GitHub data source with the Personal Access Token you created and verify that the connection works correctly. This step establishes the authenticated connection between Grafana and the GitHub API.\n\nProper authentication ensures that your data source can access the repositories and data you need for your dashboards. The connection test validates that your token has the correct permissions and that the GitHub API is accessible."
     },
     {
-      "type": "interactive",
-      "action": "formfill",
-      "reftarget": "[data-testid='data-testid Data source settings page name input field']",
-      "doIt": false,
-      "requirements": ["exists-reftarget"],
-      "content": "In the **Name** field, enter a descriptive name for your data source.\n\nFor example, enter `My GitHub Organization Data` or `GitHub Repository Data`."
-    },
-    {
-      "type": "markdown",
-      "content": "Optionally, enable the **Default** toggle if you want this to be your default data source when creating new panels."
+      "type": "video",
+      "src": "https://www.youtube.com/embed/DW693S3cO48",
+      "provider": "youtube",
+      "title": "Configure GitHub data source walkthrough",
+      "start": 298,
+      "end": 319
     },
     {
       "type": "markdown",
-      "content": "Scroll down to the **Authentication** section at the bottom of the page."
+      "content": "To configure authentication and verify the connection, complete the following steps:"
     },
     {
-      "type": "markdown",
-      "content": "For **Authentication Type**, **Personal Access Token** is selected by default. This is the recommended option for most users."
-    },
-    {
-      "type": "interactive",
-      "action": "formfill",
-      "reftarget": "input[placeholder='Personal Access Token']",
-      "doIt": false,
-      "requirements": ["exists-reftarget"],
-      "content": "Paste the GitHub Personal Access Token you created earlier.\n\n**Tip:** Ensure you paste the complete token without any extra spaces or characters."
-    },
-    {
-      "type": "markdown",
-      "content": "Under **Connection**, select your **GitHub License Type**:\n\n- **Free, Pro & Team** (default) - For personal accounts and standard GitHub organizations\n- **Enterprise Cloud** - For GitHub Enterprise Cloud customers\n- **Enterprise Server** - For self-hosted GitHub Enterprise Server"
-    },
-    {
-      "type": "interactive",
-      "action": "button",
-      "reftarget": "Save & test",
-      "doIt": false,
-      "requirements": ["exists-reftarget"],
-      "content": "Click **Save & test** to save the configuration and test the connection.\n\nA successful connection will display a green checkmark with the message \"Data source is working\"."
+      "type": "section",
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "formfill",
+          "reftarget": "[data-testid='data-testid Data source settings page name input field']",
+          "doIt": false,
+          "requirements": ["exists-reftarget"],
+          "content": "In the **Name** field, enter a descriptive name for your data source.\n\nFor example, enter `My GitHub Organization Data` or `GitHub Repository Data`."
+        },
+        {
+          "type": "markdown",
+          "content": "Optionally, enable the **Default** toggle if you want this to be your default data source when creating new panels."
+        },
+        {
+          "type": "markdown",
+          "content": "Scroll down to the **Authentication** section at the bottom of the page."
+        },
+        {
+          "type": "markdown",
+          "content": "For **Authentication Type**, **Personal Access Token** is selected by default. This is the recommended option for most users."
+        },
+        {
+          "type": "interactive",
+          "action": "formfill",
+          "reftarget": "input[placeholder='Personal Access Token']",
+          "doIt": false,
+          "requirements": ["exists-reftarget"],
+          "content": "Paste the GitHub Personal Access Token you created earlier.\n\n**Tip:** Ensure you paste the complete token without any extra spaces or characters."
+        },
+        {
+          "type": "markdown",
+          "content": "Under **Connection**, select your **GitHub License Type**:\n\n- **Free, Pro & Team** (default) - For personal accounts and standard GitHub organizations\n- **Enterprise Cloud** - For GitHub Enterprise Cloud customers\n- **Enterprise Server** - For self-hosted GitHub Enterprise Server"
+        },
+        {
+          "type": "interactive",
+          "action": "button",
+          "reftarget": "Save & test",
+          "doIt": false,
+          "requirements": ["exists-reftarget"],
+          "content": "Click **Save & test** to save the configuration and test the connection.\n\nA successful connection will display a green checkmark with the message \"Data source is working\"."
+        }
+      ]
     }
   ]
 }

--- a/github-data-source-lj/create-github-token/content.json
+++ b/github-data-source-lj/create-github-token/content.json
@@ -1,0 +1,71 @@
+{
+  "id": "github-data-source-create-token",
+  "title": "Obtain a GitHub Personal Access Token",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "In this milestone, you create a GitHub Personal Access Token that allows your Grafana data source to authenticate with the GitHub API. The token provides the necessary permissions to read repository data including issues, pull requests, and other metrics."
+    },
+    {
+      "type": "video",
+      "src": "https://www.youtube.com/embed/DW693S3cO48",
+      "provider": "youtube",
+      "title": "Create GitHub Personal Access Token walkthrough",
+      "start": 160,
+      "end": 298
+    },
+    {
+      "type": "markdown",
+      "content": "GitHub Personal Access Tokens serve as an authentication method for API access. For the GitHub data source, you can use one of the following:\n\n- personal access token (classic)\n- fine-grained personal access token\n\nYou can find more information about the personal access tokens on the [GitHub documentation page](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens).\n\n**Note:** You can also use the [GitHub App Authentication](https://grafana.com/docs/plugins/grafana-github-datasource/latest/setup/token/#using-github-app-authentication) instead of a personal access token for better security and fine-grained access to resources.\n\nFor now, you will continue the learning journey by creating a classic token with specific repository permissions to access the data you want to visualize in your dashboards.\n\nTo create a GitHub Personal Access Token, complete the following steps:"
+    },
+    {
+      "type": "section",
+      "blocks": [
+        {
+          "type": "markdown",
+          "content": "Sign in to your GitHub account at `github.com`."
+        },
+        {
+          "type": "markdown",
+          "content": "Click your profile avatar in the upper right corner and select **Settings**."
+        },
+        {
+          "type": "markdown",
+          "content": "In the left sidebar, scroll down and click **Developer settings**."
+        },
+        {
+          "type": "markdown",
+          "content": "Click **Personal access tokens > Tokens (classic)**."
+        },
+        {
+          "type": "markdown",
+          "content": "Click **Generate new token > Generate new token (classic)**."
+        },
+        {
+          "type": "markdown",
+          "content": "In the **Note** field, enter a descriptive name for the token.\n\nFor example, enter `Grafana Cloud GitHub Data Source`."
+        },
+        {
+          "type": "markdown",
+          "content": "Set the **Expiration** based on your organization's security policies.\n\nFor testing purposes, you can select **7 days**. For production use, consider your organization's token rotation policies."
+        },
+        {
+          "type": "markdown",
+          "content": "Under **Select scopes**, select the following permissions:\n\n- For all repositories: `public_repo`, `repo:status`, `repo_deployment`, `read:packages`, `read:user`, `user:email`\n- For GitHub projects: `read:org`, `read:project`\n- An extra setting is required for private repositories: `repo` (Full control of private repositories)"
+        },
+        {
+          "type": "markdown",
+          "content": "Click **Generate token** at the bottom of the page."
+        },
+        {
+          "type": "markdown",
+          "content": "Copy the generated token immediately and store it securely. GitHub will not display the token again after you leave this page.\n\n**Caution:** Treat your Personal Access Token like a password. Store it securely and never commit it to version control or share it publicly."
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "You now have a GitHub Personal Access Token that can be used to authenticate your GitHub data source. Keep the token secure and readily accessible for the next milestone."
+    }
+  ]
+}

--- a/github-data-source-lj/end-journey/content.json
+++ b/github-data-source-lj/end-journey/content.json
@@ -1,0 +1,10 @@
+{
+  "id": "github-data-source-end-journey",
+  "title": "Destination reached!",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "Congratulations on completing this journey! Job well done!\n\nWe hope you've enjoyed traveling with us as you:\n\n- Learned about the value of monitoring GitHub repositories through observability platforms\n- Learned about the advantages of using the GitHub data source plugin in Grafana\n- Created a GitHub Personal Access Token with appropriate permissions\n- Successfully installed and configured the GitHub data source plugin"
+    }
+  ]
+}

--- a/github-data-source-lj/install-github-plugin/content.json
+++ b/github-data-source-lj/install-github-plugin/content.json
@@ -4,88 +4,83 @@
   "blocks": [
     {
       "type": "markdown",
-      "content": "In this milestone, you install the GitHub data source plugin and add it to your Grafana Cloud instance."
+      "content": "The GitHub data source is not installed by default. In this milestone, you search for the data source and install it in your Grafana Cloud instance.\n\nThe GitHub data source is available in the Grafana plugin catalog and can be installed directly from the Grafana Cloud interface. Once installed, it provides the necessary components to connect to the GitHub API and retrieve repository metrics."
     },
     {
-      "type": "multistep",
-      "content": "Navigate to **Administration > Plugins and data > Plugins**.",
-      "steps": [
+      "type": "video",
+      "src": "https://www.youtube.com/embed/DW693S3cO48",
+      "provider": "youtube",
+      "title": "Install GitHub data source walkthrough",
+      "start": 107,
+      "end": 154
+    },
+    {
+      "type": "markdown",
+      "content": "To install the GitHub data source, complete the following steps:"
+    },
+    {
+      "type": "section",
+      "blocks": [
         {
+          "type": "interactive",
           "action": "highlight",
-          "reftarget": "a[data-testid='data-testid Nav menu item'][href='/admin']"
+          "reftarget": "a[data-testid='data-testid Nav menu item'][href='/plugins']",
+          "content": "Navigate to **Administration > Plugins and data > Plugins**.",
+          "requirements": ["navmenu-open"]
         },
         {
-          "action": "highlight",
-          "reftarget": "a[data-testid='data-testid Nav menu item'][href='/admin/plugins']"
+          "type": "interactive",
+          "action": "formfill",
+          "reftarget": "input[placeholder='Search Grafana plugins']",
+          "targetvalue": "GitHub",
+          "requirements": ["on-page:/plugins", "exists-reftarget"],
+          "content": "In the **Search** field, enter `GitHub` to filter the available plugins."
         },
         {
+          "type": "interactive",
           "action": "highlight",
-          "reftarget": "a[data-testid='data-testid Nav menu item'][href='/plugins']"
+          "reftarget": "a[href='/plugins/grafana-github-datasource']",
+          "requirements": ["exists-reftarget"],
+          "content": "Locate the **GitHub** data source plugin and click on it to view the plugin details."
+        },
+        {
+          "type": "interactive",
+          "action": "button",
+          "reftarget": "Install",
+          "doIt": false,
+          "requirements": ["on-page:/plugins/grafana-github-datasource", "exists-reftarget"],
+          "content": "Click **Install** to add the GitHub data source to your Grafana Cloud instance.\n\nWait for the installation to complete. The status will change from \"Installing\" to \"Installed\"."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "a[href='/connections/datasources']",
+          "content": "Navigate to **Connections > Data sources**.",
+          "requirements": ["navmenu-open"]
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='data-testid data-source-add-button']",
+          "requirements": ["on-page:/connections/datasources", "exists-reftarget"],
+          "content": "Click **Add new data source** in the upper right of the page."
+        },
+        {
+          "type": "interactive",
+          "action": "formfill",
+          "reftarget": "input[placeholder='Filter by name or type']",
+          "targetvalue": "GitHub",
+          "requirements": ["on-page:/connections/datasources/new", "exists-reftarget"],
+          "content": "In the search field, enter `GitHub` to filter the available data source types."
+        },
+        {
+          "type": "interactive",
+          "action": "button",
+          "reftarget": "GitHub",
+          "requirements": ["exists-reftarget"],
+          "content": "Click **GitHub** to select the GitHub data source and begin configuration."
         }
-      ],
-      "requirements": [
-        "navmenu-open"
       ]
-    },
-    {
-      "type": "interactive",
-      "action": "formfill",
-      "reftarget": "input[placeholder='Search Grafana plugins']",
-      "targetvalue": "GitHub",
-      "requirements": ["on-page:/plugins", "exists-reftarget"],
-      "content": "In the **Search** field, enter `GitHub` to filter the available plugins."
-    },
-    {
-      "type": "interactive",
-      "action": "highlight",
-      "reftarget": "a[href='/plugins/grafana-github-datasource']",
-      "requirements": ["exists-reftarget"],
-      "content": "Locate the **GitHub** data source plugin and click on it to view the plugin details."
-    },
-    {
-      "type": "interactive",
-      "action": "button",
-      "reftarget": "Install",
-      "doIt": false,
-      "requirements": ["on-page:/plugins/grafana-github-datasource", "exists-reftarget"],
-      "content": "Click **Install** to add the GitHub data source to your Grafana Cloud instance.\n\nWait for the installation to complete. The status will change from \"Installing\" to \"Installed\"."
-    },
-    {
-      "type": "multistep",
-      "content": "Navigate to **Connections > Data sources**.",
-      "requirements": ["navmenu-open"],
-      "steps": [
-        {
-          "action": "highlight",
-          "reftarget": "a[data-testid='data-testid Nav menu item'][href='/connections']"
-        },
-        {
-          "action": "highlight",
-          "reftarget": "a[href='/connections/datasources']"
-        }
-      ]
-    },
-    {
-      "type": "interactive",
-      "action": "highlight",
-      "reftarget": "[data-testid='data-testid data-source-add-button']",
-      "requirements": ["on-page:/connections/datasources", "exists-reftarget"],
-      "content": "Click **Add new data source** in the upper right of the page."
-    },
-    {
-      "type": "interactive",
-      "action": "formfill",
-      "reftarget": "input[placeholder='Filter by name or type']",
-      "targetvalue": "GitHub",
-      "requirements": ["on-page:/connections/datasources/new", "exists-reftarget"],
-      "content": "In the search field, enter `GitHub` to filter the available data source types."
-    },
-    {
-      "type": "interactive",
-      "action": "button",
-      "reftarget": "GitHub",
-      "requirements": ["exists-reftarget"],
-      "content": "Click **GitHub** to select the GitHub data source and begin configuration."
     }
   ]
 }

--- a/linux-server-integration-lj/business-value/content.json
+++ b/linux-server-integration-lj/business-value/content.json
@@ -1,0 +1,42 @@
+{
+  "id": "linux-server-integration-business-value",
+  "title": "The case for observability",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "IT systems are complicated. There are nodes, pods, services, system resources - sometimes thousands of them - all connected in a complex web of relationships. And when things go wrong, it can be very difficult to determine the root cause and fix it quickly. Consider the following:\n\n- Slow performance in an application might be caused by heavy load, or it could be a memory leak or even a hardware error. Monitoring your infrastructure allows you to find the root cause quickly and accurately.\n- Running out of disk space can be a disaster for any environment. Understanding that there's a problem before it becomes a problem enables you to prevent it.\n- When applications or services are co-located, being able to identify hotspots and conflicts between them can help you redistribute the load properly.\n\nAnd time is of the essence. System downtime can be very expensive. If you run customer-facing applications such as e-commerce site or a financial institution, every minute of downtime costs you money. Some estimates put the average cost of downtime at $5,600 per minute. If you are a large retailer, this cost can be much more. Even if you're not running a commercial service, downtime can have impact. If you can't turn on your lights because your home automation is having problems, it's still a real issue."
+    },
+    {
+      "type": "markdown",
+      "content": "## Enter...observability"
+    },
+    {
+      "type": "video",
+      "src": "https://www.youtube.com/embed/TQur9GJHIIQ",
+      "provider": "youtube",
+      "title": "What is observability?"
+    },
+    {
+      "type": "markdown",
+      "content": "Observability is the process of making a system's internal state more transparent. Systems are made observable by the data they produce, which in turn helps you to determine if your infrastructure or application is healthy and functioning normally."
+    },
+    {
+      "type": "markdown",
+      "content": "Observability is a holistic approach to understanding and managing complex systems. It involves collecting data from all parts of the system to create a deep understanding of the system's internal workings and how these interact with each other. Observability focuses on understanding and interpreting data to make the system's behavior and performance as transparent as possible. It also requires a means of making the data easily available for humans to interpret.\n\nAn observability system enables system operators, DevOps practitioners, and site reliability engineers to ask questions across the information gathered. These are questions that are not anticipated in advance, but rather questions that arise due to unexpected or novel events within a system."
+    },
+    {
+      "type": "markdown",
+      "content": "## The value of the Linux server integration"
+    },
+    {
+      "type": "video",
+      "src": "https://www.youtube.com/embed/Zk6Dq6W6a74",
+      "provider": "youtube",
+      "title": "The value of the Linux server integration"
+    },
+    {
+      "type": "markdown",
+      "content": "While Grafana is capable of great flexibility and customization, it also provides an out-of-the-box solution for Linux server monitoring. After you've deployed the Linux server integration, it starts collecting the most relevant logs and metrics from your Linux systems. The collected data is available in a set of dashboards and alerts that enable you to see and be notified of what's happening in a single node or across the entire fleet. The pre-built dashboards and alerts represent industry best practices that let you monitor your infrastructure the right way.\n\nWhile these dashboards provide you most of what you need, you always have the option of creating your own, custom dashboards."
+    }
+  ]
+}

--- a/linux-server-integration-lj/configure-alloy/content.json
+++ b/linux-server-integration-lj/configure-alloy/content.json
@@ -15,28 +15,33 @@
       "content": "After you've installed Grafana Alloy, the next step is to configure it for the Linux Server integration. This configuration process requires you to copy a code snippet from Grafana Cloud and add it to the Alloy configuration file.\n\n**Did you know?** By default, the integration only collects the metrics and logs necessary to populate the Linux server dashboards and alerts. Although you have the option to configure Alloy to collect all available metrics and logs, we recommend starting with the default configuration.\n\nTo configure Alloy to use the Linux server integration:"
     },
     {
-      "type": "interactive",
-      "action": "highlight",
-      "reftarget": "div[data-testid='alloy-simple-block']+button",
-      "requirements": ["exists-reftarget"],
-      "content": "In the **Set up Grafana Alloy to use the Linux server integration** section, click **Copy to clipboard**."
-    },
-    {
-      "type": "image",
-      "src": "/media/docs/learning-journey/linux/snippet-1.png",
-      "alt": "Shows the snippet to copy from Grafana Cloud to the Alloy configuration file"
-    },
-    {
-      "type": "markdown",
-      "content": "On your Linux machine, run the following command to open the Alloy configuration file:\n\n```\nsudo nano /etc/alloy/config.alloy\n```"
-    },
-    {
-      "type": "markdown",
-      "content": "Scroll to the end of the configuration file and paste the code snippet you copied from Grafana Cloud."
-    },
-    {
-      "type": "markdown",
-      "content": "Press `Ctrl+O` to write the changes to the file, then press **Enter** to save. Press `Ctrl+X` to exit the editor.\n\nIn the next step of your journey, you'll restart Alloy and test the configuration."
+      "type": "section",
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "div[data-testid='alloy-simple-block']+button",
+          "requirements": ["exists-reftarget"],
+          "content": "In the **Set up Grafana Alloy to use the Linux server integration** section, click **Copy to clipboard**."
+        },
+        {
+          "type": "image",
+          "src": "/media/docs/learning-journey/linux/snippet-1.png",
+          "alt": "Shows the snippet to copy from Grafana Cloud to the Alloy configuration file"
+        },
+        {
+          "type": "markdown",
+          "content": "On your Linux machine, run the following command to open the Alloy configuration file:\n\n```\nsudo nano /etc/alloy/config.alloy\n```"
+        },
+        {
+          "type": "markdown",
+          "content": "Scroll to the end of the configuration file and paste the code snippet you copied from Grafana Cloud."
+        },
+        {
+          "type": "markdown",
+          "content": "Press `Ctrl+O` to write the changes to the file, then press **Enter** to save. Press `Ctrl+X` to exit the editor.\n\nIn the next step of your journey, you'll restart Alloy and test the configuration."
+        }
+      ]
     }
   ]
 }

--- a/linux-server-integration-lj/end-linux-server/content.json
+++ b/linux-server-integration-lj/end-linux-server/content.json
@@ -1,0 +1,10 @@
+{
+  "id": "linux-server-integration-end-linux-server",
+  "title": "Destination reached!",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "Congratulations on completing this journey! Job well done!\n\nWe hope you've enjoyed traveling with us as you:\n\n- Learned about the value of observability and monitoring a Linux server\n- Installed the Linux server integration\n- Learned how to use pre-built dashboards and alerts to identify and troubleshoot problems in your environment"
+    }
+  ]
+}

--- a/linux-server-integration-lj/install-alloy/content.json
+++ b/linux-server-integration-lj/install-alloy/content.json
@@ -4,7 +4,6 @@
   "blocks": [
     {
       "type": "video",
-      "type": "video",
       "src": "https://www.youtube.com/embed/bCPjAVNMelk",
       "provider": "youtube",
       "title": "Select Linux distribution walkthrough",
@@ -16,35 +15,40 @@
       "content": "The next step in your journey takes you to installing Grafana Alloy. Alloy offers native pipelines for OTel, Prometheus, Pyroscope, Loki, and many other metrics, logs, traces, and profile tools. In addition, you can use Alloy pipelines to do different tasks, such as configure alert rules in Loki and Mimir. Alloy is fully compatible with the OTel Collector, Prometheus Agent, and Promtail.\n\nTo install Alloy you must either use an existing token or create a token.\n\n**Did you know?** The token safeguards against unauthorized access, ensuring that only you can install Alloy on your Linux machine.\n\nTo install Alloy, complete the following steps:"
     },
     {
-      "type": "interactive",
-      "action": "highlight",
-      "reftarget": "button[data-testid='agent-config-button']",
-      "requirements": ["exists-reftarget"],
-      "content": "In the **Install Alloy** section, click **Run Grafana Alloy**."
-    },
-    {
-      "type": "markdown",
-      "content": "Perform one of the following:\n\n| If you want to | Then |\n| --- | --- |\n| Create a new token | Click **Create new token**, enter a meaningful token name (e.g., `prodUS`), then click **Create token**. |\n| Use an existing token | Click **Use an existing token** and enter a token you have created in the past. |\n\n**Tip:** You don't need to copy the token. The token is added to the install Grafana Alloy script that you copy in the next step."
-    },
-    {
-      "type": "markdown",
-      "content": "Verify that the **Enable Remote Configuration** toggle is set to on."
-    },
-    {
-      "type": "markdown",
-      "content": "In the **Install and run Grafana Alloy** section, click **Copy to Clipboard**."
-    },
-    {
-      "type": "markdown",
-      "content": "Log in to the Linux machine and open the Terminal. Paste the contents of the clipboard into the terminal and press **Enter**.\n\nThis command installs Grafana Alloy on the Linux machine. When the installation is complete, you'll see `Alloy is now running!`"
-    },
-    {
-      "type": "markdown",
-      "content": "To verify that Grafana Alloy is installed correctly, click **Test Alloy connection**.\n\nIf Grafana Alloy is installed correctly, you'll see `Awesome! Grafana Alloy is good to go`."
-    },
-    {
-      "type": "markdown",
-      "content": "If Alloy is successfully installed, click **Proceed to install integration**."
+      "type": "section",
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "button[data-testid='agent-config-button']",
+          "requirements": ["exists-reftarget"],
+          "content": "In the **Install Alloy** section, click **Run Grafana Alloy**."
+        },
+        {
+          "type": "markdown",
+          "content": "Perform one of the following:\n\n| If you want to | Then |\n| --- | --- |\n| Create a new token | Click **Create new token**, enter a meaningful token name (e.g., `prodUS`), then click **Create token**. |\n| Use an existing token | Click **Use an existing token** and enter a token you have created in the past. |\n\n**Tip:** You don't need to copy the token. The token is added to the install Grafana Alloy script that you copy in the next step."
+        },
+        {
+          "type": "markdown",
+          "content": "Verify that the **Enable Remote Configuration** toggle is set to on."
+        },
+        {
+          "type": "markdown",
+          "content": "In the **Install and run Grafana Alloy** section, click **Copy to Clipboard**."
+        },
+        {
+          "type": "markdown",
+          "content": "Log in to the Linux machine and open the Terminal. Paste the contents of the clipboard into the terminal and press **Enter**.\n\nThis command installs Grafana Alloy on the Linux machine. When the installation is complete, you'll see `Alloy is now running!`"
+        },
+        {
+          "type": "markdown",
+          "content": "To verify that Grafana Alloy is installed correctly, click **Test Alloy connection**.\n\nIf Grafana Alloy is installed correctly, you'll see `Awesome! Grafana Alloy is good to go`."
+        },
+        {
+          "type": "markdown",
+          "content": "If Alloy is successfully installed, click **Proceed to install integration**."
+        }
+      ]
     }
   ]
 }

--- a/linux-server-integration-lj/install-dashboards-alerts/content.json
+++ b/linux-server-integration-lj/install-dashboards-alerts/content.json
@@ -14,31 +14,36 @@
       "content": "The Grafana Cloud Linux server integration comes with a number of pre-built dashboards and alerts that you can use immediately. In this step of the journey, you install those dashboards and alerts.\n\n**Did you know?** You aren't limited to using the pre-built dashboards and alerts. You can create your own dashboards and alerts.\n\nTo install and view Linux server dashboards and alerts:"
     },
     {
-      "type": "interactive",
-      "action": "highlight",
-      "reftarget": "button[data-testid='install-button']",
-      "requirements": ["exists-reftarget"],
-      "content": "In the **Install dashboards and alerts** section, click **Install**."
-    },
-    {
-      "type": "markdown",
-      "content": "You should see the following message: `Dashboards and alerts have been installed.`"
-    },
-    {
-      "type": "interactive",
-      "action": "highlight",
-      "reftarget": "a[data-testid='view-dashboards-button']",
-      "requirements": ["exists-reftarget"],
-      "doIt": false,
-      "content": "To view dashboards, click **View Dashboards**.\n\nA folder containing the integration dashboards appears."
-    },
-    {
-      "type": "markdown",
-      "content": "To see the installed alerts, navigate to **Alerts & IRM > Alerting > Alert rules**."
-    },
-    {
-      "type": "markdown",
-      "content": "The Alert rules page shows all active alerts. Linux integration alerts begin with `integrations-linux-node`."
+      "type": "section",
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "button[data-testid='install-button']",
+          "requirements": ["exists-reftarget"],
+          "content": "In the **Install dashboards and alerts** section, click **Install**."
+        },
+        {
+          "type": "markdown",
+          "content": "You should see the following message: `Dashboards and alerts have been installed.`"
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "a[data-testid='view-dashboards-button']",
+          "requirements": ["exists-reftarget"],
+          "doIt": false,
+          "content": "To view dashboards, click **View Dashboards**.\n\nA folder containing the integration dashboards appears."
+        },
+        {
+          "type": "markdown",
+          "content": "To see the installed alerts, navigate to **Alerts & IRM > Alerting > Alert rules**."
+        },
+        {
+          "type": "markdown",
+          "content": "The Alert rules page shows all active alerts. Linux integration alerts begin with `integrations-linux-node`."
+        }
+      ]
     }
   ]
 }

--- a/linux-server-integration-lj/restart-test-connection/content.json
+++ b/linux-server-integration-lj/restart-test-connection/content.json
@@ -15,19 +15,24 @@
       "content": "By now, you've installed and configured Grafana Alloy. Congratulations! In this step, you'll restart Grafana Alloy and test that Grafana Cloud is collecting data from your Linux machine.\n\nTo restart Alloy and test the connection:"
     },
     {
-      "type": "markdown",
-      "content": "In the Linux machine Terminal, enter the following command and press **Enter**:\n\n```\nsudo systemctl restart alloy.service\n```\n\n**Tip:** You see the Terminal prompt after you run the Alloy restart command. You don't receive feedback from Linux that the restart is running or is complete."
-    },
-    {
-      "type": "interactive",
-      "action": "highlight",
-      "reftarget": "button[data-testid='test-connection-button']",
-      "requirements": ["exists-reftarget"],
-      "content": "In Grafana Cloud, click **Test connection**."
-    },
-    {
-      "type": "markdown",
-      "content": "It might take up to a few minutes for the system to verify the connection.\n\nYou'll know the connection is working when you see `Integration is collecting data and sending it to Grafana Cloud`."
+      "type": "section",
+      "blocks": [
+        {
+          "type": "markdown",
+          "content": "In the Linux machine Terminal, enter the following command and press **Enter**:\n\n```\nsudo systemctl restart alloy.service\n```\n\n**Tip:** You see the Terminal prompt after you run the Alloy restart command. You don't receive feedback from Linux that the restart is running or is complete."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "button[data-testid='test-connection-button']",
+          "requirements": ["exists-reftarget"],
+          "content": "In Grafana Cloud, click **Test connection**."
+        },
+        {
+          "type": "markdown",
+          "content": "It might take up to a few minutes for the system to verify the connection.\n\nYou'll know the connection is working when you see `Integration is collecting data and sending it to Grafana Cloud`."
+        }
+      ]
     }
   ]
 }

--- a/linux-server-integration-lj/select-platform/content.json
+++ b/linux-server-integration-lj/select-platform/content.json
@@ -15,18 +15,10 @@
       "content": "Your first step on this journey is to select the Linux distribution and architecture you are using.\n\n**Did you know?** Grafana Cloud uses the values you select to generate the commands you use to install Grafana Alloy on your machine.\n\nTo select the distribution:"
     },
     {
-      "type": "multistep",
+      "type": "interactive",
+      "action": "highlight",
+      "reftarget": "a[data-testid='data-testid Nav menu item'][href='/connections/add-new-connection']",
       "content": "Click **Connections > Add new connection** in the left-side menu.",
-      "steps": [
-        {
-          "action": "highlight",
-          "reftarget": "a[data-testid='data-testid Nav menu item'][href='/connections']"
-        },
-        {
-          "action": "highlight",
-          "reftarget": "a[data-testid='data-testid Nav menu item'][href='/connections/add-new-connection']"
-        }
-      ],
       "requirements": ["navmenu-open"]
     },
     {

--- a/macos-integration-lj/business-value/content.json
+++ b/macos-integration-lj/business-value/content.json
@@ -1,0 +1,28 @@
+{
+  "id": "macos-integration-business-value",
+  "title": "The case for observability",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "IT systems are complicated. There are nodes, pods, services, system resources - sometimes thousands of them - all connected in a complex web of relationships. And when things go wrong, it can be very difficult to determine the root cause and fix it quickly. Consider the following:\n\n- Slow performance in an application might be caused by heavy load, or it could be a memory leak or even a hardware error. Monitoring your infrastructure allows you to find the root cause quickly and accurately.\n- Running out of disk space can be a disaster for any environment. Understanding that there's a problem _before_ it becomes a problem enables you to prevent it.\n- When applications or services are co-located, being able to identify hotspots and conflicts between them can help you redistribute the load properly.\n\nAnd time is of the essence. System downtime can be very expensive. If you run customer-facing applications such as e-commerce site or a financial institution, every minute of downtime costs you money. Some estimates put the average cost of downtime at $5,600 per minute. If you are a large retailer, this cost can be much more. Even if you're not running a commercial service, downtime can have impact. If you can't turn on your lights because your home automation is having problems, it's still a real issue."
+    },
+    {
+      "type": "markdown",
+      "content": "## Enter...observability"
+    },
+    {
+      "type": "video",
+      "src": "https://www.youtube.com/embed/TQur9GJHIIQ",
+      "provider": "youtube",
+      "title": "What is observability?"
+    },
+    {
+      "type": "markdown",
+      "content": "Observability is the process of making a system's internal state more transparent. Systems are made observable by the data they produce, which in turn helps you to determine if your infrastructure or application is healthy and functioning normally."
+    },
+    {
+      "type": "markdown",
+      "content": "Observability is a holistic approach to understanding and managing complex systems. It involves collecting data from all parts of the system to create a deep understanding of the system's internal workings and how these interact with each other. Observability focuses on understanding and interpreting data to make the system's behavior and performance as transparent as possible. It also requires a means of making the data easily available for humans to interpret.\n\nAn observability system enables system operators, DevOps practitioners, and site reliability engineers to ask questions across the information gathered. These are questions that are not anticipated in advance, but rather questions that arise due to unexpected or novel events within a system."
+    }
+  ]
+}

--- a/macos-integration-lj/configure-alloy/content.json
+++ b/macos-integration-lj/configure-alloy/content.json
@@ -7,27 +7,36 @@
       "content": "After you've installed Grafana Alloy, the next step is to configure it for the macOS integration. This configuration process requires you to copy a code snippet from Grafana Cloud and add it to the Alloy configuration file.\n\n**Did you know?** By default, the integration only collects the metrics and logs necessary to populate the macOS dashboards and alerts. Although you have the option to configure Alloy to collect all available metrics and logs, we recommend starting with the default configuration.\n\nTo configure Alloy to use the macOS integration:"
     },
     {
-      "type": "markdown",
-      "content": "In Grafana Cloud, under the **Make configuration selections** section, click **Make optional selections** and ensure **Simple set-up** is checked."
+      "type": "section",
+      "blocks": [
+        {
+          "type": "markdown",
+          "content": "In Grafana Cloud, under the **Make configuration selections** section, click **Make optional selections** and ensure **Simple set-up** is checked."
+        },
+        {
+          "type": "markdown",
+          "content": "On your macOS machine, run the following command to open the Alloy configuration file:\n\n```\nnano $(brew --prefix)/etc/alloy/config.alloy\n```"
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "div[data-testid='alloy-simple-block']+button",
+          "requirements": ["exists-reftarget"],
+          "content": "Back in Grafana Cloud, scroll down to the **Prepare your configuration file** section and click **Copy to clipboard**."
+        },
+        {
+          "type": "markdown",
+          "content": "On your macOS machine, scroll to the end of the configuration file and paste the configuration snippets you copied from Grafana Cloud."
+        },
+        {
+          "type": "markdown",
+          "content": "Press `Ctrl+O` to write the changes to the file, then press **Enter** to save. Press `Ctrl+X` to exit the editor."
+        }
+      ]
     },
     {
       "type": "markdown",
-      "content": "On your macOS machine, run the following command to open the Alloy configuration file:\n\n```\nnano $(brew --prefix)/etc/alloy/config.alloy\n```"
-    },
-    {
-      "type": "interactive",
-      "action": "highlight",
-      "reftarget": "div[data-testid='alloy-simple-block']+button",
-      "requirements": ["exists-reftarget"],
-      "content": "Back in Grafana Cloud, scroll down to the **Prepare your configuration file** section and click **Copy to clipboard**."
-    },
-    {
-      "type": "markdown",
-      "content": "On your macOS machine, scroll to the end of the configuration file and paste the configuration snippets you copied from Grafana Cloud."
-    },
-    {
-      "type": "markdown",
-      "content": "Press `Ctrl+O` to write the changes to the file, then press **Enter** to save. Press `Ctrl+X` to exit the editor.\n\nIn the next step of your journey, you'll restart Alloy and test the connection."
+      "content": "In the next step of your journey, you'll restart Alloy and test the connection."
     }
   ]
 }

--- a/macos-integration-lj/end-macos/content.json
+++ b/macos-integration-lj/end-macos/content.json
@@ -1,0 +1,10 @@
+{
+  "id": "macos-integration-end-macos",
+  "title": "Destination reached!",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "Congratulations on completing this journey! Job well done!\n\nWe hope you've enjoyed traveling with us as you:\n\n- Learned about the value of observability and monitoring a macOS system\n- Installed the macOS integration\n- Learned how to use pre-built dashboards and alerts to identify and troubleshoot problems in your environment"
+    }
+  ]
+}

--- a/macos-integration-lj/install-alloy/content.json
+++ b/macos-integration-lj/install-alloy/content.json
@@ -7,47 +7,52 @@
       "content": "The next step in your journey is to install Grafana Alloy. Alloy offers native pipelines for OTel, Prometheus, Pyroscope, Loki, and many other metrics, logs, traces, and profile tools. In addition, you can use Alloy pipelines to do different tasks, such as configure alert rules in Loki and Mimir. Alloy is fully compatible with the OTel Collector, Prometheus Agent, and Promtail.\n\nTo install Alloy you must either use an existing token or create a new one.\n\n**Did you know?** The token safeguards against unauthorized access, ensuring that only you can install Alloy on your Mac.\n\nInstall Alloy by completing the following steps:"
     },
     {
-      "type": "interactive",
-      "action": "highlight",
-      "reftarget": "button[data-testid='agent-config-button']",
-      "requirements": ["exists-reftarget"],
-      "content": "In the **Install Alloy** section, click **Run Grafana Alloy**."
-    },
-    {
-      "type": "markdown",
-      "content": "Perform one of the following:\n\n| If you want to | Then |\n| --- | --- |\n| Create a new token | Click **Create new token**, enter a meaningful token name (e.g., `MyMacBookPro`), then click **Create token**. |\n| Use an existing token | Click **Use an existing token** and enter a token you have created in the past. |\n\n**Tip:** You don't need to copy the token. The token is added to a Grafana Alloy configuration command that you copy and run in a later step."
-    },
-    {
-      "type": "markdown",
-      "content": "Verify that the **Enable Remote Configuration** toggle is set to on."
-    },
-    {
-      "type": "markdown",
-      "content": "Log in to the Mac as a user with administrator permissions and open Terminal. Run the following command to install Alloy:\n\n```\nbrew install grafana/grafana/alloy\n```\n\n**Tip:** It may take a few minutes to install Alloy. Hang in there!"
-    },
-    {
-      "type": "markdown",
-      "content": "Return to Grafana Cloud in your browser and scroll down to the **Set up the Alloy Configuration** section."
-    },
-    {
-      "type": "markdown",
-      "content": "Click **Copy to Clipboard** to copy a command to generate an Alloy configuration file."
-    },
-    {
-      "type": "markdown",
-      "content": "Paste the contents of the clipboard into the terminal and press **Enter**. Enter your macOS password when requested.\n\nOnce the command completes, you'll see `Alloy is ready to run` in the terminal."
-    },
-    {
-      "type": "markdown",
-      "content": "Enter the following command to restart Alloy:\n\n```\nbrew services restart grafana/grafana/alloy\n```\n\nIf you see `Successfully started alloy`, then Alloy is running."
-    },
-    {
-      "type": "markdown",
-      "content": "Return to Grafana Cloud in your browser and click **Test Alloy connection**.\n\nIf Grafana Alloy is installed correctly, you'll see `Awesome! Grafana Alloy is good to go`.\n\n**Tip:** Testing the Alloy connection may take a minute or two. If the test initially times out, try clicking **Test Alloy connection** again."
-    },
-    {
-      "type": "markdown",
-      "content": "Once Alloy is successfully installed, click **Proceed to install integration**."
+      "type": "section",
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "button[data-testid='agent-config-button']",
+          "requirements": ["exists-reftarget"],
+          "content": "In the **Install Alloy** section, click **Run Grafana Alloy**."
+        },
+        {
+          "type": "markdown",
+          "content": "Perform one of the following:\n\n| If you want to | Then |\n| --- | --- |\n| Create a new token | Click **Create new token**, enter a meaningful token name (e.g., `MyMacBookPro`), then click **Create token**. |\n| Use an existing token | Click **Use an existing token** and enter a token you have created in the past. |\n\n**Tip:** You don't need to copy the token. The token is added to a Grafana Alloy configuration command that you copy and run in a later step."
+        },
+        {
+          "type": "markdown",
+          "content": "Verify that the **Enable Remote Configuration** toggle is set to on."
+        },
+        {
+          "type": "markdown",
+          "content": "Log in to the Mac as a user with administrator permissions and open Terminal. Run the following command to install Alloy:\n\n```\nbrew install grafana/grafana/alloy\n```\n\n**Tip:** It may take a few minutes to install Alloy. Hang in there!"
+        },
+        {
+          "type": "markdown",
+          "content": "Return to Grafana Cloud in your browser and scroll down to the **Set up the Alloy Configuration** section."
+        },
+        {
+          "type": "markdown",
+          "content": "Click **Copy to Clipboard** to copy a command to generate an Alloy configuration file."
+        },
+        {
+          "type": "markdown",
+          "content": "Paste the contents of the clipboard into the terminal and press **Enter**. Enter your macOS password when requested.\n\nOnce the command completes, you'll see `Alloy is ready to run` in the terminal."
+        },
+        {
+          "type": "markdown",
+          "content": "Enter the following command to restart Alloy:\n\n```\nbrew services restart grafana/grafana/alloy\n```\n\nIf you see `Successfully started alloy`, then Alloy is running."
+        },
+        {
+          "type": "markdown",
+          "content": "Return to Grafana Cloud in your browser and click **Test Alloy connection**.\n\nIf Grafana Alloy is installed correctly, you'll see `Awesome! Grafana Alloy is good to go`.\n\n**Tip:** Testing the Alloy connection may take a minute or two. If the test initially times out, try clicking **Test Alloy connection** again."
+        },
+        {
+          "type": "markdown",
+          "content": "Once Alloy is successfully installed, click **Proceed to install integration**."
+        }
+      ]
     }
   ]
 }

--- a/macos-integration-lj/install-dashboards-alerts/content.json
+++ b/macos-integration-lj/install-dashboards-alerts/content.json
@@ -7,31 +7,36 @@
       "content": "The Grafana Cloud macOS integration comes with a number of pre-built dashboards and alerts that you can use immediately. In this step of the journey, you install those dashboards and alerts.\n\n**Did you know?** You aren't limited to using the pre-built dashboards and alerts. You can create your own dashboards and alerts.\n\nTo install and view macOS dashboards and alerts:"
     },
     {
-      "type": "interactive",
-      "action": "highlight",
-      "reftarget": "button[data-testid='install-button']",
-      "requirements": ["exists-reftarget"],
-      "content": "In the **Install dashboards and alerts** section, click **Install**."
-    },
-    {
-      "type": "markdown",
-      "content": "You should see the following message: `Dashboards and alerts have been installed.`"
-    },
-    {
-      "type": "interactive",
-      "action": "highlight",
-      "reftarget": "a[data-testid='view-dashboards-button']",
-      "requirements": ["exists-reftarget"],
-      "doIt": false,
-      "content": "To view dashboards, click **View Dashboards**.\n\nA folder containing the macOS dashboards appears."
-    },
-    {
-      "type": "markdown",
-      "content": "To see the installed alerts, navigate to **Alerts & IRM > Alerting > Alert rules**."
-    },
-    {
-      "type": "markdown",
-      "content": "The Alert rules page shows all active alerts. macOS integration alerts begin with `integrations-macos-node`."
+      "type": "section",
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "button[data-testid='install-button']",
+          "requirements": ["exists-reftarget"],
+          "content": "In the **Install dashboards and alerts** section, click **Install**."
+        },
+        {
+          "type": "markdown",
+          "content": "You should see the following message: `Dashboards and alerts have been installed.`"
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "a[data-testid='view-dashboards-button']",
+          "requirements": ["exists-reftarget"],
+          "doIt": false,
+          "content": "To view dashboards, click **View Dashboards**.\n\nA folder containing the macOS dashboards appears."
+        },
+        {
+          "type": "markdown",
+          "content": "To see the installed alerts, navigate to **Alerts & IRM > Alerting > Alert rules**."
+        },
+        {
+          "type": "markdown",
+          "content": "The Alert rules page shows all active alerts. macOS integration alerts begin with `integrations-macos-node`."
+        }
+      ]
     }
   ]
 }

--- a/macos-integration-lj/select-architecture/content.json
+++ b/macos-integration-lj/select-architecture/content.json
@@ -7,56 +7,53 @@
       "content": "Your first step on this journey is to determine your Mac's architecture, so that the correct Alloy package can be installed.\n\nTo select the architecture, complete the following steps:"
     },
     {
-      "type": "multistep",
-      "content": "Click **Connections > Add new connection** in the left-side menu.",
-      "steps": [
+      "type": "section",
+      "blocks": [
         {
+          "type": "interactive",
           "action": "highlight",
-          "reftarget": "a[data-testid='data-testid Nav menu item'][href='/connections']"
+          "reftarget": "a[data-testid='data-testid Nav menu item'][href='/connections/add-new-connection']",
+          "content": "Click **Connections > Add new connection** in the left-side menu.",
+          "requirements": ["navmenu-open"]
         },
         {
+          "type": "interactive",
+          "action": "formfill",
+          "reftarget": "input[data-testid='search-input-input']",
+          "content": "Filter the connections by typing `macOS` in the search.",
+          "targetvalue": "macOS"
+        },
+        {
+          "type": "interactive",
           "action": "highlight",
-          "reftarget": "a[data-testid='data-testid Nav menu item'][href='/connections/add-new-connection']"
+          "reftarget": "a[href='/connections/add-new-connection/macos-node']",
+          "content": "Click the **macOS** tile."
+        },
+        {
+          "type": "markdown",
+          "content": "Use the following table to determine which architecture to select:\n\n| Architecture | Select |\n| --- | --- |\n| Mac with Apple M series processor | `Arm64` |\n| Mac with Intel processor | `Amd64` |"
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "div[data-testid='collector-arch-selection'] input",
+          "content": "Select the **architecture** that matches your Mac.\n\nIf you are unsure of your Mac's architecture, open Terminal and run `uname -m`. If it returns `x86_64`, you have an Intel Mac: select **Amd64**. If it returns `arm64`, select **Arm64**.",
+          "requirements": ["exists-reftarget"],
+          "doIt": false
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "div[data-testid='collector-installation-method'] input",
+          "content": "Select the **Homebrew** installation method.",
+          "requirements": ["exists-reftarget"],
+          "doIt": false
         }
-      ],
-      "requirements": ["navmenu-open"]
-    },
-    {
-      "type": "interactive",
-      "action": "formfill",
-      "reftarget": "input[data-testid='search-input-input']",
-      "content": "Filter the connections by typing `macOS` in the search.",
-      "targetvalue": "macOS"
-    },
-    {
-      "type": "interactive",
-      "action": "highlight",
-      "reftarget": "a[href='/connections/add-new-connection/macos-node']",
-      "content": "Click the **macOS** tile."
+      ]
     },
     {
       "type": "markdown",
-      "content": "Use the following table to determine which architecture to select:\n\n| Architecture | Select |\n| --- | --- |\n| Mac with Apple M series processor | `Arm64` |\n| Mac with Intel processor | `Amd64` |"
-    },
-    {
-      "type": "interactive",
-      "action": "highlight",
-      "reftarget": "div[data-testid='collector-arch-selection'] input",
-      "content": "Select the **architecture** that matches your Mac.",
-      "requirements": ["exists-reftarget"],
-      "doIt": false
-    },
-    {
-      "type": "markdown",
-      "content": "If you are unsure of your Mac's architecture, open Terminal and run `uname -m`. If it returns `x86_64`, you have an Intel Mac: select **Amd64**. If it returns `arm64`, select **Arm64**.\n\n**Did you know?** Grafana Cloud uses the values you select to generate the commands you use to install Grafana Alloy on your machine."
-    },
-    {
-      "type": "interactive",
-      "action": "highlight",
-      "reftarget": "div[data-testid='collector-installation-method'] input",
-      "content": "Select the **Homebrew** installation method.",
-      "requirements": ["exists-reftarget"],
-      "doIt": false
+      "content": "**Did you know?** Grafana Cloud uses the values you select to generate the commands you use to install Grafana Alloy on your machine."
     }
   ]
 }

--- a/macos-integration-lj/test-connection/content.json
+++ b/macos-integration-lj/test-connection/content.json
@@ -7,15 +7,20 @@
       "content": "By now, you've installed and configured Grafana Alloy. Congratulations! In this step, you'll restart Grafana Alloy and test that Grafana Cloud is collecting data from your macOS machine.\n\nTo restart Alloy and test the connection:"
     },
     {
-      "type": "markdown",
-      "content": "At the macOS Terminal, enter the following command and press **Enter**:\n\n```\nbrew services restart grafana/grafana/alloy\n```"
-    },
-    {
-      "type": "interactive",
-      "action": "highlight",
-      "reftarget": "button[data-testid='test-connection-button']",
-      "requirements": ["exists-reftarget"],
-      "content": "In Grafana Cloud, click **Test connection**."
+      "type": "section",
+      "blocks": [
+        {
+          "type": "markdown",
+          "content": "At the macOS Terminal, enter the following command and press **Enter**:\n\n```\nbrew services restart grafana/grafana/alloy\n```"
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "button[data-testid='test-connection-button']",
+          "requirements": ["exists-reftarget"],
+          "content": "In Grafana Cloud, click **Test connection**."
+        }
+      ]
     },
     {
       "type": "markdown",

--- a/mysql-data-source-lj/add-data-source/content.json
+++ b/mysql-data-source-lj/add-data-source/content.json
@@ -7,49 +7,47 @@
       "content": "Grafana provides built-in support for MySQL databases. In this milestone, you add the MySQL data source and give it a descriptive name.\n\nLet's walk through the steps together."
     },
     {
-      "type": "interactive",
-      "action": "highlight",
-      "reftarget": "a[data-testid='data-testid Nav menu item'][href='/connections']",
-      "requirements": ["navmenu-open", "exists-reftarget"],
-      "content": "In the navigation menu, expand the **Connections** section by clicking the arrow."
-    },
-    {
-      "type": "interactive",
-      "action": "highlight",
-      "reftarget": "a[href='/connections/datasources']",
-      "requirements": ["navmenu-open", "exists-reftarget"],
-      "content": "In the navigation menu, click **Data sources**."
-    },
-    {
-      "type": "interactive",
-      "action": "highlight",
-      "reftarget": "[data-testid='data-testid data-source-add-button']",
-      "requirements": ["exists-reftarget"],
-      "content": "Click **Add new data source**."
-    },
-    {
-      "type": "interactive",
-      "action": "formfill",
-      "reftarget": "input[placeholder='Filter by name or type']",
-      "targetvalue": "MySQL",
-      "requirements": ["exists-reftarget"],
-      "content": "In the **Search** field, enter `MySQL`."
-    },
-    {
-      "type": "interactive",
-      "action": "button",
-      "reftarget": "MySQL",
-      "requirements": ["exists-reftarget"],
-      "content": "From the search results, click **MySQL**."
-    },
-    {
-      "type": "interactive",
-      "action": "formfill",
-      "reftarget": "input[placeholder='Name']",
-      "targetvalue": "Production MySQL Database",
-      "doIt": false,
-      "requirements": ["exists-reftarget"],
-      "content": "In the **Name** field, enter a descriptive name for your MySQL data source.\n\nFor example, enter `Production MySQL Database`."
+      "type": "section",
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "a[href='/connections/datasources']",
+          "requirements": ["navmenu-open", "exists-reftarget"],
+          "content": "In the navigation menu, click **Connections > Data sources**."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='data-testid data-source-add-button']",
+          "requirements": ["exists-reftarget"],
+          "content": "Click **Add new data source**."
+        },
+        {
+          "type": "interactive",
+          "action": "formfill",
+          "reftarget": "input[placeholder='Filter by name or type']",
+          "targetvalue": "MySQL",
+          "requirements": ["exists-reftarget"],
+          "content": "In the **Search** field, enter `MySQL`."
+        },
+        {
+          "type": "interactive",
+          "action": "button",
+          "reftarget": "MySQL",
+          "requirements": ["exists-reftarget"],
+          "content": "From the search results, click **MySQL**."
+        },
+        {
+          "type": "interactive",
+          "action": "formfill",
+          "reftarget": "input[placeholder='Name']",
+          "targetvalue": "Production MySQL Database",
+          "doIt": false,
+          "requirements": ["exists-reftarget"],
+          "content": "In the **Name** field, enter a descriptive name for your MySQL data source.\n\nFor example, enter `Production MySQL Database`."
+        }
+      ]
     },
     {
       "type": "markdown",

--- a/mysql-data-source-lj/advantages-mysql/content.json
+++ b/mysql-data-source-lj/advantages-mysql/content.json
@@ -1,0 +1,10 @@
+{
+  "id": "mysql-data-source-advantages",
+  "title": "Advantages of using the MySQL data source",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "The MySQL data source in Grafana Cloud provides powerful capabilities for database monitoring and visualization. Unlike generic monitoring tools, the MySQL data source offers deep integration with your database systems.\n\nThe MySQL data source provides the following advantages:\n\n- **Native SQL support** for complex queries and data analysis\n- **Real-time monitoring** of database performance metrics\n- **Custom alerting** based on query results and thresholds\n- **Rich visualizations** including time series, tables, and graphs\n- **Template variables** for dynamic dashboard filtering\n- **Query builder** to simplify SQL query creation\n- **Secure connections** with support for SSL/TLS encryption\n- **Performance optimization** through query caching and connection pooling\n\nIn the next milestone, you'll create a dedicated user on the MySQL Server for Grafana Cloud."
+    }
+  ]
+}

--- a/mysql-data-source-lj/business-value-mysql/content.json
+++ b/mysql-data-source-lj/business-value-mysql/content.json
@@ -1,0 +1,10 @@
+{
+  "id": "mysql-data-source-business-value",
+  "title": "The value of MySQL monitoring",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "Database monitoring is critical for maintaining application performance, ensuring data integrity, and preventing costly downtime. MySQL databases are often the backbone of web applications, handling everything from user authentication to business-critical transactions.\n\nWith proper MySQL monitoring through observability, you can:\n\n- **Identify performance bottlenecks** before they impact users\n- **Track query performance** and optimize slow-running queries\n- **Monitor resource utilization** including CPU, memory, and disk I/O\n- **Detect connection issues** and prevent database overload\n- **Ensure data integrity** by monitoring replication lag and errors\n- **Plan capacity** based on growth trends and usage patterns\n- **Reduce mean time to resolution** when database issues occur\n\nIn the next milestone, you'll learn about the specific advantages of using the MySQL data source in Grafana Cloud."
+    }
+  ]
+}

--- a/mysql-data-source-lj/configure-datasource/content.json
+++ b/mysql-data-source-lj/configure-datasource/content.json
@@ -7,32 +7,37 @@
       "content": "In this milestone, you configure the connection details and the authentication credentials so that Grafana Cloud can connect to your MySQL database.\n\nThis includes the hostname, port, and user name."
     },
     {
-      "type": "interactive",
-      "action": "formfill",
-      "reftarget": "input[name='host']",
-      "doIt": false,
-      "requirements": ["exists-reftarget"],
-      "content": "In the **Host URL** field under the **Connection** section, enter the hostname or IP address of your MySQL server.\n\nFor example, enter `localhost:3306` or `mysql.example.com:3306`."
-    },
-    {
-      "type": "markdown",
-      "content": "Now complete the **Authentication** section:"
-    },
-    {
-      "type": "interactive",
-      "action": "formfill",
-      "reftarget": "input[placeholder='Username']",
-      "doIt": false,
-      "requirements": ["exists-reftarget"],
-      "content": "In the **Username** field, enter the name of the MySQL user that you want to connect to.\n\nFor example, enter `grafanaReader`."
-    },
-    {
-      "type": "interactive",
-      "action": "formfill",
-      "reftarget": "input[placeholder='Password']",
-      "doIt": false,
-      "requirements": ["exists-reftarget"],
-      "content": "In the **Password** field, enter the password for the MySQL user that you defined above.\n\nFor example, enter `password`."
+      "type": "section",
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "formfill",
+          "reftarget": "input[name='host']",
+          "doIt": false,
+          "requirements": ["exists-reftarget"],
+          "content": "In the **Host URL** field under the **Connection** section, enter the hostname or IP address of your MySQL server.\n\nFor example, enter `localhost:3306` or `mysql.example.com:3306`."
+        },
+        {
+          "type": "markdown",
+          "content": "Now complete the **Authentication** section:"
+        },
+        {
+          "type": "interactive",
+          "action": "formfill",
+          "reftarget": "input[placeholder='Username']",
+          "doIt": false,
+          "requirements": ["exists-reftarget"],
+          "content": "In the **Username** field, enter the name of the MySQL user that you want to connect to.\n\nFor example, enter `grafanaReader`."
+        },
+        {
+          "type": "interactive",
+          "action": "formfill",
+          "reftarget": "input[placeholder='Password']",
+          "doIt": false,
+          "requirements": ["exists-reftarget"],
+          "content": "In the **Password** field, enter the password for the MySQL user that you defined above.\n\nFor example, enter `password`."
+        }
+      ]
     },
     {
       "type": "markdown",

--- a/mysql-data-source-lj/end-journey/content.json
+++ b/mysql-data-source-lj/end-journey/content.json
@@ -1,0 +1,10 @@
+{
+  "id": "mysql-data-source-end",
+  "title": "Destination reached!",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "Congratulations on completing this journey! Job well done!\n\nWe hope you've enjoyed traveling with us as you:\n\n- Learned about the value of MySQL database monitoring and observability\n- Learned about the advantages of using the MySQL data source in Grafana Cloud\n- Added and configured the MySQL data source plugin\n- Configured connection details including hostname, port, and database credentials\n- Set up authentication with secure credentials and SSL configuration\n- Successfully tested the database connection via PDC to the Grafana Cloud instance\n- Verified MySQL data access through Grafana's Explore feature"
+    }
+  ]
+}

--- a/mysql-data-source-lj/prepare-configuration/content.json
+++ b/mysql-data-source-lj/prepare-configuration/content.json
@@ -1,0 +1,39 @@
+{
+  "id": "mysql-data-source-prepare",
+  "title": "Prepare MySQL database configuration",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "In this milestone, you prepare the MySQL database configuration required for monitoring. This includes creating a dedicated monitoring user account with the necessary permissions and gathering the connection details needed for Grafana.\n\nCreating a dedicated monitoring user with minimal required privileges follows security best practices and ensures that the monitoring system has only the access it needs to collect metrics and logs.\n\n**Prerequisites**:\n\n- Check if the MySQL server is up and running.\n- Make sure that your firewall is open for MySQL server (default port is `3306`).\n\nTo prepare your MySQL database configuration, complete the following steps:"
+    },
+    {
+      "type": "section",
+      "blocks": [
+        {
+          "type": "markdown",
+          "content": "Connect to your MySQL server as an administrative user:\n\n```bash\nmysql -u root -p\n```"
+        },
+        {
+          "type": "markdown",
+          "content": "Create a dedicated monitoring user for Grafana.:\n\n```sql\nCREATE USER 'grafanaReader' IDENTIFIED BY 'password';\n```"
+        },
+        {
+          "type": "markdown",
+          "content": "Grant the necessary privileges for monitoring:\n\n```sql\nGRANT SELECT ON performance_schema.* TO 'grafanaReader';\n```"
+        },
+        {
+          "type": "markdown",
+          "content": "Exit the MySQL client:\n\n```sql\nEXIT;\n```"
+        },
+        {
+          "type": "markdown",
+          "content": "Test the monitoring user connection:\n\n```bash\nmysql -u grafanaReader -p -e \"SHOW STATUS LIKE 'Uptime';\"\n```"
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "In the next milestone, you'll add the MySQL data source to your Grafana Cloud instance."
+    }
+  ]
+}

--- a/mysql-data-source-lj/test-connection/content.json
+++ b/mysql-data-source-lj/test-connection/content.json
@@ -11,18 +11,23 @@
       "content": "**Recommendation:** We recommend that you create a private connection whenever you connect Grafana Cloud to an external data source."
     },
     {
-      "type": "interactive",
-      "action": "highlight",
-      "reftarget": "input[aria-label='Private data source connect']",
-      "requirements": ["exists-reftarget"],
-      "content": "In the **Private data source connect** field, select the name of a PDC agent.\n\n**Note:** For the test connection to be successful, you must select a PDC agent that's running."
-    },
-    {
-      "type": "interactive",
-      "action": "button",
-      "reftarget": "Save & test",
-      "requirements": ["exists-reftarget"],
-      "content": "Click **Save & test**.\n\nWhen successful, you'll see the message: `Database Connection OK`"
+      "type": "section",
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "input[aria-label='Private data source connect']",
+          "requirements": ["exists-reftarget"],
+          "content": "In the **Private data source connect** field, select the name of a PDC agent.\n\n**Note:** For the test connection to be successful, you must select a PDC agent that's running."
+        },
+        {
+          "type": "interactive",
+          "action": "button",
+          "reftarget": "Save & test",
+          "requirements": ["exists-reftarget"],
+          "content": "Click **Save & test**.\n\nWhen successful, you'll see the message: `Database Connection OK`"
+        }
+      ]
     },
     {
       "type": "markdown",

--- a/mysql-data-source-lj/verify-mysql-data/content.json
+++ b/mysql-data-source-lj/verify-mysql-data/content.json
@@ -7,34 +7,39 @@
       "content": "In this milestone, you verify that your MySQL data source is working correctly by running a test query in Grafana's Explore feature."
     },
     {
-      "type": "interactive",
-      "action": "highlight",
-      "reftarget": "a[href='/explore']",
-      "requirements": ["navmenu-open", "exists-reftarget"],
-      "content": "In the Grafana Cloud navigation menu, click **Explore**."
-    },
-    {
-      "type": "interactive",
-      "action": "highlight",
-      "reftarget": "[data-testid='data-testid Select a data source']",
-      "doIt": false,
-      "requirements": ["on-page:/explore", "exists-reftarget"],
-      "content": "From the data source dropdown at the top-left, select your MySQL data source.\n\nFor example, select **Production MySQL Database**."
-    },
-    {
-      "type": "interactive",
-      "action": "highlight",
-      "reftarget": "[data-testid='query-editor-rows']",
-      "doIt": false,
-      "requirements": ["on-page:/explore", "exists-reftarget"],
-      "content": "In the query editor, enter a simple SQL query to test your connection.\n\nFor example, enter:\n\n```sql\nSELECT * FROM performance_schema.file_instances LIMIT 5\n```\n\n**Tip:** You can use any valid SQL query that works with your MySQL database."
-    },
-    {
-      "type": "interactive",
-      "action": "highlight",
-      "reftarget": "button[aria-label='Run query']",
-      "requirements": ["on-page:/explore", "exists-reftarget"],
-      "content": "Click **Run query** to execute the query.\n\nYou should see the query results displayed in the results panel below the query editor."
+      "type": "section",
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "a[href='/explore']",
+          "requirements": ["navmenu-open", "exists-reftarget"],
+          "content": "In the Grafana Cloud navigation menu, click **Explore**."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='data-testid Select a data source']",
+          "doIt": false,
+          "requirements": ["on-page:/explore", "exists-reftarget"],
+          "content": "From the data source dropdown at the top-left, select your MySQL data source.\n\nFor example, select **Production MySQL Database**."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='query-editor-rows']",
+          "doIt": false,
+          "requirements": ["on-page:/explore", "exists-reftarget"],
+          "content": "In the query editor, enter a simple SQL query to test your connection.\n\nFor example, enter:\n\n```sql\nSELECT * FROM performance_schema.file_instances LIMIT 5\n```\n\n**Tip:** You can use any valid SQL query that works with your MySQL database."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "button[aria-label='Run query']",
+          "requirements": ["on-page:/explore", "exists-reftarget"],
+          "content": "Click **Run query** to execute the query.\n\nYou should see the query results displayed in the results panel below the query editor."
+        }
+      ]
     },
     {
       "type": "markdown",

--- a/mysql-integration-lj/business-value/content.json
+++ b/mysql-integration-lj/business-value/content.json
@@ -1,0 +1,10 @@
+{
+  "id": "mysql-integration-business-value",
+  "title": "The value of MySQL monitoring",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "MySQL monitoring is essential for maintaining database performance, preventing downtime, and ensuring optimal user experience. Without proper monitoring, database issues can go undetected until they impact application performance or cause service interruptions.\n\nMonitoring MySQL databases provides critical insights into query performance, connection handling, storage utilization, and replication health. This observability enables proactive identification of bottlenecks, capacity planning, and optimization opportunities before they affect your applications.\n\nGrafana Cloud provides the following advantages for MySQL monitoring:\n\n- Pre-built dashboards with essential MySQL metrics for immediate insights\n- Comprehensive alerting rules that notify you of performance issues and anomalies\n- Centralized log collection and analysis for troubleshooting and audit trails\n- Integration with observability infrastructure through Grafana Alloy\n- Cost-effective monitoring solution that scales with your database infrastructure\n- Historical data retention for trend analysis and capacity planning\n\nIn the next milestone, you navigate to the MySQL integration page in Grafana Cloud."
+    }
+  ]
+}

--- a/mysql-integration-lj/configure-alloy/content.json
+++ b/mysql-integration-lj/configure-alloy/content.json
@@ -7,40 +7,49 @@
       "content": "In this milestone, you configure Grafana Alloy using the configuration snippets provided by the MySQL integration. These snippets enable Grafana Alloy to collect MySQL metrics and logs and send them to your Grafana Cloud instance.\n\nThe configuration includes components for MySQL metrics collection using the Prometheus MySQL exporter component and log collection using Loki source file components.\n\nTo configure Grafana Alloy for MySQL monitoring, complete the following steps:"
     },
     {
-      "type": "markdown",
-      "content": "On the MySQL integration page in Grafana Cloud, scroll to the **Set up Grafana Alloy to use the MySQL integration** section."
+      "type": "section",
+      "blocks": [
+        {
+          "type": "markdown",
+          "content": "On the MySQL integration page in Grafana Cloud, scroll to the **Set up Grafana Alloy to use the MySQL integration** section."
+        },
+        {
+          "type": "markdown",
+          "content": "At the bottom of the snippet, click **Copy to clipboard**."
+        },
+        {
+          "type": "markdown",
+          "content": "Open the Grafana Alloy configuration file on your system. For example, on a Linux machine, run:\n\n```\nsudo nano /etc/alloy/config.alloy\n```"
+        },
+        {
+          "type": "markdown",
+          "content": "Paste the integration snippet into the configuration file."
+        },
+        {
+          "type": "markdown",
+          "content": "Update the `data_source_name` parameter with your MySQL connection details. For example: `alloy_monitor:secure_password@(localhost:3306)/`"
+        },
+        {
+          "type": "markdown",
+          "content": "Review the log path in the logs configuration and update it if necessary:\n\n- For Linux systems, the default path is `/var/log/mysql/*.log`\n- For Windows systems, the default path is `C:\\ProgramData\\MySQL\\MySQL Server*\\Data\\*.log`"
+        },
+        {
+          "type": "markdown",
+          "content": "Save the configuration file and exit the editor."
+        },
+        {
+          "type": "markdown",
+          "content": "Restart the Grafana Alloy service to apply the configuration. On Linux, run:\n\n```\nsudo systemctl restart alloy\n```"
+        },
+        {
+          "type": "markdown",
+          "content": "Check the service status to ensure it started successfully. On Linux, run:\n\n```\nsudo systemctl status alloy\n```"
+        }
+      ]
     },
     {
       "type": "markdown",
-      "content": "At the bottom of the snippet, click **Copy to clipboard**."
-    },
-    {
-      "type": "markdown",
-      "content": "Open the Grafana Alloy configuration file on your system. For example, on a Linux machine, run:\n\n```\nsudo nano /etc/alloy/config.alloy\n```"
-    },
-    {
-      "type": "markdown",
-      "content": "Paste the integration snippet into the configuration file."
-    },
-    {
-      "type": "markdown",
-      "content": "Update the `data_source_name` parameter with your MySQL connection details. For example: `alloy_monitor:secure_password@(localhost:3306)/`"
-    },
-    {
-      "type": "markdown",
-      "content": "Review the log path in the logs configuration and update it if necessary:\n\n- For Linux systems, the default path is `/var/log/mysql/*.log`\n- For Windows systems, the default path is `C:\\ProgramData\\MySQL\\MySQL Server*\\Data\\*.log`"
-    },
-    {
-      "type": "markdown",
-      "content": "Save the configuration file and exit the editor."
-    },
-    {
-      "type": "markdown",
-      "content": "Restart the Grafana Alloy service to apply the configuration. On Linux, run:\n\n```\nsudo systemctl restart alloy\n```"
-    },
-    {
-      "type": "markdown",
-      "content": "Check the service status to ensure it started successfully. On Linux, run:\n\n```\nsudo systemctl status alloy\n```\n\nThe Grafana Alloy service should restart successfully and begin collecting MySQL metrics and logs.\n\nIn the next milestone, you test the connection to verify that data is being collected and sent to Grafana Cloud."
+      "content": "The Grafana Alloy service should restart successfully and begin collecting MySQL metrics and logs.\n\nIn the next milestone, you test the connection to verify that data is being collected and sent to Grafana Cloud."
     }
   ]
 }

--- a/mysql-integration-lj/end-journey/content.json
+++ b/mysql-integration-lj/end-journey/content.json
@@ -1,0 +1,10 @@
+{
+  "id": "mysql-integration-end-journey",
+  "title": "Destination reached!",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "Congratulations on completing this journey. Job well done.\n\nYou have successfully set up comprehensive MySQL monitoring with Grafana Alloy and Grafana Cloud. This achievement delivers significant value for your database operations and application reliability.\n\nYou completed this journey as you:\n\n- Understood the value of MySQL database monitoring for performance and reliability\n- Navigated to the MySQL integration page and selected your platform environment\n- Installed Grafana Alloy to collect MySQL metrics and logs\n- Prepared MySQL database configuration with a dedicated monitoring user\n- Configured Grafana Alloy with MySQL integration snippets\n- Tested the connection to verify data collection and transmission\n- Installed pre-built dashboards and alert rules for immediate monitoring capabilities\n- Explored the MySQL dashboards to understand performance insights and troubleshooting capabilities"
+    }
+  ]
+}

--- a/mysql-integration-lj/install-alloy/content.json
+++ b/mysql-integration-lj/install-alloy/content.json
@@ -7,35 +7,44 @@
       "content": "In this milestone, you install Grafana Alloy on your selected platform. Grafana Alloy collects MySQL metrics and forwards them to Grafana Cloud for monitoring and visualization.\n\nBefore installing Grafana Alloy, you need to obtain your Grafana Cloud configuration details to establish secure communication between Alloy and your Grafana Cloud stack.\n\nTo install Grafana Alloy, complete the following steps:"
     },
     {
-      "type": "interactive",
-      "action": "highlight",
-      "reftarget": "button[data-testid='agent-config-button']",
-      "requirements": ["exists-reftarget"],
-      "content": "In the **Install Alloy** section, click **Run Grafana Alloy**."
+      "type": "section",
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "button[data-testid='agent-config-button']",
+          "requirements": ["exists-reftarget"],
+          "content": "In the **Install Alloy** section, click **Run Grafana Alloy**."
+        },
+        {
+          "type": "markdown",
+          "content": "Perform one of the following:\n\n| If you want to | Then |\n| --- | --- |\n| Create a new token | Click **Create new token**, enter a meaningful token name (e.g., `prodUS`), then click **Create token**. |\n| Use an existing token | Click **Use an existing token** and enter a token you have created in the past. |\n\n**Tip:** You don't need to copy the token. The token is added to the install Grafana Alloy script that you copy in the next step."
+        },
+        {
+          "type": "markdown",
+          "content": "Verify that the **Enable Remote Configuration** toggle is set to on."
+        },
+        {
+          "type": "markdown",
+          "content": "In the **Install and run Grafana Alloy** section, click **Copy to Clipboard**."
+        },
+        {
+          "type": "markdown",
+          "content": "Log into the machine where you are installing Grafana Alloy, open the Terminal, and paste the contents of the clipboard. Press **Enter** to install Grafana Alloy.\n\nWhen the installation is complete, you'll see `Alloy is now running!`"
+        },
+        {
+          "type": "markdown",
+          "content": "To verify that Grafana Alloy is installed correctly, click **Test Alloy connection**.\n\nIf Grafana Alloy is installed correctly, you'll see `Awesome! Grafana Alloy is good to go`."
+        },
+        {
+          "type": "markdown",
+          "content": "If Alloy is successfully installed, click **Proceed to install integration**."
+        }
+      ]
     },
     {
       "type": "markdown",
-      "content": "Perform one of the following:\n\n| If you want to | Then |\n| --- | --- |\n| Create a new token | Click **Create new token**, enter a meaningful token name (e.g., `prodUS`), then click **Create token**. |\n| Use an existing token | Click **Use an existing token** and enter a token you have created in the past. |\n\n**Tip:** You don't need to copy the token. The token is added to the install Grafana Alloy script that you copy in the next step."
-    },
-    {
-      "type": "markdown",
-      "content": "Verify that the **Enable Remote Configuration** toggle is set to on."
-    },
-    {
-      "type": "markdown",
-      "content": "In the **Install and run Grafana Alloy** section, click **Copy to Clipboard**."
-    },
-    {
-      "type": "markdown",
-      "content": "Log into the machine where you are installing Grafana Alloy, open the Terminal, and paste the contents of the clipboard. Press **Enter** to install Grafana Alloy.\n\nWhen the installation is complete, you'll see `Alloy is now running!`"
-    },
-    {
-      "type": "markdown",
-      "content": "To verify that Grafana Alloy is installed correctly, click **Test Alloy connection**.\n\nIf Grafana Alloy is installed correctly, you'll see `Awesome! Grafana Alloy is good to go`."
-    },
-    {
-      "type": "markdown",
-      "content": "If Alloy is successfully installed, click **Proceed to install integration**.\n\nIn your next milestone, you'll configure the MySQL integration settings."
+      "content": "In your next milestone, you'll configure the MySQL integration settings."
     }
   ]
 }

--- a/mysql-integration-lj/install-dashboards-alerts/content.json
+++ b/mysql-integration-lj/install-dashboards-alerts/content.json
@@ -7,31 +7,36 @@
       "content": "In this milestone, you install the pre-built MySQL dashboards and alert rules that come with the integration. These provide immediate visibility into your MySQL database performance and automated notifications for critical issues.\n\nThe MySQL integration includes 2 pre-built dashboards and 15 useful alert rules that cover essential monitoring scenarios such as database connectivity, replication status, performance bottlenecks, and resource utilization.\n\nTo install the MySQL dashboards and alerts, complete the following steps:"
     },
     {
-      "type": "markdown",
-      "content": "On the MySQL integration page in Grafana Cloud, scroll to the **Install dashboards and alerts** section."
-    },
-    {
-      "type": "interactive",
-      "action": "highlight",
-      "reftarget": "button[data-testid='install-button']",
-      "requirements": ["exists-reftarget"],
-      "content": "Click the **Install** button to add the pre-built dashboards and alerts to your Grafana Cloud instance."
-    },
-    {
-      "type": "markdown",
-      "content": "Wait for the installation to complete. You'll see a confirmation message when the dashboards and alerts are successfully installed."
-    },
-    {
-      "type": "interactive",
-      "action": "highlight",
-      "reftarget": "a[data-testid='view-dashboards-button']",
-      "requirements": ["exists-reftarget"],
-      "doIt": false,
-      "content": "Navigate to **Dashboards** in your Grafana Cloud instance to view the installed MySQL dashboards:\n\n- **MySQL**: Overview dashboard with key performance metrics\n- **MySQL logs**: Log analysis dashboard for troubleshooting"
-    },
-    {
-      "type": "markdown",
-      "content": "Navigate to **Alerts & IRM > Alerting > Alert rules** to view the installed MySQL alert rules."
+      "type": "section",
+      "blocks": [
+        {
+          "type": "markdown",
+          "content": "On the MySQL integration page in Grafana Cloud, scroll to the **Install dashboards and alerts** section."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "button[data-testid='install-button']",
+          "requirements": ["exists-reftarget"],
+          "content": "Click the **Install** button to add the pre-built dashboards and alerts to your Grafana Cloud instance."
+        },
+        {
+          "type": "markdown",
+          "content": "Wait for the installation to complete. You'll see a confirmation message when the dashboards and alerts are successfully installed."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "a[data-testid='view-dashboards-button']",
+          "requirements": ["exists-reftarget"],
+          "doIt": false,
+          "content": "Navigate to **Dashboards** in your Grafana Cloud instance to view the installed MySQL dashboards:\n\n- **MySQL**: Overview dashboard with key performance metrics\n- **MySQL logs**: Log analysis dashboard for troubleshooting"
+        },
+        {
+          "type": "markdown",
+          "content": "Navigate to **Alerts & IRM > Alerting > Alert rules** to view the installed MySQL alert rules."
+        }
+      ]
     },
     {
       "type": "markdown",

--- a/mysql-integration-lj/prepare-configuration/content.json
+++ b/mysql-integration-lj/prepare-configuration/content.json
@@ -1,0 +1,47 @@
+{
+  "id": "mysql-integration-prepare-configuration",
+  "title": "Prepare MySQL database configuration",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "In this milestone, you prepare the MySQL database configuration required for monitoring. This includes creating a dedicated monitoring user account with the necessary permissions and gathering the connection details needed for Grafana Alloy.\n\nCreating a dedicated monitoring user with minimal required privileges follows security best practices and ensures that the monitoring system has only the access it needs to collect metrics and logs.\n\nTo prepare your MySQL database configuration, complete the following steps:"
+    },
+    {
+      "type": "section",
+      "blocks": [
+        {
+          "type": "markdown",
+          "content": "Connect to your MySQL server as an administrative user:\n\n```\nmysql -u root -p\n```"
+        },
+        {
+          "type": "markdown",
+          "content": "Create a dedicated monitoring user for Grafana Alloy:\n\n```sql\nCREATE USER 'alloy_monitor'@'localhost' IDENTIFIED BY 'secure_password';\n```"
+        },
+        {
+          "type": "markdown",
+          "content": "Grant the necessary privileges for monitoring:\n\n```sql\nGRANT PROCESS, REPLICATION CLIENT, SELECT ON *.* TO 'alloy_monitor'@'localhost';\nGRANT SELECT ON performance_schema.* TO 'alloy_monitor'@'localhost';\n```"
+        },
+        {
+          "type": "markdown",
+          "content": "Apply the privilege changes:\n\n```sql\nFLUSH PRIVILEGES;\n```"
+        },
+        {
+          "type": "markdown",
+          "content": "Exit the MySQL client:\n\n```sql\nEXIT;\n```"
+        },
+        {
+          "type": "markdown",
+          "content": "Test the monitoring user connection:\n\n```\nmysql -u alloy_monitor -p -e \"SHOW STATUS LIKE 'Uptime';\"\n```"
+        },
+        {
+          "type": "markdown",
+          "content": "Note your MySQL connection details for the next milestone:\n\n- Hostname: `localhost` (or your MySQL server hostname)\n- Port: `3306` (or your custom MySQL port)\n- Username: `alloy_monitor`\n- Password: The password you set for the monitoring user\n- Database: Leave empty for monitoring all databases"
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "In the next milestone, you configure Grafana Alloy with the MySQL monitoring settings."
+    }
+  ]
+}

--- a/mysql-integration-lj/select-platform/content.json
+++ b/mysql-integration-lj/select-platform/content.json
@@ -7,58 +7,55 @@
       "content": "In this milestone, you navigate to the MySQL integration page in Grafana Cloud and select your platform environment. This generates customized configuration snippets for your specific operating system and deployment scenario.\n\nThe integration page provides configuration options for different platforms including Debian, Windows, and generic configurations for other Linux distributions.\n\nTo navigate to the MySQL integration and select your platform, complete the following steps:"
     },
     {
-      "type": "multistep",
-      "content": "Click **Connections > Add new connection** in the left-side menu.",
-      "steps": [
+      "type": "section",
+      "blocks": [
         {
+          "type": "interactive",
           "action": "highlight",
-          "reftarget": "a[data-testid='data-testid Nav menu item'][href='/connections']"
+          "reftarget": "a[data-testid='data-testid Nav menu item'][href='/connections/add-new-connection']",
+          "content": "Click **Connections > Add new connection** in the left-side menu.",
+          "requirements": ["navmenu-open"]
         },
         {
+          "type": "interactive",
+          "action": "formfill",
+          "reftarget": "input[data-testid='search-input-input']",
+          "content": "Filter the connections by typing `MySQL` in the search.",
+          "targetvalue": "MySQL",
+          "requirements": ["exists-reftarget"]
+        },
+        {
+          "type": "interactive",
           "action": "highlight",
-          "reftarget": "a[data-testid='data-testid Nav menu item'][href='/connections/add-new-connection']"
+          "reftarget": "a[href='/connections/add-new-connection/mysql']",
+          "content": "Click the **MySQL** tile to open the setup page.",
+          "requirements": ["exists-reftarget"]
+        },
+        {
+          "type": "markdown",
+          "content": "Grafana Alloy supports the following platforms:\n- **Linux** (x86_64, ARM64)\n- **macOS** (x86_64, ARM64)\n- **Windows** (x86_64)\n- **Kubernetes deployments**"
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "div[data-testid='collector-os-selection'] input",
+          "content": "Select the **operating system** that matches your platform.",
+          "requirements": ["exists-reftarget"],
+          "doIt": false
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "div[data-testid='collector-arch-selection'] input",
+          "content": "Select the **architecture** that matches your system (Amd64 for x86_64, Arm64 for aarch64).\n\nIf you are unsure of the architecture, run `uname -m` in your terminal. If it returns `x86_64`, select **Amd64**. If it returns `aarch64`, select **Arm64**.",
+          "requirements": ["exists-reftarget"],
+          "doIt": false
         }
-      ],
-      "requirements": ["navmenu-open"]
-    },
-    {
-      "type": "interactive",
-      "action": "formfill",
-      "reftarget": "input[data-testid='search-input-input']",
-      "content": "Filter the connections by typing `MySQL` in the search.",
-      "targetvalue": "MySQL",
-      "requirements": ["exists-reftarget"]
-    },
-    {
-      "type": "interactive",
-      "action": "highlight",
-      "reftarget": "a[href='/connections/add-new-connection/mysql']",
-      "content": "Click the **MySQL** tile to open the setup page.",
-      "requirements": ["exists-reftarget"]
+      ]
     },
     {
       "type": "markdown",
-      "content": "Grafana Alloy supports the following platforms:\n- **Linux** (x86_64, ARM64)\n- **macOS** (x86_64, ARM64)\n- **Windows** (x86_64)\n- **Kubernetes deployments**"
-    },
-    {
-      "type": "interactive",
-      "action": "highlight",
-      "reftarget": "div[data-testid='collector-os-selection'] input",
-      "content": "Select the **operating system** that matches your platform.",
-      "requirements": ["exists-reftarget"],
-      "doIt": false
-    },
-    {
-      "type": "interactive",
-      "action": "highlight",
-      "reftarget": "div[data-testid='collector-arch-selection'] input",
-      "content": "Select the **architecture** that matches your system (Amd64 for x86_64, Arm64 for aarch64).",
-      "requirements": ["exists-reftarget"],
-      "doIt": false
-    },
-    {
-      "type": "markdown",
-      "content": "If you are unsure of the architecture, run `uname -m` in your terminal. If it returns `x86_64`, select **Amd64**. If it returns `aarch64`, select **Arm64**.\n\nIn your next milestone, you'll install Grafana Alloy on your selected platform."
+      "content": "In your next milestone, you'll install Grafana Alloy on your selected platform."
     }
   ]
 }

--- a/mysql-integration-lj/test-connection/content.json
+++ b/mysql-integration-lj/test-connection/content.json
@@ -7,19 +7,24 @@
       "content": "In this milestone, you verify that Grafana Alloy is successfully collecting MySQL metrics and logs and sending them to your Grafana Cloud instance. Testing the connection ensures that your monitoring setup is working correctly before installing dashboards and alerts.\n\nThe MySQL integration provides a built-in connection test feature that validates both the configuration and data flow to Grafana Cloud.\n\nTo test the MySQL monitoring connection, complete the following steps:"
     },
     {
-      "type": "markdown",
-      "content": "On the MySQL integration page in Grafana Cloud, scroll to the **Test connection** section."
-    },
-    {
-      "type": "interactive",
-      "action": "highlight",
-      "reftarget": "button[data-testid='test-connection-button']",
-      "requirements": ["exists-reftarget"],
-      "content": "Click the **Test connection** button to validate that data is flowing from your MySQL instance to Grafana Cloud."
-    },
-    {
-      "type": "markdown",
-      "content": "Wait for the connection test to complete. A successful test indicates that:\n\n- Grafana Alloy is running and configured correctly\n- MySQL metrics are being collected\n- Data is reaching your Grafana Cloud instance"
+      "type": "section",
+      "blocks": [
+        {
+          "type": "markdown",
+          "content": "On the MySQL integration page in Grafana Cloud, scroll to the **Test connection** section."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "button[data-testid='test-connection-button']",
+          "requirements": ["exists-reftarget"],
+          "content": "Click the **Test connection** button to validate that data is flowing from your MySQL instance to Grafana Cloud."
+        },
+        {
+          "type": "markdown",
+          "content": "Wait for the connection test to complete. A successful test indicates that:\n\n- Grafana Alloy is running and configured correctly\n- MySQL metrics are being collected\n- Data is reaching your Grafana Cloud instance"
+        }
+      ]
     },
     {
       "type": "markdown",

--- a/prom-remote-write-lj/verify-metrics-query-works/content.json
+++ b/prom-remote-write-lj/verify-metrics-query-works/content.json
@@ -1,0 +1,37 @@
+{
+  "id": "prom-remote-write-verify-metrics",
+  "title": "Verify metrics query successful",
+  "blocks": [
+    {
+      "type": "video",
+      "src": "https://www.youtube.com/embed/BDJO-vC-gEw",
+      "provider": "youtube",
+      "title": "Verify metrics query successful",
+      "start": 349
+    },
+    {
+      "type": "markdown",
+      "content": "As the final step in your journey, complete the following steps to confirm that you've successfully sent Prometheus metrics to Grafana Cloud:"
+    },
+    {
+      "type": "section",
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "a[href=\"/a/grafana-metricsdrilldown-app/drilldown\"]",
+          "requirements": ["navmenu-open", "exists-reftarget"],
+          "content": "In the Grafana side menu, click **Drilldown > Metrics**."
+        },
+        {
+          "type": "markdown",
+          "content": "If you see a **Let's start!** button, click it."
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "You should see Prometheus metrics displayed in the Grafana Drilldown Metrics app.\n\n **Congratulations!** You've successfully connected to your Prometheus data source."
+    }
+  ]
+}

--- a/prometheus-lj/add-data-source-url/content.json
+++ b/prometheus-lj/add-data-source-url/content.json
@@ -3,6 +3,14 @@
   "title": "Enter the Prometheus data source URL",
   "blocks": [
     {
+      "type": "video",
+      "src": "https://www.youtube.com/embed/_ojYThjkpN0",
+      "provider": "youtube",
+      "title": "Enter the Prometheus data source URL",
+      "start": 268,
+      "end": 330
+    },
+    {
       "type": "markdown",
       "content": "In this milestone, you enter the Prometheus server URL. This URL is the address of the machine where Prometheus collects data."
     },

--- a/prometheus-lj/add-data-source/content.json
+++ b/prometheus-lj/add-data-source/content.json
@@ -3,45 +3,50 @@
   "title": "Add the Prometheus data source",
   "blocks": [
     {
-      "type": "markdown",
-      "content": "In this milestone, you add the Prometheus data source and give it a name.\n\nGrafana provides built-in support for a Prometheus data source."
+      "type": "video",
+      "src": "https://www.youtube.com/embed/_ojYThjkpN0",
+      "provider": "youtube",
+      "title": "Add the Prometheus data source",
+      "start": 230,
+      "end": 268
     },
     {
-      "type": "multistep",
-      "content": "In the Grafana side menu, expand **Connections** and click **Data sources**.",
-      "requirements": ["navmenu-open", "exists-reftarget"],
-      "steps": [
+      "type": "markdown",
+      "content": "In this milestone, you add the Prometheus data source and give it a name.\n\nGrafana provides built-in support for a Prometheus data source.\n\nTo add the Prometheus data source, complete the following steps:"
+    },
+    {
+      "type": "section",
+      "blocks": [
         {
+          "type": "interactive",
           "action": "highlight",
-          "reftarget": "a[data-testid='data-testid Nav menu item'][href='/connections']"
+          "reftarget": "a[href='/connections/datasources']",
+          "requirements": ["navmenu-open", "exists-reftarget"],
+          "content": "In the Grafana side menu, click **Connections > Data sources**."
         },
         {
+          "type": "interactive",
           "action": "highlight",
-          "reftarget": "a[href='/connections/datasources']"
+          "reftarget": "[data-testid=\"data-testid data-source-add-button\"]",
+          "requirements": ["on-page:/connections/datasources", "exists-reftarget"],
+          "content": "Click **Add new data source**."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[aria-label=\"Add new data source Prometheus\"]",
+          "requirements": ["on-page:/connections/datasources/new", "exists-reftarget"],
+          "content": "Select **Prometheus** from the list of data sources."
+        },
+        {
+          "type": "interactive",
+          "action": "formfill",
+          "reftarget": "[data-testid=\"data-testid Data source settings page name input field\"]",
+          "doIt": false,
+          "requirements": ["exists-reftarget"],
+          "content": "In the **Name** field, enter a descriptive name for your data source.\n\nFor example: `My Prometheus Server`"
         }
       ]
-    },
-    {
-      "type": "interactive",
-      "action": "highlight",
-      "reftarget": "[data-testid=\"data-testid data-source-add-button\"]",
-      "requirements": ["on-page:/connections/datasources", "exists-reftarget"],
-      "content": "Click **Add new data source**."
-    },
-    {
-      "type": "interactive",
-      "action": "highlight",
-      "reftarget": "[aria-label=\"Add new data source Prometheus\"]",
-      "requirements": ["on-page:/connections/datasources/new", "exists-reftarget"],
-      "content": "Select **Prometheus** from the list of data sources."
-    },
-    {
-      "type": "interactive",
-      "action": "formfill",
-      "reftarget": "[data-testid=\"data-testid Data source settings page name input field\"]",
-      "doIt": false,
-      "requirements": ["exists-reftarget"],
-      "content": "In the **Name** field, enter a descriptive name for your data source.\n\nFor example: `My Prometheus Server`"
     },
     {
       "type": "markdown",

--- a/prometheus-lj/business-value-olly/content.json
+++ b/prometheus-lj/business-value-olly/content.json
@@ -1,0 +1,28 @@
+{
+  "id": "prometheus-business-value-olly",
+  "title": "The case for observability",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "IT systems are complicated. There are nodes, pods, services, system resources - sometimes thousands of them - all connected in a complex web of relationships. And when things go wrong, it can be very difficult to determine the root cause and fix it quickly. Consider the following:\n\n- Slow performance in an application might be caused by heavy load, or it could be a memory leak or even a hardware error. Monitoring your infrastructure allows you to find the root cause quickly and accurately.\n- Running out of disk space can be a disaster for any environment. Understanding that there's a problem _before_ it becomes a problem enables you to prevent it.\n- When applications or services are co-located, being able to identify hotspots and conflicts between them can help you redistribute the load properly.\n\nAnd time is of the essence. System downtime can be very expensive. If you run customer-facing applications such as e-commerce site or a financial institution, every minute of downtime costs you money. Some estimates put the average cost of downtime at $5,600 per minute. If you are a large retailer, this cost can be much more. Even if you're not running a commercial service, downtime can have impact. If you can't turn on your lights because your home automation is having problems, it's still a real issue."
+    },
+    {
+      "type": "markdown",
+      "content": "## Enter...observability"
+    },
+    {
+      "type": "video",
+      "src": "https://www.youtube.com/embed/TQur9GJHIIQ",
+      "provider": "youtube",
+      "title": "What is observability?"
+    },
+    {
+      "type": "markdown",
+      "content": "Observability is the process of making a system's internal state more transparent. Systems are made observable by the data they produce, which in turn helps you to determine if your infrastructure or application is healthy and functioning normally."
+    },
+    {
+      "type": "markdown",
+      "content": "Observability is a holistic approach to understanding and managing complex systems. It involves collecting data from all parts of the system to create a deep understanding of the system's internal workings and how these interact with each other. Observability focuses on understanding and interpreting data to make the system's behavior and performance as transparent as possible. It also requires a means of making the data easily available for humans to interpret.\n\nAn observability system enables system operators, DevOps practitioners, and site reliability engineers to ask questions across the information gathered. These are questions that are not anticipated in advance, but rather questions that arise due to unexpected or novel events within a system."
+    }
+  ]
+}

--- a/prometheus-lj/business-value-prom/content.json
+++ b/prometheus-lj/business-value-prom/content.json
@@ -1,0 +1,18 @@
+{
+  "id": "prometheus-business-value-prom",
+  "title": "When to connect to a self-managed data source",
+  "blocks": [
+    {
+      "type": "video",
+      "src": "https://www.youtube.com/embed/_ojYThjkpN0",
+      "provider": "youtube",
+      "title": "When to connect to a self-managed data source",
+      "start": 70,
+      "end": 155
+    },
+    {
+      "type": "markdown",
+      "content": "Grafana Cloud data source connections allow you to visualize metric data directly from where it is stored, meaning the data itself is not sent to nor stored in Grafana Cloud.\n\nConsider connecting to a self-managed metrics data source when:\n\n- The cost of sending metric data to Grafana Cloud is too high\n- Compliance requirements prevent storing data off-premise\n- You need custom configurations, like support for alpha Prometheus features\n- Your retention needs exceed the 13-month limit\n- Your team wants to handle the management of the metrics environment internally\n- The metrics are already stored and managed in another platform, like Amazon Managed Prometheus or Google Cloud Platform Managed Prometheus\n- You prefer to continue with your existing non-Prometheus metric data sources, as you don't want to transition to Prometheus or Mimir and learn PromQL"
+    }
+  ]
+}

--- a/prometheus-lj/config-authentication/content.json
+++ b/prometheus-lj/config-authentication/content.json
@@ -3,6 +3,14 @@
   "title": "Enter Prometheus data source authentication credentials",
   "blocks": [
     {
+      "type": "video",
+      "src": "https://www.youtube.com/embed/_ojYThjkpN0",
+      "provider": "youtube",
+      "title": "Enter Prometheus data source authentication credentials",
+      "start": 330,
+      "end": 343
+    },
+    {
       "type": "markdown",
       "content": "Every time Grafana Cloud queries your Prometheus data source, the security settings you have configured for that data source dictate whether the query can successfully execute and retrieve data.\n\nYour Prometheus instance's security configuration may be basic, use OAuth, or have no security at all."
     },
@@ -15,24 +23,25 @@
       "content": "If you've configured Prometheus to require authentication, complete the following steps:"
     },
     {
-      "type": "interactive",
-      "action": "highlight",
-      "reftarget": "#auth-method-select",
-      "doIt": false,
-      "requirements": ["exists-reftarget"],
-      "content": "In the **Authentication method** dropdown, select a method of authentication.\n\nFor example: **Basic authentication**."
+      "type": "section",
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "#auth-method-select",
+          "doIt": false,
+          "requirements": ["exists-reftarget"],
+          "content": "In the **Authentication method** dropdown, select a method of authentication.\n\nFor example: **Basic authentication**."
+        },
+        {
+          "type": "markdown",
+          "content": "For basic authentication, enter the username and password."
+        }
+      ]
     },
     {
       "type": "markdown",
-      "content": "After selecting **Basic authentication**, additional fields appear for entering your credentials:"
-    },
-    {
-      "type": "markdown",
-      "content": "Enter your **Username** in the field provided."
-    },
-    {
-      "type": "markdown",
-      "content": "Enter your **Password** in the field provided."
+      "content": "In the next step of your journey, you'll select a PDC agent."
     }
   ]
 }

--- a/prometheus-lj/end-journey/content.json
+++ b/prometheus-lj/end-journey/content.json
@@ -1,0 +1,10 @@
+{
+  "id": "prometheus-end-journey",
+  "title": "Destination reached!",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "Congratulations on completing this journey! Job well done!\n\nWe hope you've enjoyed traveling with us as you:\n\n- Learned about the value of observability and connecting to a Prometheus data source\n- Verified that your Prometheus server is capturing metrics\n- Entered the URL and credentials of a Prometheus server\n- Selected a private data source connection and tested the connection\n- Verified that metrics appear in Grafana Drilldown Metrics"
+    }
+  ]
+}

--- a/prometheus-lj/select-private-connection/content.json
+++ b/prometheus-lj/select-private-connection/content.json
@@ -3,6 +3,14 @@
   "title": "Select PDC and test connection",
   "blocks": [
     {
+      "type": "video",
+      "src": "https://www.youtube.com/embed/_ojYThjkpN0",
+      "provider": "youtube",
+      "title": "Select PDC and test connection",
+      "start": 343,
+      "end": 364
+    },
+    {
       "type": "markdown",
       "content": "The private data source connect (PDC) feature allows you to establish a secure connection between Grafana Cloud and your Prometheus data source.\n\nIf you don't use PDC, your queries and data are transmitted over the public internet, exposing them to potential security risks."
     },
@@ -12,23 +20,32 @@
     },
     {
       "type": "markdown",
-      "content": "In this milestone, you select an active PDC agent and test the connection to Grafana Cloud."
+      "content": "In this milestone, you select an active PDC agent and test the connection to Grafana Cloud.\n\nTo select a PDC agent and test the connection, complete the following steps:"
     },
     {
-      "type": "interactive",
-      "action": "highlight",
-      "reftarget": "[aria-label=\"Private data source connect\"]",
-      "doIt": false,
-      "requirements": ["exists-reftarget"],
-      "content": "In the **Private data source connect** field, select the name of a PDC agent.\n\n💡 For the test connection to be successful, you must select a PDC agent that's running."
+      "type": "section",
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[aria-label=\"Private data source connect\"]",
+          "doIt": false,
+          "requirements": ["exists-reftarget"],
+          "content": "In the **Private data source connect** field, select the name of a PDC agent.\n\n💡 For the test connection to be successful, you must select a PDC agent that's running."
+        },
+        {
+          "type": "interactive",
+          "action": "button",
+          "reftarget": "Save & test",
+          "doIt": false,
+          "requirements": ["exists-reftarget"],
+          "content": "Click **Save & test**.\n\nWhen successful, you'll see the message: `Successfully queried the Prometheus API.`"
+        }
+      ]
     },
     {
-      "type": "interactive",
-      "action": "button",
-      "reftarget": "Save & test",
-      "doIt": false,
-      "requirements": ["exists-reftarget"],
-      "content": "Click **Save & test**.\n\nWhen successful, you'll see the message: `Successfully queried the Prometheus API.`"
+      "type": "markdown",
+      "content": "Next, you can start to visualize data by building a dashboard, or by querying data in the Explore view."
     }
   ]
 }

--- a/prometheus-lj/verify-ds-connection/content.json
+++ b/prometheus-lj/verify-ds-connection/content.json
@@ -3,26 +3,31 @@
   "title": "Verify Prometheus data source query successful",
   "blocks": [
     {
-      "type": "markdown",
-      "content": "As the final step in your journey, confirm that you've successfully connected to the Prometheus data source by viewing metrics in Grafana Drilldown Metrics."
-    },
-    {
-      "type": "interactive",
-      "action": "highlight",
-      "reftarget": "a[data-testid='data-testid Nav menu item'][href='/drilldown']",
-      "requirements": ["navmenu-open", "exists-reftarget"],
-      "content": "In the Grafana side menu, expand the **Drilldown** section by clicking the caret."
-    },
-    {
-      "type": "interactive",
-      "action": "highlight",
-      "reftarget": "a[href=\"/a/grafana-metricsdrilldown-app/drilldown\"]",
-      "requirements": ["exists-reftarget"],
-      "content": "Click **Metrics**."
+      "type": "video",
+      "src": "https://www.youtube.com/embed/_ojYThjkpN0",
+      "provider": "youtube",
+      "title": "Verify Prometheus data source query successful",
+      "start": 364
     },
     {
       "type": "markdown",
-      "content": "If you see a **Let's start!** button, click it."
+      "content": "As the final step in your journey, complete the following steps to confirm that you've successfully connected to the Prometheus data source:"
+    },
+    {
+      "type": "section",
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "a[href=\"/a/grafana-metricsdrilldown-app/drilldown\"]",
+          "requirements": ["navmenu-open", "exists-reftarget"],
+          "content": "In the Grafana side menu, click **Drilldown > Metrics**."
+        },
+        {
+          "type": "markdown",
+          "content": "If you see a **Let's start!** button, click it."
+        }
+      ]
     },
     {
       "type": "markdown",

--- a/prometheus-lj/verify-prom-data/content.json
+++ b/prometheus-lj/verify-prom-data/content.json
@@ -1,0 +1,43 @@
+{
+  "id": "prometheus-verify-prom-data",
+  "title": "Verify Prometheus metrics are written to an endpoint",
+  "blocks": [
+    {
+      "type": "video",
+      "src": "https://www.youtube.com/embed/_ojYThjkpN0",
+      "provider": "youtube",
+      "title": "Verify Prometheus metrics",
+      "start": 156,
+      "end": 230
+    },
+    {
+      "type": "markdown",
+      "content": "While installing and configuring Prometheus in your local environment is out of scope for this journey, a good first step in this journey is to verify that your system is writing metrics to the Prometheus endpoint.\n\nTo verify Prometheus metrics are written to an endpoint, complete the following steps:"
+    },
+    {
+      "type": "section",
+      "blocks": [
+        {
+          "type": "markdown",
+          "content": "Log into the machine on which Prometheus is installed."
+        },
+        {
+          "type": "markdown",
+          "content": "If required, switch to a user that has administrative privileges."
+        },
+        {
+          "type": "markdown",
+          "content": "To check the Prometheus service status, run one of the following commands:\n\nFor Linux:\n\n```\nsystemctl status prometheus.service\n```\n\nFor Windows:\n\n```\nsc query prometheus\n```\n\nYou should see something similar to the following:\n\n![Picture that shows the Prometheus service up and running](/media/docs/learning-journey/prom-data-source/verify-prom-data-1.png)"
+        },
+        {
+          "type": "markdown",
+          "content": "To ensure that Prometheus is capturing the metrics, open a browser tab and navigate to the metrics endpoint URL.\n\nFor example, navigate to `http://localhost:9090/metrics`\n\nYou should see something similar to the following:\n\n![Picture that shows metrics in a browser tab](/media/docs/learning-journey/prom-data-source/verify-prom-data-2.png)"
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "**Tip:** Consult the Prometheus documentation if you are unable to run the Prometheus service or can't verify that Prometheus is capturing metrics."
+    }
+  ]
+}

--- a/shared/snippets/case-for-o11y/content.json
+++ b/shared/snippets/case-for-o11y/content.json
@@ -1,0 +1,28 @@
+{
+  "id": "case-for-o11y",
+  "title": "The case for observability",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "IT systems are complicated. There are nodes, pods, services, system resources - sometimes thousands of them - all connected in a complex web of relationships. And when things go wrong, it can be very difficult to determine the root cause and fix it quickly. Consider the following:\n\n- Slow performance in an application might be caused by heavy load, or it could be a memory leak or even a hardware error. Monitoring your infrastructure allows you to find the root cause quickly and accurately.\n- Running out of disk space can be a disaster for any environment. Understanding that there's a problem before it becomes a problem enables you to prevent it.\n- When applications or services are co-located, being able to identify hotspots and conflicts between them can help you redistribute the load properly.\n\nAnd time is of the essence. System downtime can be very expensive. If you run customer-facing applications such as e-commerce site or a financial institution, every minute of downtime costs you money. Some estimates put the average cost of downtime at $5,600 per minute. If you are a large retailer, this cost can be much more. Even if you're not running a commercial service, downtime can have impact. If you can't turn on your lights because your home automation is having problems, it's still a real issue."
+    },
+    {
+      "type": "markdown",
+      "content": "## Enter...observability"
+    },
+    {
+      "type": "video",
+      "src": "https://www.youtube.com/embed/TQur9GJHIIQ",
+      "provider": "youtube",
+      "title": "What is observability?"
+    },
+    {
+      "type": "markdown",
+      "content": "Observability is the process of making a system's internal state more transparent. Systems are made observable by the data they produce, which in turn helps you to determine if your infrastructure or application is healthy and functioning normally."
+    },
+    {
+      "type": "markdown",
+      "content": "Observability is a holistic approach to understanding and managing complex systems. It involves collecting data from all parts of the system to create a deep understanding of the system's internal workings and how these interact with each other. Observability focuses on understanding and interpreting data to make the system's behavior and performance as transparent as possible. It also requires a means of making the data easily available for humans to interpret.\n\nAn observability system enables system operators, DevOps practitioners, and site reliability engineers to ask questions across the information gathered. These are questions that are not anticipated in advance, but rather questions that arise due to unexpected or novel events within a system."
+    }
+  ]
+}

--- a/visualization-logs/add-visualization/content.json
+++ b/visualization-logs/add-visualization/content.json
@@ -7,63 +7,67 @@
       "content": "A Grafana dashboard is a set of one or more panels, organized and arranged into one or more rows, that provide an at-a-glance view of related information. These panels are created using components that query and transform raw data from a data source into visualizations.\n\nA data source can be an SQL database, Grafana Loki, Grafana Mimir, or an API endpoint. It can even be a basic CSV file. Data source plugins take a query you want answered, retrieve the data from the data source, and reconcile the differences between the data model of the data source and the data model of Grafana dashboards."
     },
     {
-      "type": "markdown",
-      "content": "To create a dashboard and add a visualization, complete the following steps:"
-    },
-    {
-      "type": "markdown",
-      "content": "**Sign in to Grafana Cloud**\n\nSign in to your Grafana Cloud environment (for example, `mystack.grafana.net`)."
-    },
-    {
-      "type": "interactive",
-      "action": "highlight",
-      "reftarget": "a[data-testid='data-testid Nav menu item'][href='/dashboards']",
-      "content": "Click **Dashboards** in the main menu.",
-      "requirements": ["exists-reftarget", "navmenu-open"]
-    },
-    {
-      "type": "multistep",
-      "content": "Click **New** and select **New Dashboard**.",
-      "requirements": ["on-page:/dashboards"],
-      "steps": [
-        { "action": "button", "reftarget": "New" },
-        { "action": "highlight", "reftarget": "a[href='/dashboard/new']" }
-      ]
-    },
-    {
-      "type": "markdown",
-      "content": "In the edit pane on the right, under **Add**, click **Panel** or drag it onto the dashboard canvas.\n\nA new panel is added to your dashboard."
-    },
-    {
-      "type": "markdown",
-      "content": "On the new panel, enter a panel title and description, and click **Configure** to open the Edit panel view."
-    },
-    {
-      "type": "interactive",
-      "action": "highlight",
-      "reftarget": "[data-testid='data-testid Select a data source']",
-      "content": "In the **Queries** tab, click the **Data source** drop-down list and select a logs data source (such as Loki).",
-      "doIt": false,
-      "requirements": ["exists-reftarget"]
-    },
-    {
-      "type": "multistep",
-      "content": "From the visualization picker on the right, click **All visualizations** and select **Logs**.",
-      "requirements": ["exists-reftarget"],
-      "steps": [
+      "type": "section",
+      "id": "create-dashboard-logs",
+      "title": "Create a dashboard and add a visualization",
+      "requirements": ["navmenu-open"],
+      "blocks": [
         {
-          "action": "highlight",
-          "reftarget": "[data-testid='data-testid Tab All visualizations']"
+          "type": "markdown",
+          "content": "**Sign in to Grafana Cloud**\n\nSign in to your Grafana Cloud environment (for example, `mystack.grafana.net`)."
         },
         {
+          "type": "interactive",
           "action": "highlight",
-          "reftarget": "[data-testid='data-testid Plugin visualization item Logs']"
+          "reftarget": "a[data-testid='data-testid Nav menu item'][href='/dashboards']",
+          "content": "Click **Dashboards** in the main menu.",
+          "requirements": ["exists-reftarget", "navmenu-open"]
+        },
+        {
+          "type": "multistep",
+          "content": "Click **New** and select **New Dashboard**.",
+          "requirements": ["on-page:/dashboards"],
+          "steps": [
+            { "action": "button", "reftarget": "New" },
+            { "action": "highlight", "reftarget": "a[href='/dashboard/new']" }
+          ]
+        },
+        {
+          "type": "markdown",
+          "content": "In the edit pane on the right, under **Add**, click **Panel** or drag it onto the dashboard canvas.\n\nA new panel is added to your dashboard."
+        },
+        {
+          "type": "markdown",
+          "content": "On the new panel, enter a panel title and description, and click **Configure** to open the Edit panel view."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='data-testid Select a data source']",
+          "content": "In the **Queries** tab, click the **Data source** drop-down list and select a logs data source (such as Loki).",
+          "doIt": false,
+          "requirements": ["exists-reftarget"]
+        },
+        {
+          "type": "multistep",
+          "content": "From the visualization picker on the right, click **All visualizations** and select **Logs**.",
+          "requirements": ["exists-reftarget"],
+          "steps": [
+            {
+              "action": "highlight",
+              "reftarget": "[data-testid='data-testid Tab All visualizations']"
+            },
+            {
+              "action": "highlight",
+              "reftarget": "[data-testid='data-testid Plugin visualization item Logs']"
+            }
+          ]
+        },
+        {
+          "type": "markdown",
+          "content": "**Did you know?** The Logs visualization is designed specifically for displaying log data. It shows log lines with timestamps, labels, and the ability to expand individual entries for more detail."
         }
       ]
-    },
-    {
-      "type": "markdown",
-      "content": "**Did you know?** The Logs visualization is designed specifically for displaying log data. It shows log lines with timestamps, labels, and the ability to expand individual entries for more detail."
     },
     {
       "type": "markdown",

--- a/visualization-logs/save-dashboard/content.json
+++ b/visualization-logs/save-dashboard/content.json
@@ -7,33 +7,40 @@
       "content": "Each dashboard can contain multiple panels, each with a meaningful title that helps other users understand its purpose. After you save a dashboard, you can share it with others. Users with the appropriate permissions can edit the saved dashboard as needed."
     },
     {
-      "type": "interactive",
-      "action": "highlight",
-      "reftarget": "[data-testid=\"data-testid Save dashboard button\"]",
-      "content": "When you've finished editing the panel, click **Save**.",
-      "requirements": ["exists-reftarget"]
-    },
-    {
-      "type": "markdown",
-      "content": "In the save dialog:\n1. Enter a **title** and **description** for your dashboard\n2. Select a **folder** if applicable\n3. Click **Save**"
-    },
-    {
-      "type": "interactive",
-      "action": "highlight",
-      "reftarget": "[data-testid=\"data-testid Back to dashboard button\"]",
-      "content": "Click **Back to dashboard** to return to the dashboard view.",
-      "requirements": ["exists-reftarget"]
-    },
-    {
-      "type": "interactive",
-      "action": "highlight",
-      "reftarget": "[data-testid=\"data-testid Edit dashboard button\"]",
-      "content": "Click **Exit edit** to leave edit mode and view your completed dashboard.",
-      "requirements": ["exists-reftarget"]
-    },
-    {
-      "type": "markdown",
-      "content": "🎉 Congratulations! You've successfully created a dashboard with a logs visualization. Your dashboard is now saved and ready to share with your team."
+      "type": "section",
+      "id": "save-dashboard",
+      "title": "Save the dashboard",
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid=\"data-testid Save dashboard button\"]",
+          "content": "When you've finished editing the panel, click **Save**.",
+          "requirements": ["exists-reftarget"]
+        },
+        {
+          "type": "markdown",
+          "content": "In the save dialog:\n1. Enter a **title** and **description** for your dashboard\n2. Select a **folder** if applicable\n3. Click **Save**"
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid=\"data-testid Back to dashboard button\"]",
+          "content": "Click **Back to dashboard** to return to the dashboard view.",
+          "requirements": ["exists-reftarget"]
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid=\"data-testid Edit dashboard button\"]",
+          "content": "Click **Exit edit** to leave edit mode and view your completed dashboard.",
+          "requirements": ["exists-reftarget"]
+        },
+        {
+          "type": "markdown",
+          "content": "🎉 Congratulations! You've successfully created a dashboard with a logs visualization. Your dashboard is now saved and ready to share with your team."
+        }
+      ]
     }
   ]
 }

--- a/visualization-logs/time-range-refresh/content.json
+++ b/visualization-logs/time-range-refresh/content.json
@@ -11,28 +11,31 @@
       "content": "**Tip:** Choose the slowest refresh interval that meets your requirements. If near real-time updates are unnecessary, opt for a 1-minute or longer refresh interval. Selecting a faster interval when data changes infrequently can degrade dashboard performance."
     },
     {
-      "type": "markdown",
-      "content": "To configure a visualization time range and refresh interval, complete the following steps:"
-    },
-    {
-      "type": "interactive",
-      "action": "highlight",
-      "reftarget": "[data-testid='data-testid TimePicker Open Button']",
-      "content": "To select a time range, click the **time picker** drop-down and select a time range (for example, `Last 6 hours`).",
-      "doIt": false,
-      "requirements": ["exists-reftarget"]
-    },
-    {
-      "type": "interactive",
-      "action": "highlight",
-      "reftarget": "[data-testid='data-testid RefreshPicker interval button']",
-      "content": "To select a refresh interval, click the **refresh** drop-down and select a time interval (for example, `5s`).",
-      "doIt": false,
-      "requirements": ["exists-reftarget"]
-    },
-    {
-      "type": "markdown",
-      "content": "You are now ready to save the dashboard so that other users can view it."
+      "type": "section",
+      "id": "configure-time-range",
+      "title": "Configure time range and refresh interval",
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='data-testid TimePicker Open Button']",
+          "content": "To select a time range, click the **time picker** drop-down and select a time range (for example, `Last 6 hours`).",
+          "doIt": false,
+          "requirements": ["exists-reftarget"]
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='data-testid RefreshPicker interval button']",
+          "content": "To select a refresh interval, click the **refresh** drop-down and select a time interval (for example, `5s`).",
+          "doIt": false,
+          "requirements": ["exists-reftarget"]
+        },
+        {
+          "type": "markdown",
+          "content": "You are now ready to save the dashboard so that other users can view it."
+        }
+      ]
     },
     {
       "type": "markdown",

--- a/visualization-logs/write-query/content.json
+++ b/visualization-logs/write-query/content.json
@@ -23,72 +23,75 @@
       "content": "### Operation (optional)\n\nAn operation creates a metric query. Metric queries extend log queries by applying a function to log query results. This powerful feature creates metrics from logs.\n\nFor example, the `count_over_time` operation calculates the number of error logs received for each time interval."
     },
     {
-      "type": "markdown",
-      "content": "## How to write a LogQL query\n\nTo write a LogQL query using the Query Builder, complete the following steps:"
-    },
-    {
-      "type": "interactive",
-      "action": "highlight",
-      "reftarget": "[data-testid=\"data-testid Select label\"]",
-      "content": "Select a key-value pair from the **Label filter** drop-down list.\n\nFor example, select `namespace`, `=`, and `game-app`.",
-      "doIt": false,
-      "requirements": ["exists-reftarget"]
-    },
-    {
-      "type": "markdown",
-      "content": "**Did you know?** If you are unsure of the label name, you can click **Label browser** and search for the label."
-    },
-    {
-      "type": "interactive",
-      "action": "highlight",
-      "reftarget": "[data-testid=\"label-browser-button\"]",
-      "content": "Click **Label browser** to explore available labels and values.",
-      "doIt": false,
-      "requirements": ["exists-reftarget"]
-    },
-    {
-      "type": "interactive",
-      "action": "button",
-      "reftarget": "Refresh",
-      "content": "Click **Refresh** located in the top-right corner of the dashboard.\n\nThe visualization should populate with data.",
-      "doIt": false,
-      "requirements": ["exists-reftarget"]
-    },
-    {
-      "type": "markdown",
-      "content": "**Did you know?** At this stage, you can save the dashboard and share it with others. The current dashboard includes a Logs panel displaying all logs within the selected namespace. However, this view offers limited utility for troubleshooting.\n\nIn the next steps, you'll learn how to apply a filter expression and aggregation to the log data to monitor the count of error logs per time interval."
-    },
-    {
-      "type": "markdown",
-      "content": "To define a log pipeline expression, select a line filter operator.\n\nFor example, select **Line contains** and enter `error`. The system returns all error logs. All other log types (warning, info) aren't included in the Logs panel."
-    },
-    {
-      "type": "interactive",
-      "action": "button",
-      "reftarget": "Operations",
-      "content": "Click **+ Operations** and select a function.\n\nFor example, click **Range function > Count over time**.",
-      "doIt": false,
-      "requirements": ["exists-reftarget"]
-    },
-    {
-      "type": "interactive",
-      "action": "highlight",
-      "reftarget": "[data-testid=\"data-testid visualization picker\"]",
-      "content": "From the **Visualization** drop-down list located in the upper-right of the page, select **Time series**.",
-      "doIt": false,
-      "requirements": ["exists-reftarget"]
-    },
-    {
-      "type": "markdown",
-      "content": "**Did you know?** When you apply an operation to log data, you are creating a metrics LogQL query."
-    },
-    {
-      "type": "interactive",
-      "action": "button",
-      "reftarget": "Refresh",
-      "content": "Click **Refresh** located in the top-right corner of the dashboard.\n\nThe visualization updates to show a time series graph.",
-      "doIt": false,
-      "requirements": ["exists-reftarget"]
+      "type": "section",
+      "id": "write-logql-query",
+      "title": "Write a LogQL query",
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid=\"data-testid Select label\"]",
+          "content": "Select a key-value pair from the **Label filter** drop-down list.\n\nFor example, select `namespace`, `=`, and `game-app`.",
+          "doIt": false,
+          "requirements": ["exists-reftarget"]
+        },
+        {
+          "type": "markdown",
+          "content": "**Did you know?** If you are unsure of the label name, you can click **Label browser** and search for the label."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid=\"label-browser-button\"]",
+          "content": "Click **Label browser** to explore available labels and values.",
+          "doIt": false,
+          "requirements": ["exists-reftarget"]
+        },
+        {
+          "type": "interactive",
+          "action": "button",
+          "reftarget": "Refresh",
+          "content": "Click **Refresh** located in the top-right corner of the dashboard.\n\nThe visualization should populate with data.",
+          "doIt": false,
+          "requirements": ["exists-reftarget"]
+        },
+        {
+          "type": "markdown",
+          "content": "**Did you know?** At this stage, you can save the dashboard and share it with others. The current dashboard includes a Logs panel displaying all logs within the selected namespace. However, this view offers limited utility for troubleshooting.\n\nIn the next steps, you'll learn how to apply a filter expression and aggregation to the log data to monitor the count of error logs per time interval."
+        },
+        {
+          "type": "markdown",
+          "content": "To define a log pipeline expression, select a line filter operator.\n\nFor example, select **Line contains** and enter `error`. The system returns all error logs. All other log types (warning, info) aren't included in the Logs panel."
+        },
+        {
+          "type": "interactive",
+          "action": "button",
+          "reftarget": "Operations",
+          "content": "Click **+ Operations** and select a function.\n\nFor example, click **Range function > Count over time**.",
+          "doIt": false,
+          "requirements": ["exists-reftarget"]
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid=\"data-testid visualization picker\"]",
+          "content": "From the **Visualization** drop-down list located in the upper-right of the page, select **Time series**.",
+          "doIt": false,
+          "requirements": ["exists-reftarget"]
+        },
+        {
+          "type": "markdown",
+          "content": "**Did you know?** When you apply an operation to log data, you are creating a metrics LogQL query."
+        },
+        {
+          "type": "interactive",
+          "action": "button",
+          "reftarget": "Refresh",
+          "content": "Click **Refresh** located in the top-right corner of the dashboard.\n\nThe visualization updates to show a time series graph.",
+          "doIt": false,
+          "requirements": ["exists-reftarget"]
+        }
+      ]
     },
     {
       "type": "markdown",

--- a/visualization-metrics-lj/add-visualization/content.json
+++ b/visualization-metrics-lj/add-visualization/content.json
@@ -4,39 +4,52 @@
   "blocks": [
     {
       "type": "markdown",
-      "content": "In this milestone, you'll create a new dashboard and add your first visualization panel. Let's walk through the steps together."
+      "content": "A Grafana dashboard is a set of one or more panels, organized and arranged into one or more rows, that provide an at-a-glance view of related information. These panels are created using components that query and transform raw data from a data source into visualizations.\n\nA data source can be an SQL database, Grafana Loki, Grafana Mimir, or an API endpoint. It can even be a basic CSV file. Data source plugins take a query you want answered, retrieve the data from the data source, and reconcile the differences between the data model of the data source and the data model of Grafana dashboards.\n\nTo create a dashboard and add a visualization, complete the following steps:"
     },
     {
-      "type": "markdown",
-      "content": "**Sign in to Grafana Cloud**\n\nSign in to your Grafana Cloud environment (for example, `mystack.grafana.net`)."
-    },
-    {
-      "type": "interactive",
-      "action": "highlight",
-      "reftarget": "ul[aria-label=\"Navigation\"] a[href=\"/dashboards\"]",
-      "content": "Click **Dashboards** in the main menu.",
-      "requirements": ["exists-reftarget", "navmenu-open"]
-    },
-    {
-      "type": "multistep",
-      "content": "Click **New** and select **New Dashboard**.",
-      "requirements": ["on-page:/dashboards"],
-      "steps": [
-        { "action": "button", "reftarget": "New" },
-        { "action": "highlight", "reftarget": "a[href=\"/dashboard/new\"]" }
+      "type": "section",
+      "blocks": [
+        {
+          "type": "markdown",
+          "content": "Sign in to your Grafana Cloud environment (for example, `mystack.grafana.net`)."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "ul[aria-label=\"Navigation\"] a[href=\"/dashboards\"]",
+          "content": "Click **Dashboards** in the main menu.",
+          "requirements": ["exists-reftarget", "navmenu-open"]
+        },
+        {
+          "type": "multistep",
+          "content": "Click **New** and select **New Dashboard**.",
+          "requirements": ["on-page:/dashboards"],
+          "steps": [
+            { "action": "button", "reftarget": "New" },
+            { "action": "highlight", "reftarget": "a[href=\"/dashboard/new\"]" }
+          ]
+        },
+        {
+          "type": "markdown",
+          "content": "In the **Add** drawer, click the **Panel** card to add a new visualization to your dashboard.\n\nA new panel is added to your dashboard."
+        },
+        {
+          "type": "markdown",
+          "content": "On the new panel, click **Configure**.\n\nThe **Edit panel** view opens with the default Prometheus data source preselected."
+        },
+        {
+          "type": "markdown",
+          "content": "If you want to use a different data source, in the **Queries** tab, click the **Data source** drop-down list and select one of your existing data sources."
+        }
       ]
     },
     {
       "type": "markdown",
-      "content": "In the **Add** drawer, click the **Panel** card to add a new visualization to your dashboard."
+      "content": "**Did you know?** For a Prometheus data source, the default visualization is a time-series graph. You can select another type of visualization from the visualization list in the panel editor. To see the full list of visualizations, click the **All visualizations** tab."
     },
     {
       "type": "markdown",
-      "content": "On the new panel, enter a panel title and description, and click **Configure** to open the Edit panel view."
-    },
-    {
-      "type": "markdown",
-      "content": "The **Edit panel** view opens with the default Prometheus data source preselected.\n\n> **Did you know?** For a Prometheus data source, the default visualization is a time-series graph. You can select another type from the visualization list in the panel editor.\n\nIf you want to use a different data source, click the **Data source** drop-down list in the Queries tab and select one of your existing data sources."
+      "content": "In your next milestone, you'll use the Query Builder to write a PromQL query that generates a visualization."
     }
   ]
 }

--- a/visualization-metrics-lj/business-value-visualizations/content.json
+++ b/visualization-metrics-lj/business-value-visualizations/content.json
@@ -1,0 +1,37 @@
+{
+  "id": "visualization-metrics-business-value",
+  "title": "About dashboards and visualizations",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "Observability is a cornerstone of site reliability engineering (SRE). It enables engineers to gain deep insights into the health, performance, and behavior of complex systems. By collecting and analyzing telemetry data such as logs, metrics, and traces, observability helps identify and resolve issues before they impact users.\n\nDashboards and visualizations are critical tools in this process. They provide a clear, real-time view of system performance, making it easier to detect anomalies, track trends, and correlate events. For example:\n\n- State timeline visualizations help engineers monitor and analyze changes in states or statuses of various entities over time."
+    },
+    {
+      "type": "image",
+      "src": "/media/docs/grafana/panels-visualizations/screenshot-state-timeline-v11.4.png",
+      "alt": "A state timeline visualization showing CPU usage"
+    },
+    {
+      "type": "markdown",
+      "content": "- Time-series visualizations can reveal latency spikes, enabling engineers to address performance degradation proactively."
+    },
+    {
+      "type": "image",
+      "src": "/media/docs/learning-journey/metrics-viz/time-series-viz.png",
+      "alt": "A time-series visualization showing CPU usage"
+    },
+    {
+      "type": "markdown",
+      "content": "- Alert list visualizations can quickly display a list of important alerts, such as high CPU usage or failed status checks."
+    },
+    {
+      "type": "image",
+      "src": "/media/docs/learning-journey/metrics-viz/alert-viz.png",
+      "alt": "An alert visualization showing alerts firing"
+    },
+    {
+      "type": "markdown",
+      "content": "Dashboards and visualizations transform raw data into actionable insights, empowering SREs to maintain high availability, optimize resource allocation, and deliver a seamless user experience—all while saving the business money by minimizing disruptions and operational inefficiencies. By leveraging these visualizations, businesses can prevent costly downtime and maintain customer trust."
+    }
+  ]
+}

--- a/visualization-metrics-lj/end-journey/content.json
+++ b/visualization-metrics-lj/end-journey/content.json
@@ -1,0 +1,10 @@
+{
+  "id": "visualization-metrics-end",
+  "title": "Destination reached!",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "Congratulations on completing this journey! Job well done!\n\nWe hope you've enjoyed traveling with us as you:\n\n- Learned about the importance of visualization in the field of observability\n- Planned for your visualizations so that dashboards align with business objectives\n- Built a dashboard and incorporated a visualization to display key metrics\n- Used the Query Builder to write a PromQL query"
+    }
+  ]
+}

--- a/visualization-metrics-lj/plan-visualization/content.json
+++ b/visualization-metrics-lj/plan-visualization/content.json
@@ -1,0 +1,14 @@
+{
+  "id": "visualization-metrics-plan",
+  "title": "Plan your visualization",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "Visualizations and dashboards are powerful tools designed to provide actionable insights into business problems. By translating raw data into meaningful visual representations, they help you identify trends, monitor performance, and make informed decisions. To maximize their value, it's essential to align your visualizations with your business goals."
+    },
+    {
+      "type": "markdown",
+      "content": "## Key questions to consider\n\nWhen creating dashboards and visualizations, the sheer number of metrics, visualization types, and data transformation options can feel overwhelming. The key to success lies in aligning your dashboards with your business objectives. While anyone can create a dashboard that visualizes data, the real challenge is ensuring that the data and visualization types are both relevant and effective in solving specific business problems.\n\nAs you start planning your dashboards and visualizations, consider the following questions to guide your approach:\n\n- **What business problem are you trying to solve?**  \n  Clearly define the problem you want to address. This ensures that your visualizations are purpose-driven and focused on actionable insights.\n  \n    - *Example:* If your goal is to reduce server downtime, your visualization should focus on metrics like system uptime, error rates, and server health.\n\n- **What specific questions should a visualization answer?**  \n  Break down the business problem into smaller, measurable questions that your visualization can address. This helps you identify the exact data you need to display.\n\n     - *Example:* For improving application performance, you might ask, \"What are the peak traffic times?\" or \"Which endpoints are experiencing the highest latency?\"\n\n- **Which metrics will provide relevant insights?**  \n  From a vast array of available metrics, select the ones that directly provide the insights you need. This requires a solid understanding of your data, the meaning behind each metric, and its relevance to your objectives.\n\n    - *Examples:* `node_cpu_seconds_total` for CPU usage, `machine_memory_bytes` for memory capacity, or `node_filesystem_device_error` for filesystem issues.\n\n- **How will the insights help drive decisions or actions?**  \n  Ensure that the visualizations provide actionable insights that can inform decisions or trigger specific actions. This step bridges the gap between data and outcomes.  \n  \n     - *Example:* If your visualization shows a spike in error rates during specific hours, you can schedule additional monitoring or allocate resources to address the issue proactively.\n\nBy answering these questions, you can create dashboards that not only display data but also empower your team to make informed, high impact decisions."
+    }
+  ]
+}

--- a/visualization-metrics-lj/save-dashboard/content.json
+++ b/visualization-metrics-lj/save-dashboard/content.json
@@ -4,32 +4,53 @@
   "blocks": [
     {
       "type": "markdown",
-      "content": "Each dashboard can contain multiple panels, each with a meaningful title that helps other users understand its purpose. After you save a dashboard, you can share it with others. Users with the appropriate permissions can edit the saved dashboard as needed."
+      "content": "Each dashboard can contain multiple panels, each with a meaningful title that helps other users understand its purpose. After you save a dashboard, you can share it with others. Users with the appropriate permissions can edit the saved dashboard as needed.\n\nTo title a panel and save a dashboard, complete the following steps:"
     },
     {
-      "type": "interactive",
-      "action": "highlight",
-      "reftarget": "[data-testid=\"data-testid Save dashboard button\"]",
-      "content": "When you've finished editing the panel, click **Save**.",
-      "requirements": ["exists-reftarget"]
+      "type": "section",
+      "blocks": [
+        {
+          "type": "markdown",
+          "content": "On the right of the **Edit panel** page, under **Panel options**, enter a panel **Title** and description.\n\nThe title appears at the top of the visualization."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid=\"data-testid Save dashboard button\"]",
+          "content": "When you've finished editing the panel, click **Save**.",
+          "requirements": ["exists-reftarget"]
+        },
+        {
+          "type": "markdown",
+          "content": "Enter a **title** and **description** for your dashboard."
+        },
+        {
+          "type": "markdown",
+          "content": "Select a **folder**, if applicable."
+        },
+        {
+          "type": "markdown",
+          "content": "Click **Save**."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid=\"data-testid Back to dashboard button\"]",
+          "content": "Click **Back to dashboard** to return to the dashboard view.",
+          "requirements": ["exists-reftarget"]
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid=\"data-testid Edit dashboard button\"]",
+          "content": "Click **Exit edit** to leave edit mode and view your completed dashboard.",
+          "requirements": ["exists-reftarget"]
+        }
+      ]
     },
     {
       "type": "markdown",
-      "content": "In the save dialog:\n1. Enter a **title** and **description** for your dashboard\n2. Select a **folder** if applicable\n3. Click **Save**"
-    },
-    {
-      "type": "interactive",
-      "action": "highlight",
-      "reftarget": "[data-testid=\"data-testid Back to dashboard button\"]",
-      "content": "Click **Back to dashboard** to return to the dashboard view.",
-      "requirements": ["exists-reftarget"]
-    },
-    {
-      "type": "interactive",
-      "action": "highlight",
-      "reftarget": "[data-testid=\"data-testid Edit dashboard button\"]",
-      "content": "Click **Exit edit** to leave edit mode and view your completed dashboard.",
-      "requirements": ["exists-reftarget"]
+      "content": "**Did you know?** In Grafana Cloud, you can have Grafana generate panel titles and descriptions for you using generative AI features."
     },
     {
       "type": "markdown",

--- a/visualization-metrics-lj/time-range-refresh/content.json
+++ b/visualization-metrics-lj/time-range-refresh/content.json
@@ -4,31 +4,44 @@
   "blocks": [
     {
       "type": "markdown",
-      "content": "You can define the time span for which data is displayed in the visualization. For instance, if the current time is 1 PM and you set a time range of 1 hour, the visualization will show data from 12 PM to 1 PM.\n\nAdditionally, you can enable automatic data refresh. The refresh interval determines how frequently the data updates.\n\n> **Tip:** Choose the slowest refresh interval that meets your requirements. Selecting a faster interval when data changes infrequently can degrade dashboard performance."
+      "content": "You can define the time span for which data is displayed in the visualization. For instance, if the current time is 1 PM and you set a time range of 1 hour, the visualization will show data from 12 PM to 1 PM.\n\nAdditionally, you can enable automatic data refresh. The refresh interval determines how frequently the data updates.\n\nTo configure a visualization time range and refresh interval, complete the following steps:"
     },
     {
-      "type": "interactive",
-      "action": "highlight",
-      "reftarget": "[data-testid=\"data-testid TimePicker Open Button\"]",
-      "content": "Click the **time picker** drop-down in the toolbar to select a time range for your visualization.",
-      "doIt": false,
-      "requirements": ["exists-reftarget"]
+      "type": "section",
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid=\"data-testid TimePicker Open Button\"]",
+          "content": "To select a time range, click the **time picker** drop-down in the toolbar.",
+          "doIt": false,
+          "requirements": ["exists-reftarget"]
+        },
+        {
+          "type": "markdown",
+          "content": "Select a time range from the available options (for example, **Last 1 hour**, **Last 6 hours**, or **Last 24 hours**)."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid=\"data-testid RefreshPicker interval button\"]",
+          "content": "To select a refresh interval, click the **refresh** drop-down icon.",
+          "doIt": false,
+          "requirements": ["exists-reftarget"]
+        },
+        {
+          "type": "markdown",
+          "content": "Select a refresh interval from the available options (for example, **1m**, **5m**, or **15m**)."
+        }
+      ]
     },
     {
       "type": "markdown",
-      "content": "Select a time range from the available options (for example, **Last 1 hour**, **Last 6 hours**, or **Last 24 hours**)."
-    },
-    {
-      "type": "interactive",
-      "action": "highlight",
-      "reftarget": "[data-testid=\"data-testid RefreshPicker interval button\"]",
-      "content": "Click the **refresh** drop-down icon to select how often the visualization data updates.",
-      "doIt": false,
-      "requirements": ["exists-reftarget"]
+      "content": "**Tip:** Choose the slowest refresh interval that meets your requirements. Selecting a faster interval when data changes infrequently can degrade dashboard performance."
     },
     {
       "type": "markdown",
-      "content": "Select a refresh interval from the available options (for example, **1m**, **5m**, or **15m**).\n\nYou're now ready to save the dashboard so that other users can view it."
+      "content": "You're now ready to save the dashboard so that other users can view it."
     }
   ]
 }

--- a/visualization-metrics-lj/write-query/content.json
+++ b/visualization-metrics-lj/write-query/content.json
@@ -4,55 +4,64 @@
   "blocks": [
     {
       "type": "markdown",
-      "content": "Now that you have a panel configured, it's time to write the query. A query is an expression that specifies the dataset to be used in the visualization.\n\nA PromQL query consists of three basic elements:\n- **Metric**: The specific time series data you want to analyze\n- **Label filter**: Key-value pairs that narrow down the dataset\n- **Operation**: Functions that modify or process the data"
+      "content": "Now that you have a panel configured, it's time to write the query. A query is an expression that specifies the dataset to be used in the visualization.\n\nA PromQL query consists of three basic elements:\n- **Metric**: The specific time series data you want to analyze\n- **Label filter**: Key-value pairs that narrow down the dataset\n- **Operation**: Functions that modify or process the data\n\nTo write a PromQL query using the Query Builder, complete the following steps:"
     },
     {
-      "type": "interactive",
-      "action": "highlight",
-      "reftarget": "[data-testid=\"data-testid metric select\"]",
-      "content": "Click the **Metric** drop-down list to select a metric.",
-      "doIt": false,
-      "requirements": ["exists-reftarget"]
+      "type": "section",
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid=\"data-testid metric select\"]",
+          "content": "Click the **Metric** drop-down list to select a metric.",
+          "doIt": false,
+          "requirements": ["exists-reftarget"]
+        },
+        {
+          "type": "markdown",
+          "content": "Select a metric from the list, for example `node_cpu_usage_seconds_total`."
+        },
+        {
+          "type": "markdown",
+          "content": "(Optional) In the **Label filters** fields, select a key-value pair and operator to filter your data. For example, select `node`, `=`, and your specific node ID."
+        },
+        {
+          "type": "interactive",
+          "action": "button",
+          "reftarget": "Operations",
+          "content": "Click **+ Operations** to add a function to your query.",
+          "doIt": false,
+          "requirements": ["exists-reftarget"]
+        },
+        {
+          "type": "markdown",
+          "content": "Select a function from the menu. For example, select **Range > Rate** and `$__rate_interval`."
+        },
+        {
+          "type": "interactive",
+          "action": "button",
+          "reftarget": "Operations",
+          "content": "Click **+ Operations** again to add another operation.",
+          "doIt": false,
+          "requirements": ["exists-reftarget"]
+        },
+        {
+          "type": "markdown",
+          "content": "Select another function. For example, select **Aggregations > Sum**."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid=\"data-testid RefreshPicker run button\"]",
+          "content": "Click **Refresh** in the toolbar to run the query and populate the visualization with data.",
+          "doIt": false,
+          "requirements": ["exists-reftarget"]
+        }
+      ]
     },
     {
       "type": "markdown",
-      "content": "Select a metric from the list, for example `node_cpu_usage_seconds_total`.\n\n> **Tip:** If you're unsure of the metric name, click the **Metrics explorer** icon to search for metrics by name and type."
-    },
-    {
-      "type": "markdown",
-      "content": "**Add label filters (optional)**\n\nIn the **Label filters** fields, you can optionally select a key-value pair and operator to filter your data. For example, select `node`, `=`, and your specific node ID."
-    },
-    {
-      "type": "interactive",
-      "action": "button",
-      "reftarget": "Operations",
-      "content": "Click **+ Operations** to add a function to your query.",
-      "doIt": false,
-      "requirements": ["exists-reftarget"]
-    },
-    {
-      "type": "markdown",
-      "content": "Select a function from the menu. For example, select **Range > Rate** and `$__rate_interval`."
-    },
-    {
-      "type": "interactive",
-      "action": "button",
-      "reftarget": "Operations",
-      "content": "Click **+ Operations** again to add another operation.",
-      "doIt": false,
-      "requirements": ["exists-reftarget"]
-    },
-    {
-      "type": "markdown",
-      "content": "Select another function. For example, select **Aggregations > Sum**."
-    },
-    {
-      "type": "interactive",
-      "action": "highlight",
-      "reftarget": "[data-testid=\"data-testid RefreshPicker run button\"]",
-      "content": "Click **Refresh** in the toolbar to run the query and populate the visualization with data.",
-      "doIt": false,
-      "requirements": ["exists-reftarget"]
+      "content": "**Did you know?** If you're unsure of the metric name, click the **Metrics explorer** icon to search for metrics by name and type."
     },
     {
       "type": "markdown",

--- a/visualization-traces-lj/add-traces-panel/content.json
+++ b/visualization-traces-lj/add-traces-panel/content.json
@@ -4,78 +4,86 @@
   "blocks": [
     {
       "type": "markdown",
-      "content": "Traces visualizations let you follow a request as it traverses the services in your infrastructure. The traces visualization displays traces data in a diagram that allows you to easily interpret it. Traces visualizations currently render one trace traversal based on the traceID used in TraceQL or using a variable.\n\nTo add a Traces panel to a dashboard, complete the following steps:"
+      "content": "Traces visualizations let you follow a request as it traverses the services in your infrastructure. The traces visualization displays traces data in a diagram that allows you to easily interpret it. Traces visualizations currently render one trace traversal based on the traceID used in TraceQL or using a variable."
     },
     {
-      "type": "multistep",
-      "content": "While viewing a dashboard in edit mode, click the **+** button in the sidebar, then click the **Panel** card to add a new panel.",
+      "type": "section",
+      "id": "add-traces-panel",
+      "title": "Add a Traces panel",
       "requirements": ["exists-reftarget"],
-      "steps": [
+      "blocks": [
         {
-          "action": "highlight",
-          "reftarget": "[data-testid='data-testid Dashboard Sidebar new button']"
+          "type": "multistep",
+          "content": "While viewing a dashboard in edit mode, click the **+** button in the sidebar, then click the **Panel** card to add a new panel.",
+          "requirements": ["exists-reftarget"],
+          "steps": [
+            {
+              "action": "highlight",
+              "reftarget": "[data-testid='data-testid Dashboard Sidebar new button']"
+            },
+            {
+              "action": "highlight",
+              "reftarget": "[data-testid='data-testid sidebar add new panel']"
+            }
+          ]
         },
         {
-          "action": "highlight",
-          "reftarget": "[data-testid='data-testid sidebar add new panel']"
-        }
-      ]
-    },
-    {
-      "type": "markdown",
-      "content": "On the new panel, enter a title and description, and click **Configure**."
-    },
-    {
-      "type": "interactive",
-      "action": "highlight",
-      "reftarget": "input[data-testid='data-testid Select a data source']",
-      "content": "Click the **Data source** drop-down and select the same traces data source you selected for the traces table.",
-      "requirements": ["exists-reftarget"],
-      "doIt": false
-    },
-    {
-      "type": "multistep",
-      "content": "From the visualization picker on the right, click **All visualizations** and select **Traces**.",
-      "requirements": ["exists-reftarget"],
-      "steps": [
-        {
-          "action": "highlight",
-          "reftarget": "[data-testid='data-testid Tab All visualizations']"
+          "type": "markdown",
+          "content": "On the new panel, enter a title and description, and click **Configure**."
         },
         {
+          "type": "interactive",
           "action": "highlight",
-          "reftarget": "[data-testid='data-testid Plugin visualization item Traces']"
+          "reftarget": "input[data-testid='data-testid Select a data source']",
+          "content": "Click the **Data source** drop-down and select the same traces data source you selected for the traces table.",
+          "requirements": ["exists-reftarget"],
+          "doIt": false
+        },
+        {
+          "type": "multistep",
+          "content": "From the visualization picker on the right, click **All visualizations** and select **Traces**.",
+          "requirements": ["exists-reftarget"],
+          "steps": [
+            {
+              "action": "highlight",
+              "reftarget": "[data-testid='data-testid Tab All visualizations']"
+            },
+            {
+              "action": "highlight",
+              "reftarget": "[data-testid='data-testid Plugin visualization item Traces']"
+            }
+          ]
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "label[for^='option-traceql-']",
+          "content": "In the query editor, click the **TraceQL** query type tab.",
+          "requirements": ["exists-reftarget"]
+        },
+        {
+          "type": "markdown",
+          "content": "Enter `${traceId}` in the TraceQL query field to create a dashboard variable.\n\nThis variable is used as the template query."
+        },
+        {
+          "type": "markdown",
+          "content": "Under the **Panel options**, enter a **Title** for your trace panel."
+        },
+        {
+          "type": "interactive",
+          "action": "button",
+          "reftarget": "Save",
+          "content": "Save the changes to the dashboard.",
+          "requirements": ["exists-reftarget"]
+        },
+        {
+          "type": "interactive",
+          "action": "button",
+          "reftarget": "Back to dashboard",
+          "content": "Click **Back to dashboard**.",
+          "requirements": ["exists-reftarget"]
         }
       ]
-    },
-    {
-      "type": "interactive",
-      "action": "highlight",
-      "reftarget": "label[for^='option-traceql-']",
-      "content": "In the query editor, click the **TraceQL** query type tab.",
-      "requirements": ["exists-reftarget"]
-    },
-    {
-      "type": "markdown",
-      "content": "Enter `${traceId}` in the TraceQL query field to create a dashboard variable.\n\nThis variable is used as the template query."
-    },
-    {
-      "type": "markdown",
-      "content": "Under the **Panel options**, enter a **Title** for your trace panel."
-    },
-    {
-      "type": "interactive",
-      "action": "button",
-      "reftarget": "Save",
-      "content": "Save the changes to the dashboard.",
-      "requirements": ["exists-reftarget"]
-    },
-    {
-      "type": "interactive",
-      "action": "button",
-      "reftarget": "Back to dashboard",
-      "content": "Click **Back to dashboard**.",
-      "requirements": ["exists-reftarget"]
     },
     {
       "type": "markdown",

--- a/visualization-traces-lj/add-traces-table/content.json
+++ b/visualization-traces-lj/add-traces-table/content.json
@@ -4,51 +4,59 @@
   "blocks": [
     {
       "type": "markdown",
-      "content": "TraceQL is a query language designed for searching and filtering traces within Grafana Cloud. It enables you to write expressions that specify criteria to locate specific traces. A basic TraceQL query consists of key-value pairs that filter traces, ensuring only those matching the defined criteria are included in the results.\n\nIn this milestone, you'll write a TraceQL query using the Search query builder that visualizes a list of traces in a table.\n\nTo write a TraceQL query, perform the following steps:"
+      "content": "TraceQL is a query language designed for searching and filtering traces within Grafana Cloud. It enables you to write expressions that specify criteria to locate specific traces. A basic TraceQL query consists of key-value pairs that filter traces, ensuring only those matching the defined criteria are included in the results.\n\nIn this milestone, you'll write a TraceQL query using the Search query builder that visualizes a list of traces in a table."
     },
     {
-      "type": "interactive",
-      "action": "highlight",
-      "reftarget": "label[for*='traceqlSearch']",
-      "content": "In the Query Builder, click the **Search** tab located to the right of **Query type**.\n\nThe traces table populates with a list of traces and a list of search criteria appears.",
-      "requirements": ["exists-reftarget"]
-    },
-    {
-      "type": "markdown",
-      "content": "For any of the search criteria, select an operator and a value.\n\nFor example, when:\n- Service Name = `app-2048`\n- Span Name = `POST /`\n- Status = `Error`\n\nThe resulting TraceQL query is:\n`{resource.service.name=\"app-2048\" && name=\"POST /\" && status=error}`"
-    },
-    {
-      "type": "interactive",
-      "action": "highlight",
-      "reftarget": "[data-testid='data-testid RefreshPicker run button']",
-      "content": "Click **Refresh** to update the list of traces in the table.",
-      "requirements": ["exists-reftarget"]
-    },
-    {
-      "type": "interactive",
-      "action": "button",
-      "reftarget": "Save",
-      "content": "Click **Save** located in the upper-right corner of the page.",
-      "requirements": ["exists-reftarget"]
-    },
-    {
-      "type": "markdown",
-      "content": "Enter a title and description for your dashboard, and select a folder, if applicable."
-    },
-    {
-      "type": "markdown",
-      "content": "Click **Save** to save the dashboard."
-    },
-    {
-      "type": "interactive",
-      "action": "button",
-      "reftarget": "Back to dashboard",
-      "content": "Click **Back to dashboard**.",
-      "requirements": ["exists-reftarget"]
-    },
-    {
-      "type": "markdown",
-      "content": "**Did you know?** If you're using Grafana Enterprise or Grafana Cloud, you can save queries for reuse across panels and dashboards. Click **Save query** to save your current query, or use the **Saved queries** drop-down menu to reuse a previously saved query."
+      "type": "section",
+      "id": "write-traceql-query",
+      "title": "Write a TraceQL query",
+      "requirements": ["exists-reftarget"],
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "label[for*='traceqlSearch']",
+          "content": "In the Query Builder, click the **Search** tab located to the right of **Query type**.\n\nThe traces table populates with a list of traces and a list of search criteria appears.",
+          "requirements": ["exists-reftarget"]
+        },
+        {
+          "type": "markdown",
+          "content": "For any of the search criteria, select an operator and a value.\n\nFor example, when:\n- Service Name = `app-2048`\n- Span Name = `POST /`\n- Status = `Error`\n\nThe resulting TraceQL query is:\n`{resource.service.name=\"app-2048\" && name=\"POST /\" && status=error}`"
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='data-testid RefreshPicker run button']",
+          "content": "Click **Refresh** to update the list of traces in the table.",
+          "requirements": ["exists-reftarget"]
+        },
+        {
+          "type": "interactive",
+          "action": "button",
+          "reftarget": "Save",
+          "content": "Click **Save** located in the upper-right corner of the page.",
+          "requirements": ["exists-reftarget"]
+        },
+        {
+          "type": "markdown",
+          "content": "Enter a title and description for your dashboard, and select a folder, if applicable."
+        },
+        {
+          "type": "markdown",
+          "content": "Click **Save** to save the dashboard."
+        },
+        {
+          "type": "interactive",
+          "action": "button",
+          "reftarget": "Back to dashboard",
+          "content": "Click **Back to dashboard**.",
+          "requirements": ["exists-reftarget"]
+        },
+        {
+          "type": "markdown",
+          "content": "**Did you know?** If you're using Grafana Enterprise or Grafana Cloud, you can save queries for reuse across panels and dashboards. Click **Save query** to save your current query, or use the **Saved queries** drop-down menu to reuse a previously saved query."
+        }
+      ]
     },
     {
       "type": "markdown",

--- a/visualization-traces-lj/add-variable/content.json
+++ b/visualization-traces-lj/add-variable/content.json
@@ -4,34 +4,42 @@
   "blocks": [
     {
       "type": "markdown",
-      "content": "Grafana dashboard variables let you create dynamic and interactive views of your tracing data. Instead of having a static dashboard that always shows the same information, variables let you filter, drill down, and explore your traces without having to manually edit queries or create multiple dashboards.\n\nDashboard variables transform your traces dashboards from static reports into powerful, interactive investigative tools, significantly improving your ability to understand, monitor, and troubleshoot distributed systems.\n\nIn this milestone, you'll add a dashboard variable that allows you to filter and explore trace spans based on specific trace IDs.\n\nTo add a dashboard variable, complete the following steps:"
+      "content": "Grafana dashboard variables let you create dynamic and interactive views of your tracing data. Instead of having a static dashboard that always shows the same information, variables let you filter, drill down, and explore your traces without having to manually edit queries or create multiple dashboards.\n\nDashboard variables transform your traces dashboards from static reports into powerful, interactive investigative tools, significantly improving your ability to understand, monitor, and troubleshoot distributed systems.\n\nIn this milestone, you'll add a dashboard variable that allows you to filter and explore trace spans based on specific trace IDs."
     },
     {
-      "type": "interactive",
-      "action": "highlight",
-      "reftarget": "[data-testid='data-testid Edit dashboard button']",
-      "content": "On the dashboard, click **Edit**.",
-      "requirements": ["exists-reftarget"]
-    },
-    {
-      "type": "interactive",
-      "action": "button",
-      "reftarget": "Add variable",
-      "content": "Click **Add variable**.",
+      "type": "section",
+      "id": "add-variable",
+      "title": "Add a dashboard variable",
       "requirements": ["exists-reftarget"],
-      "doIt": false
-    },
-    {
-      "type": "markdown",
-      "content": "From the **Variable type** drop-down list, select `Custom`."
-    },
-    {
-      "type": "markdown",
-      "content": "In the **Name** field of the **Custom variable** modal, enter `traceId`."
-    },
-    {
-      "type": "markdown",
-      "content": "In the **Label** field, enter `Trace ID`.\n\n`Trace ID` appears above the panel."
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='data-testid Edit dashboard button']",
+          "content": "On the dashboard, click **Edit**.",
+          "requirements": ["exists-reftarget"]
+        },
+        {
+          "type": "interactive",
+          "action": "button",
+          "reftarget": "Add variable",
+          "content": "Click **Add variable**.",
+          "requirements": ["exists-reftarget"],
+          "doIt": false
+        },
+        {
+          "type": "markdown",
+          "content": "From the **Variable type** drop-down list, select `Custom`."
+        },
+        {
+          "type": "markdown",
+          "content": "In the **Name** field of the **Custom variable** modal, enter `traceId`."
+        },
+        {
+          "type": "markdown",
+          "content": "In the **Label** field, enter `Trace ID`.\n\n`Trace ID` appears above the panel."
+        }
+      ]
     },
     {
       "type": "markdown",

--- a/visualization-traces-lj/add-visualization/content.json
+++ b/visualization-traces-lj/add-visualization/content.json
@@ -4,62 +4,70 @@
   "blocks": [
     {
       "type": "markdown",
-      "content": "A Grafana dashboard is a set of one or more panels, organized and arranged into one or more rows, that provide an at-a-glance view of related information. These panels are created using components that query and transform raw data from a data source into visualizations.\n\nA data source can be an SQL database, Grafana Loki, Grafana Mimir, or an API endpoint. It can even be a basic CSV file. Data source plugins take a query you want answered, retrieve the data from the data source, and reconcile the differences between the data model of the data source and the data model of Grafana dashboards.\n\nTo create a dashboard and add a visualization, complete the following steps:"
+      "content": "A Grafana dashboard is a set of one or more panels, organized and arranged into one or more rows, that provide an at-a-glance view of related information. These panels are created using components that query and transform raw data from a data source into visualizations.\n\nA data source can be an SQL database, Grafana Loki, Grafana Mimir, or an API endpoint. It can even be a basic CSV file. Data source plugins take a query you want answered, retrieve the data from the data source, and reconcile the differences between the data model of the data source and the data model of Grafana dashboards."
     },
     {
-      "type": "markdown",
-      "content": "Sign in to your Grafana Cloud environment, for example `mystack.grafana.net`."
-    },
-    {
-      "type": "interactive",
-      "action": "highlight",
-      "reftarget": "a[data-testid='data-testid Nav menu item'][href='/dashboards']",
-      "content": "Click **Dashboards** in the main menu.",
-      "requirements": ["navmenu-open"]
-    },
-    {
-      "type": "multistep",
-      "content": "Click **New** and select **New Dashboard**.",
-      "requirements": ["exists-reftarget"],
-      "steps": [
+      "type": "section",
+      "id": "create-dashboard-traces",
+      "title": "Create a dashboard and add a visualization",
+      "requirements": ["navmenu-open"],
+      "blocks": [
         {
-          "action": "button",
-          "reftarget": "New"
+          "type": "markdown",
+          "content": "Sign in to your Grafana Cloud environment, for example `mystack.grafana.net`."
         },
         {
+          "type": "interactive",
           "action": "highlight",
-          "reftarget": "a[href='/dashboard/new']"
-        }
-      ]
-    },
-    {
-      "type": "markdown",
-      "content": "In the **Add** drawer, click the **Panel** card to add a new visualization to your dashboard."
-    },
-    {
-      "type": "markdown",
-      "content": "On the new panel, enter a panel title and description, and click **Configure** to open the Edit panel view."
-    },
-    {
-      "type": "interactive",
-      "action": "highlight",
-      "reftarget": "input[data-testid='data-testid Select a data source']",
-      "content": "In the **Queries** tab, click the **Data source** drop-down list and select a traces data source (such as Tempo).",
-      "requirements": ["exists-reftarget"],
-      "doIt": false
-    },
-    {
-      "type": "multistep",
-      "content": "From the visualization picker on the right, click **All visualizations** and select **Table**.",
-      "requirements": ["exists-reftarget"],
-      "steps": [
-        {
-          "action": "highlight",
-          "reftarget": "[data-testid='data-testid Tab All visualizations']"
+          "reftarget": "a[data-testid='data-testid Nav menu item'][href='/dashboards']",
+          "content": "Click **Dashboards** in the main menu.",
+          "requirements": ["navmenu-open"]
         },
         {
+          "type": "multistep",
+          "content": "Click **New** and select **New Dashboard**.",
+          "requirements": ["exists-reftarget"],
+          "steps": [
+            {
+              "action": "button",
+              "reftarget": "New"
+            },
+            {
+              "action": "highlight",
+              "reftarget": "a[href='/dashboard/new']"
+            }
+          ]
+        },
+        {
+          "type": "markdown",
+          "content": "In the **Add** drawer, click the **Panel** card to add a new visualization to your dashboard."
+        },
+        {
+          "type": "markdown",
+          "content": "On the new panel, enter a panel title and description, and click **Configure** to open the Edit panel view."
+        },
+        {
+          "type": "interactive",
           "action": "highlight",
-          "reftarget": "[data-testid='data-testid Plugin visualization item Table']"
+          "reftarget": "input[data-testid='data-testid Select a data source']",
+          "content": "In the **Queries** tab, click the **Data source** drop-down list and select a traces data source (such as Tempo).",
+          "requirements": ["exists-reftarget"],
+          "doIt": false
+        },
+        {
+          "type": "multistep",
+          "content": "From the visualization picker on the right, click **All visualizations** and select **Table**.",
+          "requirements": ["exists-reftarget"],
+          "steps": [
+            {
+              "action": "highlight",
+              "reftarget": "[data-testid='data-testid Tab All visualizations']"
+            },
+            {
+              "action": "highlight",
+              "reftarget": "[data-testid='data-testid Plugin visualization item Table']"
+            }
+          ]
         }
       ]
     },

--- a/visualization-traces-lj/test-dashboard/content.json
+++ b/visualization-traces-lj/test-dashboard/content.json
@@ -4,19 +4,26 @@
   "blocks": [
     {
       "type": "markdown",
-      "content": "In this milestone you'll rearrange the panels that appear in the dashboard and test that the traces panel is configured correctly.\n\nTo reorder dashboard panels and test the dashboard, complete the following steps:"
+      "content": "In this milestone you'll rearrange the panels that appear in the dashboard and test that the traces panel is configured correctly."
     },
     {
-      "type": "markdown",
-      "content": "While in dashboard edit mode, hover your cursor over the traces table panel until you see a move cursor.\n\nClick and drag the traces table and place it above the traces panel.\n\n**Did you know?** You aren't required to change the order of the panels, but having the traces table above the traces panel makes working with the dashboard a bit more intuitive for users."
-    },
-    {
-      "type": "markdown",
-      "content": "Copy a **Trace ID** from the traces table."
-    },
-    {
-      "type": "markdown",
-      "content": "Paste the Trace ID into the **Trace ID** field at the top of the dashboard and press **Enter**.\n\nThe traces panel should populate with more detailed information about the trace.\n\nYou can use the traces panel to explore span attributes and resource attributes, which you can use to troubleshoot issues with your system."
+      "type": "section",
+      "id": "test-dashboard",
+      "title": "Reorder and test the dashboard",
+      "blocks": [
+        {
+          "type": "markdown",
+          "content": "While in dashboard edit mode, hover your cursor over the traces table panel until you see a move cursor.\n\nClick and drag the traces table and place it above the traces panel.\n\n**Did you know?** You aren't required to change the order of the panels, but having the traces table above the traces panel makes working with the dashboard a bit more intuitive for users."
+        },
+        {
+          "type": "markdown",
+          "content": "Copy a **Trace ID** from the traces table."
+        },
+        {
+          "type": "markdown",
+          "content": "Paste the Trace ID into the **Trace ID** field at the top of the dashboard and press **Enter**.\n\nThe traces panel should populate with more detailed information about the trace.\n\nYou can use the traces panel to explore span attributes and resource attributes, which you can use to troubleshoot issues with your system."
+        }
+      ]
     },
     {
       "type": "markdown",

--- a/visualization-traces-lj/time-range-refresh/content.json
+++ b/visualization-traces-lj/time-range-refresh/content.json
@@ -4,35 +4,43 @@
   "blocks": [
     {
       "type": "markdown",
-      "content": "You can define the time span for which data is displayed in the visualization. For instance, if the current time is 1 PM and you set a time range of 1 hour, the visualization will show data from 12 PM to 1 PM. A variety of predefined time ranges are available for selection.\n\nAdditionally, you can enable automatic data refresh for the visualization. The refresh interval determines how frequently the data is updated. For example, setting a 1-minute refresh interval means that the data updates every minute. You can choose from multiple refresh intervals based on your specific needs.\n\n**Tip:** Choose the slowest refresh interval that meets your requirements. If near real-time updates are unnecessary, opt for a 1-minute or longer refresh interval. Selecting a faster interval when data changes infrequently can degrade dashboard performance.\n\nTo configure a visualization time range and refresh interval, complete the following steps:"
+      "content": "You can define the time span for which data is displayed in the visualization. For instance, if the current time is 1 PM and you set a time range of 1 hour, the visualization will show data from 12 PM to 1 PM. A variety of predefined time ranges are available for selection.\n\nAdditionally, you can enable automatic data refresh for the visualization. The refresh interval determines how frequently the data is updated. For example, setting a 1-minute refresh interval means that the data updates every minute. You can choose from multiple refresh intervals based on your specific needs.\n\n**Tip:** Choose the slowest refresh interval that meets your requirements. If near real-time updates are unnecessary, opt for a 1-minute or longer refresh interval. Selecting a faster interval when data changes infrequently can degrade dashboard performance."
     },
     {
-      "type": "interactive",
-      "action": "highlight",
-      "reftarget": "[data-testid='data-testid TimePicker Open Button']",
-      "content": "To select a time range, click the **time picker** drop-down icon.",
+      "type": "section",
+      "id": "configure-time-range-traces",
+      "title": "Configure time range and refresh interval",
       "requirements": ["exists-reftarget"],
-      "doIt": false
-    },
-    {
-      "type": "markdown",
-      "content": "Select a time range from the options (for example, **Last 1 hour**, **Last 6 hours**, or a custom range)."
-    },
-    {
-      "type": "interactive",
-      "action": "highlight",
-      "reftarget": "[data-testid='data-testid RefreshPicker interval button']",
-      "content": "To select a refresh interval, click the **refresh** drop-down icon.",
-      "requirements": ["exists-reftarget"],
-      "doIt": false
-    },
-    {
-      "type": "markdown",
-      "content": "Select a refresh interval from the options (for example, **1m**, **5m**, or **Off**)."
-    },
-    {
-      "type": "markdown",
-      "content": "Congratulations! You've completed this milestone and are ready to finish your journey."
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='data-testid TimePicker Open Button']",
+          "content": "To select a time range, click the **time picker** drop-down icon.",
+          "requirements": ["exists-reftarget"],
+          "doIt": false
+        },
+        {
+          "type": "markdown",
+          "content": "Select a time range from the options (for example, **Last 1 hour**, **Last 6 hours**, or a custom range)."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='data-testid RefreshPicker interval button']",
+          "content": "To select a refresh interval, click the **refresh** drop-down icon.",
+          "requirements": ["exists-reftarget"],
+          "doIt": false
+        },
+        {
+          "type": "markdown",
+          "content": "Select a refresh interval from the options (for example, **1m**, **5m**, or **Off**)."
+        },
+        {
+          "type": "markdown",
+          "content": "Congratulations! You've completed this milestone and are ready to finish your journey."
+        }
+      ]
     },
     {
       "type": "markdown",

--- a/windows-integration/install-dashboards-alerts/content.json
+++ b/windows-integration/install-dashboards-alerts/content.json
@@ -32,25 +32,11 @@
       "content": "You'll see a folder containing several dashboards:\n- Windows CPU and system\n- Windows disks and filesystems\n- Windows fleet overview\n- Windows logs\n- Windows overview\n\nNow let's navigate to see the installed alerts."
     },
     {
-      "type": "multistep",
+      "type": "interactive",
+      "action": "highlight",
+      "reftarget": "a[data-testid='data-testid Nav menu item'][href='/alerting/list']",
       "content": "Navigate to **Alerts & IRM > Alerting > Alert rules**.",
-      "steps": [
-        {
-          "action": "highlight",
-          "reftarget": "a[data-testid='data-testid Nav menu item'][href='/alerts-and-incidents']"
-        },
-        {
-          "action": "highlight",
-          "reftarget": "a[data-testid='data-testid Nav menu item'][href='/alerting']"
-        },
-        {
-          "action": "highlight",
-          "reftarget": "a[data-testid='data-testid Nav menu item'][href='/alerting/list']"
-        }
-      ],
-      "requirements": [
-        "navmenu-open"
-      ]
+      "requirements": ["navmenu-open"]
     },
     {
       "type": "markdown",

--- a/windows-integration/select-platform/content.json
+++ b/windows-integration/select-platform/content.json
@@ -7,19 +7,11 @@
       "content": "Your first step on this journey is to select the Windows integration.\n\nMake sure you're signed in to your Grafana Cloud environment."
     },
     {
-      "type": "multistep",
+      "type": "interactive",
+      "action": "highlight",
+      "reftarget": "a[data-testid='data-testid Nav menu item'][href='/connections/add-new-connection']",
       "content": "Navigate to **Connections > Add new connection**.",
-      "requirements": ["navmenu-open"],
-      "steps": [
-        {
-          "action": "highlight",
-          "reftarget": "a[data-testid='data-testid Nav menu item'][href='/connections']"
-        },
-        {
-          "action": "highlight",
-          "reftarget": "a[data-testid='data-testid Nav menu item'][href='/connections/add-new-connection']"
-        }
-      ]
+      "requirements": ["navmenu-open"]
     },
     {
       "type": "interactive",


### PR DESCRIPTION
- Use sections for task lists.
- Use simple menu navigation instead of multistep navmenu drilldown. Pathfinder will offer to fix it if the element is hidden in a submenu.
- Represent a lot of non-interactive milestones using content.json. Eventually all will be added so there's no split between where the content lives.
- Fix some selectors.

The JSON diff is pretty rough.

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation/guide JSON changes only; primary risk is broken tutorials due to incorrect selectors or section nesting affecting playback.
> 
> **Overview**
> **Restructures many learning-journey `content.json` guides to use `section` blocks for step sequences**, moving previously top-level `interactive`/`multistep`/`markdown` items under grouped sections and simplifying several navigation flows (preferring direct menu selectors over multi-step nav drilldowns).
> 
> Adds substantial new milestone content across multiple journeys (Logs/Metrics/Traces Drilldown, GitHub data source, MySQL data source & MySQL integration, Prometheus, Linux/macOS integrations, visualizations), including new *business value* and *end-of-journey* pages plus multiple embedded YouTube walkthrough videos. Also updates and fixes numerous UI selectors/reftargets and some instructions to match current Grafana UI.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a2f2fb935e5789b72014decd255b0d7ec66955bd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->