### PR TITLE
Refactor `/build-interactive-lj` command into modular structure

### DIFF
--- a/.cursor/commands/build-interactive-lj/README.md
+++ b/.cursor/commands/build-interactive-lj/README.md
@@ -1,0 +1,184 @@
+# Build Interactive Learning Path
+
+This command automates the creation of interactive content (`content.json` files) for learning paths in Grafana Pathfinder.
+
+---
+
+## Overview
+
+When a writer runs `/build-interactive-lj`, this command guides them through a 7-step process to create fully functional interactive guides:
+
+1. **Environment Validation** - Verify repos, browser automation, and GitHub CLI
+2. **Learning Path Validation** - Find the learning path and list milestones
+3. **Create Recommender Mapping** - Ensure the learning path appears in Pathfinder (if needed)
+4. **Scaffold Content Files** - Create content.json structure for each milestone
+5. **Selector Discovery** - Find CSS selectors for interactive elements
+6. **Test in Pathfinder** - Collaboratively test each milestone
+7. **Report and Next Steps** - Summarize results and provide PR guidance
+
+**Expected time:** 30-60 minutes depending on the number of milestones.
+
+---
+
+## Critical Rules
+
+### 🚨 CRITICAL TESTING RULE
+
+> During Step 6 (Test in Pathfinder), the AI's ONLY job is to load JSON into the Block Editor. The USER does ALL testing by clicking "Show me", "Do it", and interactive buttons themselves. The AI must NEVER click these buttons.
+
+**Why:** Users can test faster and catch visual/UX issues that automation misses.
+
+### Core Principles
+
+1. **Be autonomous, not interrogative** - Analyze content and make intelligent decisions. Don't ask questions that can be inferred from context.
+2. **Follow steps in order** - Each step has verification built in.
+3. **Test ONE milestone at a time** - Report results, then ASK before testing the next.
+4. **ASK before fixing issues** - Explain the problem and proposed fix, wait for approval.
+5. **Let the user handle git** - Summarize changes, let them decide when to commit.
+6. **Use browser tools for selectors** - ALWAYS inspect the actual DOM with Playwright.
+
+---
+
+## Anti-Patterns (Do NOT)
+
+- ❌ **Do NOT click "Show me", "Do it", or interactive buttons** - User tests, AI waits
+- ❌ **Do NOT ask questions that can be inferred** - Be autonomous (recommender file, URL patterns, platform)
+- ❌ **Do NOT skip any milestones** - EVERY milestone needs a content.json
+- ❌ **Do NOT use placeholder selectors** - Never leave `"[selector]"` or `"TODO"`
+- ❌ **Do NOT guess at selectors** - Always use Playwright to inspect
+- ❌ **Do NOT use `description` field** - Use `content`
+- ❌ **Do NOT use `formvalue` field** - Use `targetvalue`
+- ❌ **Do NOT use position-based selectors** - `:first-of-type`, `:nth-child()` break with data changes
+- ❌ **Do NOT use data-dependent selectors** - Use `^=` starts-with patterns
+- ❌ **Do NOT use non-standard CSS** - `:contains()`, `:has-text()` don't work in Pathfinder
+
+---
+
+## File Structure
+
+```
+.cursor/commands/build-interactive-lj/
+├── README.md                    # This file - main orchestrator
+├── reference/
+│   ├── selector-patterns.md     # Selector discovery rules & stability patterns
+│   ├── json-schema.md           # JSON structure requirements & field reference
+│   └── proven-patterns.md       # Appendix of working patterns for common UI
+└── steps/
+    ├── 01-environment.md        # Environment validation
+    ├── 02-validation.md         # Learning path validation
+    ├── 03-recommender.md        # Create recommender mapping
+    ├── 04-scaffold.md           # Scaffold content files
+    ├── 05-selectors.md          # Selector discovery
+    ├── 06-testing.md            # Test in Pathfinder
+    └── 07-report.md             # Report and next steps
+```
+
+---
+
+## Workflow
+
+### Welcome Message
+
+When a writer runs `/build-interactive-lj`, display:
+
+```
+👋 Welcome to the Interactive Learning Path Builder!
+
+I'm here to help you create interactive content that powers the "Show me" and 
+"Do it" buttons in Grafana Pathfinder. By the end of our session, you'll have 
+fully functional content.json files ready for a PR.
+
+Here's what our session will look like:
+
+1. **Environment check** - Verify your setup is ready (30 seconds)
+2. **Find your learning journey** - Locate source content and list milestones
+3. **Create recommender mapping** - Ensure the journey appears in Pathfinder (if needed)
+4. **Scaffold the files** - Create content.json structure for each milestone
+5. **Discover selectors** - Find CSS selectors for interactive elements
+6. **Test in Pathfinder** - Collaboratively test each milestone
+7. **Wrap up** - Summarize results and provide PR guidance
+
+Expect this to take 30-60 minutes depending on how many milestones your 
+learning journey has. I'll need your attention during testing so you can 
+verify the highlights look right.
+```
+
+### Ask: First Time?
+
+```
+Is this your first time using /build-interactive-lj? (Y/N)
+```
+
+**If YES (Tutorial Mode):**
+```
+Great! I'll walk you through the process step by step.
+
+Before each step, I'll explain what I'm about to do and ask for your 
+confirmation before proceeding. This way you'll understand exactly what's 
+happening and can ask questions along the way.
+
+Ready to get started? (Y/N)
+```
+
+**If NO (Expert Mode):**
+```
+Welcome back! I'll move quickly through the steps.
+
+Ready to get started? (Y/N)
+```
+
+### Ask: Which Learning Path?
+
+```
+Which learning path would you like to make interactive?
+
+Provide the slug (the folder name) from:
+website/content/docs/learning-paths/
+
+Examples: prometheus, github-data-source, mysql-data-source
+```
+
+Wait for the user to provide the learning path slug, then proceed to Step 1.
+
+---
+
+## Executing Steps
+
+For each step, read the corresponding file from `steps/` directory:
+
+- **Step 1:** Read `steps/01-environment.md`
+- **Step 2:** Read `steps/02-validation.md`
+- **Step 3:** Read `steps/03-recommender.md` (only if mapping not found)
+- **Step 4:** Read `steps/04-scaffold.md` and `reference/json-schema.md`
+- **Step 5:** Read `steps/05-selectors.md` and `reference/selector-patterns.md`
+- **Step 6:** Read `steps/06-testing.md`
+- **Step 7:** Read `steps/07-report.md`
+
+**Reference files** can be consulted at any time:
+- `reference/selector-patterns.md` - Selector rules and stability checks
+- `reference/json-schema.md` - JSON structure and field requirements
+- `reference/proven-patterns.md` - Reusable patterns for common UI elements
+
+---
+
+## Quick Reference
+
+### Key Repositories
+- Source: `website/content/docs/learning-paths/[slug]/`
+- Output: `interactive-tutorials/[slug]-lj/`
+- Mapping: `grafana-recommender/internal/configs/state_recommendations/`
+
+### Block Types
+- `markdown` - Explanatory text, no automation
+- `interactive` - Automated actions with "Show me" / "Do it"
+- `multistep` - Sequential navigation (shows "▶ Run N steps")
+- `guided` - User performs manually, no "Do it" button
+
+### Selector Priority
+1. `data-testid` (most stable)
+2. `aria-label`
+3. `href` (for links)
+4. `id`
+5. Stable class (least stable)
+
+**Avoid:** Generic classes, positional selectors, text content

--- a/.cursor/commands/build-interactive-lj/REFACTORING_SUMMARY.md
+++ b/.cursor/commands/build-interactive-lj/REFACTORING_SUMMARY.md
@@ -1,0 +1,158 @@
+# Refactoring Summary: Build Interactive Learning Path Command
+
+## What Changed
+
+The monolithic 1410-line `build-interactive-lj.md` file has been refactored into a modular structure with 11 focused files.
+
+---
+
+## New Structure
+
+```
+.cursor/commands/build-interactive-lj/
+├── README.md                           # Main orchestrator (replaces build-interactive-lj.md)
+├── REFACTORING_SUMMARY.md              # This file
+├── build-interactive-lj.md.backup      # Original file (backup)
+├── reference/                          # Reference documentation
+│   ├── selector-patterns.md            # Selector discovery rules & stability patterns
+│   ├── json-schema.md                  # JSON structure requirements & field reference
+│   └── proven-patterns.md              # Appendix of working patterns for common UI
+└── steps/                              # Step-by-step workflow
+    ├── 01-environment.md               # Environment validation
+    ├── 02-validation.md                # Learning path validation
+    ├── 03-recommender.md               # Create recommender mapping
+    ├── 04-scaffold.md                  # Scaffold content files
+    ├── 05-selectors.md                 # Selector discovery
+    ├── 06-testing.md                   # Test in Pathfinder
+    └── 07-report.md                    # Report and next steps
+```
+
+---
+
+## File Breakdown
+
+### Main Orchestrator
+
+**`README.md`** (replaces `build-interactive-lj.md`)
+- Welcome message and workflow overview
+- Tutorial vs Expert mode logic
+- Quick reference tables
+- Pointers to step and reference files
+- **Lines:** ~250 (down from 1410)
+
+### Reference Documentation
+
+**`reference/selector-patterns.md`**
+- Selector priority order
+- Stability anti-patterns
+- Verification checklist
+- Syntax limitations
+- Lessons learned
+- **Lines:** ~180
+
+**`reference/json-schema.md`**
+- Block types and action types
+- Field reference (correct vs incorrect field names)
+- JSON structure examples
+- Requirements reference
+- Scaffolding rules
+- **Lines:** ~200
+
+**`reference/proven-patterns.md`**
+- Navigation patterns
+- Form patterns
+- Button patterns
+- Link/tile patterns
+- Markdown patterns
+- Integration setup patterns
+- Quick decision guide
+- **Lines:** ~250
+
+### Step Files
+
+Each step file is focused on a single phase of the workflow:
+
+1. **`01-environment.md`** (~40 lines) - Environment validation
+2. **`02-validation.md`** (~40 lines) - Learning path validation
+3. **`03-recommender.md`** (~120 lines) - Create recommender mapping
+4. **`04-scaffold.md`** (~120 lines) - Scaffold content files
+5. **`05-selectors.md`** (~140 lines) - Selector discovery
+6. **`06-testing.md`** (~180 lines) - Test in Pathfinder
+7. **`07-report.md`** (~100 lines) - Report and next steps
+
+---
+
+## Benefits of Modular Structure
+
+### 1. Easier to Maintain
+- Update selector rules without touching workflow steps
+- Modify JSON schema without affecting testing procedures
+- Add new patterns to appendix independently
+
+### 2. Better for AI Agents
+- Load only relevant sections when needed
+- Reduce token usage by reading specific files
+- Clear separation of concerns (reference vs workflow)
+
+### 3. Improved Readability
+- Each file has a single, clear purpose
+- Easier to find specific information
+- Less overwhelming for new users
+
+### 4. Scalable
+- Easy to add new reference documents
+- Can add sub-steps without bloating main files
+- Can create specialized guides (e.g., "Selector Troubleshooting")
+
+---
+
+## How to Use the New Structure
+
+### For AI Agents
+
+When executing `/build-interactive-lj`:
+
+1. **Start:** Read `README.md` for workflow overview
+2. **Step 1-7:** Read corresponding `steps/XX-*.md` file
+3. **Before Step 4:** Read `reference/json-schema.md` and `reference/proven-patterns.md`
+4. **Before Step 5:** Read `reference/selector-patterns.md`
+5. **During Step 6:** Reference `reference/selector-patterns.md` for troubleshooting
+
+### For Humans
+
+- **Quick start:** Read `README.md`
+- **Deep dive on selectors:** Read `reference/selector-patterns.md`
+- **JSON syntax questions:** Read `reference/json-schema.md`
+- **Looking for examples:** Read `reference/proven-patterns.md`
+- **Specific step details:** Read `steps/XX-*.md`
+
+---
+
+## Migration Notes
+
+- Original file backed up as `build-interactive-lj.md.backup`
+- All content preserved, just reorganized
+- No functionality changes, only structural improvements
+- Command invocation remains the same: `/build-interactive-lj`
+
+---
+
+## Next Steps
+
+1. Test the new structure with a learning path build
+2. Verify all cross-references work correctly
+3. Consider adding:
+   - `reference/troubleshooting.md` for common issues
+   - `reference/examples.md` for complete content.json examples
+   - `steps/00-prerequisites.md` for first-time setup
+
+---
+
+## Rollback
+
+If needed, restore the original file:
+
+```bash
+mv build-interactive-lj.md.backup build-interactive-lj.md
+rm -rf reference/ steps/ README.md
+```

--- a/.cursor/commands/build-interactive-lj/build-interactive-lj.md.backup
+++ b/.cursor/commands/build-interactive-lj/build-interactive-lj.md.backup
@@ -1,6 +1,6 @@
-# Build Interactive Learning Journey
+# Build Interactive Learning Path
 
-This command automates the creation of interactive content (`content.json` files) for learning journeys in Grafana Pathfinder.
+This command automates the creation of interactive content (`content.json` files) for learning paths in Grafana Pathfinder.
 
 ---
 
@@ -11,13 +11,14 @@ This command automates the creation of interactive content (`content.json` files
 - [Lessons Learned](#lessons-learned)
 - [Welcome](#welcome)
 - [Ask: First Time?](#ask-first-time)
-- [Ask: Which Learning Journey?](#ask-which-learning-journey)
+- [Ask: Which Learning Path?](#ask-which-learning-path)
 - [Step 1: Environment Validation](#step-1-environment-validation)
-- [Step 2: Learning Journey Validation](#step-2-learning-journey-validation)
-- [Step 3: Scaffold Content Files](#step-3-scaffold-content-files)
-- [Step 4: Selector Discovery](#step-4-selector-discovery)
-- [Step 5: Test in Pathfinder](#step-5-test-in-pathfinder-one-milestone-at-a-time)
-- [Step 6: Report and Next Steps](#step-6-report-and-next-steps)
+- [Step 2: Learning Path Validation](#step-2-learning-path-validation)
+- [Step 3: Create Recommender Mapping](#step-3-create-recommender-mapping-if-needed)
+- [Step 4: Scaffold Content Files](#step-4-scaffold-content-files)
+- [Step 5: Selector Discovery](#step-5-selector-discovery)
+- [Step 6: Test in Pathfinder](#step-6-test-in-pathfinder-one-milestone-at-a-time)
+- [Step 7: Report and Next Steps](#step-7-report-and-next-steps)
 - [Quick Reference](#quick-reference)
 - [Appendix: Proven Patterns](#appendix-proven-patterns)
 
@@ -29,13 +30,13 @@ When executing this command, you MUST follow these principles:
 
 0. **Read and internalize the command file** — Before displaying the welcome message, silently read through this entire command file. Then commit this critical rule to your working memory:
 
-   > **CRITICAL TESTING RULE:** During Step 5 (Test in Pathfinder), the AI's ONLY job is to import JSON into the Block Editor. The USER does ALL testing by clicking "Show me", "Do it", and interactive buttons themselves. The AI must NEVER click these buttons. Wait for user feedback, then fix issues based on what they report.
+   > **CRITICAL TESTING RULE:** During Step 6 (Test in Pathfinder), the AI's ONLY job is to import JSON into the Block Editor. The USER does ALL testing by clicking "Show me", "Do it", and interactive buttons themselves. The AI must NEVER click these buttons. Wait for user feedback, then fix issues based on what they report.
 
    This rule exists because the user can test faster and catch visual/UX issues that automation misses.
 
 1. **Follow steps in order** — Do NOT skip or combine steps. Each step exists for a reason.
 
-2. **Test ONE milestone at a time** — In Step 5, test only ONE milestone, report results, then STOP and ASK the user before testing the next milestone. Do NOT batch test all milestones at once.
+2. **Test ONE milestone at a time** — In Step 6, test only ONE milestone, report results, then STOP and ASK the user before testing the next milestone. Do NOT batch test all milestones at once.
 
 3. **ASK before fixing issues** — When you find a broken selector, STOP, explain the problem, describe the proposed fix, and ASK the user for permission before making changes. Do NOT automatically attempt fixes.
 
@@ -48,11 +49,11 @@ When executing this command, you MUST follow these principles:
 
 6. **Let the user handle git** — Do NOT run `git commit` or `git push`. Summarize changes and let the user decide when to commit.
 
-7. **Ask when uncertain** — If a step is ambiguous or you're unsure how to proceed, ask the user rather than guessing.
+7. **Be autonomous, not interrogative** — Analyze the learning path content and make intelligent decisions. Don't ask the user questions that can be inferred from context (e.g., which recommender file, URL patterns, platform). Just do the work and show them the result.
 
-8. **Re-read before critical steps** — Before Step 3 (Scaffolding), re-read the "JSON Schema Requirements" section. Before Step 4 (Selector Discovery), re-read the "Selector Priority" table.
+8. **Re-read before critical steps** — Before Step 4 (Scaffolding), re-read the "JSON Schema Requirements" section. Before Step 5 (Selector Discovery), re-read the "Selector Priority" table.
 
-9. **Reference the appendix** — Before scaffolding any LJ, consult "Appendix: Proven Patterns" for reusable JSON structures. Apply patterns that match your LJ's UI elements.
+9. **Reference the appendix** — Before scaffolding any learning path, consult "Appendix: Proven Patterns" for reusable JSON structures. Apply patterns that match your learning path's UI elements.
 
 10. **ALWAYS use browser tools for selectors** — You MUST use Playwright to discover selectors by inspecting the actual DOM. NEVER guess selectors or copy them from the appendix without verifying they exist on the current page. The appendix shows patterns; browser inspection confirms reality.
 
@@ -69,6 +70,7 @@ These are common mistakes. Avoid them:
 - ❌ **Do NOT automatically fix broken selectors** — When you find an issue, STOP, explain the problem, describe your proposed fix, and ASK for permission before making changes. The user needs visibility into what's happening.
 - ❌ **Do NOT skip the welcome message** — It sets expectations for the session
 - ❌ **Do NOT combine multiple steps** — Each step has verification built in
+- ❌ **Do NOT skip any milestones during scaffolding** — EVERY milestone needs a content.json, even conceptual/intro/conclusion pages. Use markdown blocks for non-interactive content.
 - ❌ **Do NOT create content.json without reading source markdown first** — You need context
 - ❌ **Do NOT use placeholder selectors** — Never leave `"[selector]"` or `"TODO"` in files
 - ❌ **Do NOT proceed to testing with empty selectors** — All selectors must be discovered first
@@ -168,7 +170,7 @@ Some UI patterns are better documented as markdown instructions rather than auto
 
 ### Integration-Specific Notes
 
-For **integration setup flows** (Linux, Windows, macOS, MySQL, etc.):
+For **integration setup learning paths** (Linux, Windows, macOS, MySQL, etc.):
 - The "Run Grafana Alloy" expand button works: `[data-testid="agent-config-button"]`
 - Token creation and "Test connection" buttons are conditional — use markdown
 - "Install" button for dashboards/alerts works: `action: "button"` with `reftarget: "Install"`
@@ -180,7 +182,7 @@ For **integration setup flows** (Linux, Windows, macOS, MySQL, etc.):
 When a writer runs `/build-interactive-lj`, display this welcome:
 
 ```
-👋 Welcome to the Interactive Learning Journey Builder!
+👋 Welcome to the Interactive Learning Path Builder!
 
 I'm here to help you create interactive content that powers the "Show me" and 
 "Do it" buttons in Grafana Pathfinder. By the end of our session, you'll have 
@@ -192,7 +194,8 @@ Here's what our session will look like:
    automation, GitHub CLI). Takes about 30 seconds.
 
 2. **Find your learning journey** — I'll locate the source content and list 
-   all the milestones we'll be making interactive.
+   all the milestones we'll be making interactive. If needed, I'll also create 
+   a recommender mapping so the journey appears in Pathfinder.
 
 3. **Scaffold the files** — I'll create the content.json structure for each 
    milestone, converting your markdown steps into interactive blocks.
@@ -251,18 +254,18 @@ Wait for confirmation.
 
 ---
 
-## Ask: Which Learning Journey?
+## Ask: Which Learning Path?
 
 ```
-Which learning journey would you like to make interactive?
+Which learning path would you like to make interactive?
 
 Provide the slug (the folder name) from:
-website/content/docs/learning-journeys/
+website/content/docs/learning-paths/
 
 Examples: prometheus, github-data-source, mysql-data-source
 ```
 
-Wait for the user to provide the LJ slug, then proceed to Step 1.
+Wait for the user to provide the learning path slug, then proceed to Step 1.
 
 ---
 
@@ -308,14 +311,14 @@ Check these and display results:
 
 ---
 
-## Step 2: Learning Journey Validation
+## Step 2: Learning Path Validation
 
 ### Tutorial Mode Introduction
 
 ```
-**Step 2: Learning Journey Validation**
+**Step 2: Learning Path Validation**
 
-I'll locate the "[slug]" learning journey and:
+I'll locate the "[slug]" learning path and:
 - Find all milestones (the steps users complete)
 - Check if it's mapped in the recommender (so it appears in Pathfinder)
 
@@ -330,13 +333,13 @@ Validate immediately without introduction.
 
 ### Validate
 
-1. Find source: `website/content/docs/learning-journeys/[slug]/`
+1. Find source: `website/content/docs/learning-paths/[slug]/`
 2. List all milestones found
 3. Search `grafana-recommender` for mapping rules
 
 **Display:**
 ```
-Found learning journey: [title]
+Found learning path: [title]
 
 Milestones:
 1. [milestone-1-title] (milestone-1-slug)
@@ -348,17 +351,121 @@ Recommender mapping: ✅ Found / ❌ Not found
 
 **On success:**
 ```
-✅ Learning journey validated. Ready to scaffold [N] milestones.
+✅ Learning path validated. Ready to scaffold [N] milestones.
 ```
 
 ---
 
-## Step 3: Scaffold Content Files
+## Step 3: Create Recommender Mapping (if needed)
+
+### When to Run This Step
+
+Only run this step if Step 2 reported: **Recommender mapping: ❌ Not found**
+
+If the mapping was found (✅), skip to Step 4.
+
+### Autonomous Mapping Creation
+
+**Automatically analyze the learning path and create the mapping without asking questions.**
+
+**Decision logic:**
+
+1. **Recommender file** - Infer from the learning path's primary context:
+   - Data source setup/connection → `connections-cloud.json` or `connections-oss.json`
+   - Dashboard creation/visualization → `dashboards-cloud.json` or `dashboards-oss.json`
+   - Query/exploration → `explore-cloud.json` or `explore-oss.json`
+   - Alerting → `alerting-cloud.json` or `alerting-oss.json`
+   - Observability features → `observability-cloud.json` or `observability-oss.json`
+
+2. **URL pattern** - Infer from the learning path content:
+   - If it mentions specific data source type → `/connections/datasources/[type]`
+   - If it's about dashboards → `/dashboards`
+   - If it's about exploration → `/explore`
+   - If it's about a specific app plugin → `/a/[plugin-id]`
+   - Default for dashboards → `/dashboards`
+
+3. **Target platform** - Determine from the learning path:
+   - Mentions "Grafana Cloud" throughout → Cloud only
+   - Mentions "self-hosted" or "OSS" → OSS only
+   - Generic/works for both → Both platforms
+
+### Create Mapping Entry
+
+Automatically create the mapping JSON:
+
+**For Cloud:**
+- File: `grafana-recommender/internal/configs/state_recommendations/[area]-cloud.json`
+
+**For OSS:**
+- File: `grafana-recommender/internal/configs/state_recommendations/[area]-oss.json`
+
+**For Both:**
+- Add to both `-cloud.json` and `-oss.json` files
+
+**Mapping JSON structure:**
+
+```json
+{
+  "title": "[Learning path title from _index.md]",
+  "url": "https://grafana.com/docs/learning-paths/[slug]/",
+  "description": "Step-by-step guide: [Learning path title].",
+  "type": "learning-journey",
+  "match": {
+    "and": [
+      {
+        "urlPrefix": "[url-pattern]"
+      },
+      {
+        "targetPlatform": "cloud" // or "oss"
+      }
+    ]
+  }
+}
+```
+
+### Insert Mapping
+
+1. Read the target recommender file(s)
+2. Parse the JSON
+3. Find an appropriate location in the `rules` array (group with similar learning journeys)
+4. Insert the new mapping entry
+5. Write the updated JSON back to the file
+6. Validate JSON syntax
+
+**Display:**
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+✅ Step 3 complete: Recommender Mapping Created
+
+Added mapping to:
+├── grafana-recommender/internal/configs/state_recommendations/[file].json
+
+Mapping details:
+├── Title: [title]
+├── URL pattern: [pattern]
+├── Platform: [cloud/oss/both]
+└── Context: [area]
+
+⏳ Next: Step 4 - Scaffold Content Files
+   Ready to proceed? (Y/n)
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+
+### Important Notes
+
+- **JSON formatting:** Maintain consistent indentation (2 spaces) and formatting
+- **Placement:** Insert learning-journey entries near other learning journeys in the file
+- **Validation:** After editing, validate JSON syntax before proceeding
+- **Multiple platforms:** If "Both" is selected, ensure entries are identical except for `targetPlatform`
+
+---
+
+## Step 4: Scaffold Content Files
 
 ### Tutorial Mode Introduction
 
 ```
-**Step 3: Scaffold Content Files**
+**Step 4: Scaffold Content Files**
 
 I'll create the content.json structure for each milestone:
 - Read the source markdown from the website repo
@@ -379,28 +486,46 @@ Scaffold immediately without introduction.
 > 💡 **Before scaffolding:** See "Appendix: Proven Patterns" for reusable JSON structures 
 > that match common Grafana UI elements (navigation, forms, buttons, etc.).
 
-### Which Milestones Need content.json?
+### CRITICAL: Scaffold ALL Milestones
 
-**Create content.json for milestones that have:**
-- Numbered steps telling users to click, navigate, or interact with the Grafana UI
-- Form inputs, button clicks, or menu navigation
-- Any action that can be highlighted with "Show me" or automated with "Do it"
+**You MUST create content.json for EVERY milestone in the learning path.**
 
-**Skip milestones that are:**
-- Purely conceptual/educational (e.g., "Why alerting matters")
-- Introduction or overview pages with no UI actions
-- Conclusion/outro pages (e.g., "Congratulations, you completed...")
-- External-only actions (e.g., "Run this command on your server")
+This includes:
+- ✅ Milestones with interactive UI steps (use `interactive` blocks)
+- ✅ Purely conceptual/educational milestones (use `markdown` blocks)
+- ✅ Introduction or overview pages (use `markdown` blocks)
+- ✅ Conclusion/outro pages (use `markdown` blocks)
+- ✅ External-only actions (use `markdown` or `guided` blocks)
 
-**Quick test:** If the milestone has no numbered steps that reference clicking something in Grafana, skip it.
+**Why scaffold everything?**
+- Pathfinder needs a content.json for every milestone to track progress through the learning path
+- Even non-interactive milestones need to be represented so users can mark them complete
+- Skipping milestones breaks the learning path flow
 
-For each milestone that qualifies:
-1. Read `website/content/docs/learning-journeys/[slug]/[milestone]/index.md`
+**For each milestone:**
+1. Read `website/content/docs/learning-paths/[slug]/[milestone]/index.md`
 2. Create `interactive-tutorials/[slug]-lj/[milestone]/content.json`
 3. Convert content using these rules:
-   - Numbered steps → `interactive` blocks with `action: "highlight"` and empty `reftarget`
-   - Explanatory text → `markdown` blocks
-   - Sequential navigation steps (e.g., "Navigate to X > Y > Z") → `multistep` blocks
+
+**For milestones WITH interactive UI steps:**
+- Numbered steps that reference Grafana UI → `interactive` blocks with `action: "highlight"` and empty `reftarget`
+- Sequential navigation steps (e.g., "Navigate to X > Y > Z") → `multistep` blocks
+- Explanatory text between steps → `markdown` blocks
+
+**For milestones WITHOUT interactive UI steps (conceptual/intro/conclusion):**
+- Convert ALL content to `markdown` blocks
+- Use a single markdown block with the full milestone content
+- Example structure:
+  ```json
+  {
+    "blocks": [
+      {
+        "type": "markdown",
+        "content": "[Full milestone content converted from markdown]"
+      }
+    ]
+  }
+  ```
 
 ### JSON Schema Requirements
 
@@ -518,7 +643,7 @@ Before proceeding to Step 4, verify EACH content.json file:
 **Display (use this exact format):**
 ```
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-✅ Step 3 complete: Scaffold
+✅ Step 4 complete: Scaffold
 
 Created [N] content.json files:
 ├── [slug]-lj/milestone-1/content.json ([N] blocks)
@@ -527,14 +652,14 @@ Created [N] content.json files:
 
 Verification: All checks passed ✓
 
-⏳ Next: Step 4 - Selector Discovery
+⏳ Next: Step 5 - Selector Discovery
    Ready to open the test environment?
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
 ---
 
-## Step 4: Selector Discovery
+## Step 5: Selector Discovery
 
 ### Re-Read Before Starting
 
@@ -545,7 +670,7 @@ You MUST try selectors in this order: data-testid → aria-label → href → id
 
 Selector discovery happens by walking through the actual Grafana UI at: `https://learn.grafana-ops.net/`
 
-> ⚠️ **Important:** This is different from testing in Pathfinder (Step 5), which uses 
+> ⚠️ **Important:** This is different from testing in Pathfinder (Step 6), which uses 
 > `https://learn.grafana-ops.net/?pathfinder-dev=true`
 
 Playwright opens a **fresh browser with no session**. Before discovering selectors:
@@ -553,7 +678,7 @@ Playwright opens a **fresh browser with no session**. Before discovering selecto
 1. **Navigate to the test environment** using Playwright: `https://learn.grafana-ops.net/`
 2. **User must manually log in** through the Playwright browser window (Okta SAML)
 3. **Wait for user confirmation** that they are logged in
-4. **Walk through the UI flow** — navigate to pages where the LJ actions happen and inspect the DOM
+4. **Walk through the UI flow** — navigate to pages where the learning path actions happen and inspect the DOM
 
 > ⚠️ **The AI cannot log the user in** — authentication requires manual user action 
 > in the Playwright-controlled browser window.
@@ -570,7 +695,7 @@ Please log in when the browser window appears. Let me know when you're logged in
 ### Tutorial Mode Introduction
 
 ```
-**Step 4: Selector Discovery**
+**Step 5: Selector Discovery**
 
 I'll use browser automation to find selectors for each interactive element:
 - Navigate to the relevant Grafana pages
@@ -592,7 +717,7 @@ Discover immediately without introduction.
 
 Walk through the actual Grafana UI at `https://learn.grafana-ops.net/` to find selectors:
 
-1. Navigate to the starting page for the LJ (e.g., Dashboards page for dashboard creation flows)
+1. Navigate to the starting page for the learning path (e.g., Dashboards page for dashboard creation flows)
 2. For each interactive block with empty `reftarget`:
    - Navigate to the relevant page in Grafana
    - Use Playwright snapshot to inspect the DOM
@@ -646,7 +771,7 @@ Before proceeding to Step 5, verify:
 **Display (use this exact format):**
 ```
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-✅ Step 4 complete: Selector Discovery
+✅ Step 5 complete: Selector Discovery
 
 Results by milestone:
 ├── [milestone-1]: [N] selectors found
@@ -658,20 +783,20 @@ Selector quality:
 ├── 🟡 Medium confidence: [N]
 └── 🔴 Failed/needs review: [N]
 
-⏳ Next: Step 5 - Test in Pathfinder
+⏳ Next: Step 6 - Test in Pathfinder
    Ready to test? (Y/n)
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
 ---
 
-## Step 5: Test in Pathfinder (Collaborative Testing)
+## Step 6: Test in Pathfinder (Collaborative Testing)
 
 ### Access the Block Editor
 
 Testing happens in **Pathfinder Dev Mode** at: `https://learn.grafana-ops.net/?pathfinder-dev=true`
 
-> ⚠️ **Important:** This is different from selector discovery (Step 4), which uses 
+> ⚠️ **Important:** This is different from selector discovery (Step 5), which uses 
 > `https://learn.grafana-ops.net/` to walk through the actual UI.
 
 Dev mode must be enabled before you can access the Block Editor. If this is the user's first time, direct them to SETUP.md section 4.
@@ -720,7 +845,7 @@ Testing is a **collaborative process** where AI and user work together:
 ### Tutorial Mode Introduction
 
 ```
-**Step 5: Test in Pathfinder**
+**Step 6: Test in Pathfinder**
 
 We'll test collaboratively ONE MILESTONE AT A TIME:
 - I'll load the content.json and switch to Preview mode
@@ -743,7 +868,12 @@ Same behavior — load milestone, user tests, fix issues as reported.
 
 1. Navigate to `https://learn.grafana-ops.net/?pathfinder-dev=true` (if not already there)
 2. Open the Block Editor from the Pathfinder sidebar (Dev tools → Interactive guide editor)
-3. Import the content.json for THIS milestone only
+3. **Load the JSON using "Edit JSON" method:**
+   - Click "Start new guide" to clear the editor (if needed)
+   - Click "Edit JSON" button
+   - Read the content.json file for this milestone
+   - Use browser automation to paste the JSON into the editor
+   - Save/apply the JSON
 4. Switch to Preview mode
 5. **Tell user: "Ready for testing! Please click through the Show me / Do it buttons and let me know what works and what doesn't."**
 6. **STOP. WAIT. Do nothing until the user responds.** — The AI must NOT click any buttons.
@@ -751,6 +881,8 @@ Same behavior — load milestone, user tests, fix issues as reported.
 8. After user confirms milestone passes, **ASK** before loading next milestone
 
 > ⚠️ **Reminder:** After step 5, the AI's job is done until the user provides feedback. Do not proceed, do not click buttons, do not test. Just wait.
+
+> 💡 **Technical note:** Use "Edit JSON" button instead of "Import JSON guide" to avoid file upload dialogs. The Edit JSON approach allows direct text input via browser automation.
 
 ---
 
@@ -826,7 +958,7 @@ Only after all milestones have been tested and user has confirmed each one:
 
 ```
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-✅ Step 5 Complete: All Milestones Tested
+✅ Step 6 Complete: All Milestones Tested
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
 Milestones tested: [N]/[N]
@@ -835,19 +967,19 @@ Milestones tested: [N]/[N]
 ├── [milestone-3]: 🟡 [N] blocks needed fixes
 └── [milestone-4]: ✅ All blocks passed
 
-Proceeding to Step 6: Final Summary...
+Proceeding to Step 7: Final Summary...
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
 ---
 
-## Step 6: Report and Next Steps
+## Step 7: Report and Next Steps
 
 ### Summary (use this exact format)
 
 ```
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-🎉 BUILD COMPLETE: [slug] Interactive LJ
+🎉 BUILD COMPLETE: [slug] Interactive Learning Path
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
 RESULTS
@@ -868,7 +1000,7 @@ ISSUES FILED (if any)
 NEXT STEPS
 1. Review the content.json files in your editor
 2. Stage files: git add [slug]-lj/
-3. Commit with message: "Add interactive content for [slug] LJ"
+3. Commit with message: "Add interactive content for [slug] learning path"
 4. Push and create PR
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
@@ -884,7 +1016,7 @@ Would you like a Slack-ready summary? (Y/n)
 
 If yes, display:
 ```
-🎯 Interactive LJ complete: [slug]
+🎯 Interactive learning path complete: [slug]
 ✅ [N]/[N] milestones interactive
 📝 [N] issues filed for broken selectors
 🔗 Ready for PR
@@ -896,7 +1028,7 @@ When the user asks for a PR description, ALWAYS provide it in a markdown code bl
 
 ````
 ```markdown
-## Add interactive content for `[slug]` learning journey
+## Add interactive content for `[slug]` learning path
 
 ### Summary
 
@@ -921,7 +1053,7 @@ When the user asks for a PR description, ALWAYS provide it in a markdown code bl
 
 ### Related
 
-- Learning journey: `/docs/learning-journeys/[slug]/`
+- Learning path: `/docs/learning-paths/[slug]/`
 ```
 ````
 
@@ -936,7 +1068,7 @@ Use this template:
 ```
 gh issue create \
   --repo grafana/interactive-tutorials \
-  --title "[Selector] [element] in [LJ name]" \
+  --title "[Selector] [element] in [learning path name]" \
   --body "## Element
 [Description of the UI element]
 
@@ -956,7 +1088,7 @@ gh issue create \
 ## Quick Reference
 
 ### Key Files
-- Source: `website/content/docs/learning-journeys/[slug]/`
+- Source: `website/content/docs/learning-paths/[slug]/`
 - Output: `interactive-tutorials/[slug]-lj/`
 - Mapping: `grafana-recommender/internal/configs/`
 
@@ -1225,7 +1357,7 @@ When user needs to verify something worked:
 
 ### Integration Setup Patterns
 
-These patterns are specific to integration/data source setup LJs (Linux, Windows, macOS, MySQL, etc.):
+These patterns are specific to integration/data source setup learning paths (Linux, Windows, macOS, MySQL, etc.):
 
 #### Alloy Installation Expand Button
 

--- a/.cursor/commands/build-interactive-lj/reference/json-schema.md
+++ b/.cursor/commands/build-interactive-lj/reference/json-schema.md
@@ -1,0 +1,286 @@
+# JSON Schema Requirements
+
+This document defines the structure and field requirements for `content.json` files.
+
+---
+
+## Root-Level Schema (REQUIRED)
+
+**CRITICAL:** Every `content.json` file MUST include these top-level fields:
+
+```json
+{
+  "schemaVersion": "1.0.0",
+  "id": "[learning-path-slug]-[milestone-slug]",
+  "title": "[Milestone Title]",
+  "blocks": [
+    // ... content blocks here
+  ]
+}
+```
+
+### Field Specifications:
+
+| Field | Type | Required | Description | Example |
+|-------|------|----------|-------------|---------|
+| `schemaVersion` | string | ✅ Yes | Always `"1.0.0"` | `"1.0.0"` |
+| `id` | string | ✅ Yes | Format: `[learning-path-slug]-[milestone-slug]` (kebab-case) | `"billing-usage-navigate-to-billing-dashboard"` |
+| `title` | string | ✅ Yes | Human-readable milestone title from source markdown | `"Navigate to the billing dashboard"` |
+| `blocks` | array | ✅ Yes | Array of content blocks (see below) | `[{...}, {...}]` |
+
+### Complete Example:
+
+```json
+{
+  "schemaVersion": "1.0.0",
+  "id": "billing-usage-business-value",
+  "title": "Understand the business value",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "Understanding your Grafana Cloud billing and usage..."
+    },
+    {
+      "type": "interactive",
+      "action": "highlight",
+      "reftarget": "a[href='/dashboards']",
+      "content": "Navigate to **Dashboards**."
+    }
+  ]
+}
+```
+
+---
+
+## Block Types
+
+| Type | Purpose | Has "Do it"? | When to Use |
+|------|---------|--------------|-------------|
+| `markdown` | Explanatory text, instructions | No | Conceptual content, external actions, conditional UI |
+| `interactive` | Automated actions with "Show me" / "Do it" | Yes | Single UI interactions (click, fill, hover) |
+| `multistep` | Sequential navigation (shows "▶ Run N steps") | Yes | Multi-step navigation through menus |
+| `guided` | User performs manually, no automation | No | Manual actions that can't be automated |
+
+---
+
+## Interactive Action Types
+
+| Action | Use Case | `reftarget` Value | Additional Fields |
+|--------|----------|-------------------|-------------------|
+| `highlight` | Click element by CSS selector | CSS selector | - |
+| `button` | Click button by visible text | Button text | - |
+| `formfill` | Enter text in field | CSS selector | `targetvalue` |
+| `hover` | Reveal hover-dependent UI | CSS selector | - |
+| `navigate` | Change pages | URL path | - |
+
+---
+
+## Field Reference
+
+### IMPORTANT: Use Correct Field Names
+
+**Common mistakes to avoid:**
+- ❌ `description` → ✅ `content`
+- ❌ `formvalue` → ✅ `targetvalue`
+- ❌ `title` on interactive blocks (not needed)
+
+---
+
+## JSON Structure Examples
+
+### Highlight Action (Correct)
+
+```json
+{
+  "type": "interactive",
+  "action": "highlight",
+  "reftarget": "[data-testid=\"my-element\"]",
+  "content": "Click **Button** to do the thing.",
+  "requirements": ["exists-reftarget"]
+}
+```
+
+### Button Action (Correct)
+
+Uses button text, not CSS selector:
+
+```json
+{
+  "type": "interactive",
+  "action": "button",
+  "reftarget": "Install",
+  "content": "Click **Install** to add the dashboards.",
+  "requirements": ["exists-reftarget"]
+}
+```
+
+### Formfill Action (Correct)
+
+```json
+{
+  "type": "interactive",
+  "action": "formfill",
+  "reftarget": "[aria-label=\"Search connections by name\"]",
+  "targetvalue": "value to enter",
+  "content": "Enter the value.",
+  "requirements": ["exists-reftarget"]
+}
+```
+
+### Hover Action (Correct)
+
+For revealing hover-dependent UI:
+
+```json
+{
+  "type": "interactive",
+  "action": "hover",
+  "reftarget": "[data-testid=\"hover-target\"]",
+  "content": "Hover over this element to reveal options.",
+  "requirements": ["exists-reftarget"]
+}
+```
+
+### Multistep Block (Correct)
+
+For navigation sequences:
+
+```json
+{
+  "type": "multistep",
+  "content": "Navigate to **X > Y > Z**.",
+  "requirements": ["navmenu-open"],
+  "steps": [
+    { "action": "highlight", "reftarget": "[aria-label=\"Expand section: Connections\"]" },
+    { "action": "highlight", "reftarget": "a[href=\"/connections/add-new-connection\"]" }
+  ]
+}
+```
+
+### Guided Block (Correct)
+
+User performs action manually, no "Do it" button:
+
+```json
+{
+  "type": "guided",
+  "content": "Copy the installation command and run it on your server.",
+  "requirements": []
+}
+```
+
+### Markdown Block (Correct)
+
+```json
+{
+  "type": "markdown",
+  "content": "This is explanatory text. Use markdown formatting:\n\n- Bullet points\n- **Bold text**\n- `Code snippets`"
+}
+```
+
+---
+
+## Requirements Reference
+
+| Requirement | When to Use | Auto-Applied? |
+|-------------|-------------|---------------|
+| `exists-reftarget` | Any DOM interaction (highlight, formfill, button, hover) | ✅ Yes (don't add manually) |
+| `navmenu-open` | Navigation menu elements (ensures menu is expanded) | No |
+| `on-page:/path` | Page-specific actions (checks current URL) | No |
+| `section-completed:id` | Sequential dependencies between sections | No |
+| `is-admin` | Admin-only features | No |
+| `has-datasource:type` | When a specific data source is needed | No |
+| `has-plugin:id` | When a specific plugin must be installed | No |
+
+> ⚠️ **Important:** `exists-reftarget` is auto-applied by Pathfinder. Never add it manually to interactive blocks.
+
+---
+
+## When to Use Markdown Instead of Interactive
+
+Some steps are better as plain `markdown` blocks rather than `interactive`:
+
+| Scenario | Why Markdown is Better |
+|----------|------------------------|
+| Steps inside dialogs that require prior user actions | Dialog may not exist yet; automation will fail |
+| External actions (run command on another machine) | Can't automate outside the browser |
+| Conditional UI (create new vs use existing) | Multiple paths; can't predict user's choice |
+| Complex multi-option flows | Better to explain options than force one path |
+| Steps after external verification | User must complete real-world action first |
+
+### Example from Windows Integration
+
+The "Test Alloy connection" button only appears after the user has actually installed Alloy on their Windows machine. Since automation can't do that, the step is markdown:
+
+```json
+{
+  "type": "markdown",
+  "content": "After installing Alloy, click **Test Alloy connection** to verify the installation."
+}
+```
+
+---
+
+## Scaffolding Rules
+
+### CRITICAL: Scaffold ALL Milestones
+
+**You MUST create content.json for EVERY milestone in the learning path.**
+
+This includes:
+- ✅ Milestones with interactive UI steps (use `interactive` blocks)
+- ✅ Purely conceptual/educational milestones (use `markdown` blocks)
+- ✅ Introduction or overview pages (use `markdown` blocks)
+- ✅ Conclusion/outro pages (use `markdown` blocks)
+- ✅ External-only actions (use `markdown` or `guided` blocks)
+
+**Why scaffold everything?**
+- Pathfinder needs a content.json for every milestone to track progress through the learning path
+- Even non-interactive milestones need to be represented so users can mark them complete
+- Skipping milestones breaks the learning path flow
+
+### For Milestones WITH Interactive UI Steps:
+
+- Numbered steps that reference Grafana UI → `interactive` blocks with `action: "highlight"` and empty `reftarget`
+- Sequential navigation steps (e.g., "Navigate to X > Y > Z") → `multistep` blocks
+- Explanatory text between steps → `markdown` blocks
+
+### For Milestones WITHOUT Interactive UI Steps:
+
+Convert ALL content to `markdown` blocks with proper root-level schema:
+
+```json
+{
+  "schemaVersion": "1.0.0",
+  "id": "learning-path-milestone-slug",
+  "title": "Milestone Title",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "[Full milestone content converted from markdown]"
+    }
+  ]
+}
+```
+
+---
+
+## Verification Checklist
+
+Before proceeding to selector discovery, verify EACH content.json file:
+
+### Root-Level Schema:
+- [ ] File includes `"schemaVersion": "1.0.0"` at root level
+- [ ] File includes `"id"` field with format `[learning-path-slug]-[milestone-slug]`
+- [ ] File includes `"title"` field with human-readable milestone title
+- [ ] File includes `"blocks"` array at root level
+
+### Block-Level Requirements:
+- [ ] Every block has a `"type"` field
+- [ ] Instruction text uses `"content"` (NOT `"description"`)
+- [ ] Formfill actions use `"targetvalue"` (NOT `"formvalue"`)
+- [ ] Navigation steps use `"multistep"` blocks
+- [ ] Interactive blocks do NOT have `"requirements": ["exists-reftarget"]` (it's auto-applied)
+- [ ] Interactive blocks have empty `"reftarget": ""` (selectors added in Step 5)
+
+**If any check fails, fix before continuing.**

--- a/.cursor/commands/build-interactive-lj/reference/proven-patterns.md
+++ b/.cursor/commands/build-interactive-lj/reference/proven-patterns.md
@@ -1,0 +1,280 @@
+# Proven Patterns - Appendix
+
+Reusable JSON structures for common Grafana UI elements. These were validated through real testing.
+
+> ⚠️ **IMPORTANT:** These are **templates**, not copy-paste solutions. You MUST use Playwright 
+> browser tools to verify each selector exists on the actual page before using it. Selectors 
+> can change between Grafana versions.
+
+---
+
+## Navigation Patterns
+
+### Multi-Level Menu Navigation
+
+Use `multistep` with `data-testid` nav links for **2-level navigation** (parent → child). Multisteps highlight each step, then click, allowing the nav section to expand before the next step.
+
+```json
+{
+  "type": "multistep",
+  "content": "Navigate to **Drilldown > Logs** from the main menu.",
+  "requirements": ["navmenu-open"],
+  "steps": [
+    { "action": "highlight", "reftarget": "a[data-testid='data-testid Nav menu item'][href='/drilldown']" },
+    { "action": "highlight", "reftarget": "a[data-testid='data-testid Nav menu item'][href='/a/grafana-lokiexplore-app/explore']" }
+  ]
+}
+```
+
+> ✅ **Why this pattern works:**
+> - Uses `data-testid` (stable, intentional test hook)
+> - Uses `href` (predictable routes)
+> - Works whether menu sections are expanded or collapsed
+> - Multisteps are inherently highlight-only; Pathfinder handles the click timing
+
+### Multi-Level Navigation Works Reliably
+
+Even deeply nested paths like **Administration > Plugins and data > Plugins** work with multisteps:
+
+```json
+{
+  "type": "multistep",
+  "content": "Navigate to **Administration > Plugins and data > Plugins**.",
+  "steps": [
+    { "action": "highlight", "reftarget": "a[data-testid='data-testid Nav menu item'][href='/admin']" },
+    { "action": "highlight", "reftarget": "a[data-testid='data-testid Nav menu item'][href='/admin/plugins']" },
+    { "action": "highlight", "reftarget": "a[data-testid='data-testid Nav menu item'][href='/plugins']" }
+  ],
+  "requirements": ["navmenu-open"]
+}
+```
+
+> ❌ **Don't use expand button selectors** (`button[aria-label*='section:']`)
+> 
+> Expand buttons **toggle** state — they collapse if already expanded. This breaks navigation when the section is already in the "wrong" state. Always use link selectors instead.
+
+### Common Navigation Selectors
+
+| Destination | href | Full Selector |
+|-------------|------|---------------|
+| Connections | `/connections` | `a[data-testid='data-testid Nav menu item'][href='/connections']` |
+| Alerts & IRM | `/alerts-and-incidents` | `a[data-testid='data-testid Nav menu item'][href='/alerts-and-incidents']` |
+| Alerting | `/alerting` | `a[data-testid='data-testid Nav menu item'][href='/alerting']` |
+| Alert rules | `/alerting/list` | `a[data-testid='data-testid Nav menu item'][href='/alerting/list']` |
+| Dashboards | `/dashboards` | `a[data-testid='data-testid Nav menu item'][href='/dashboards']` |
+| Explore | `/explore` | `a[data-testid='data-testid Nav menu item'][href='/explore']` |
+| Add new connection | `/connections/add-new-connection` | `a[data-testid='data-testid Nav menu item'][href='/connections/add-new-connection']` |
+| Data sources | `/connections/datasources` | `a[data-testid='data-testid Nav menu item'][href='/connections/datasources']` |
+| Observability | `/observability` | `a[data-testid='data-testid Nav menu item'][href='/observability']` |
+| Application (App O11y) | `/a/grafana-app-observability-app` | `a[data-testid='data-testid Nav menu item'][href='/a/grafana-app-observability-app']` |
+
+---
+
+## Form Patterns
+
+### Search/Filter Input
+
+ALWAYS use `aria-label` for search inputs, NOT `placeholder`:
+
+```json
+{
+  "type": "interactive",
+  "action": "formfill",
+  "reftarget": "[aria-label=\"Search [description]\"]",
+  "targetvalue": "[search term]",
+  "content": "In the search box, type **[term]** to filter the results.",
+  "requirements": ["exists-reftarget"]
+}
+```
+
+**Why:** `placeholder` text can change; `aria-label` is more stable.
+
+### Text Input Fields
+
+For labeled form fields:
+
+```json
+{
+  "type": "interactive",
+  "action": "formfill",
+  "reftarget": "[aria-label=\"[Field label]\"]",
+  "targetvalue": "[value]",
+  "content": "Enter **[value]** in the [field name] field.",
+  "requirements": ["exists-reftarget"]
+}
+```
+
+---
+
+## Button Patterns
+
+### Button by Text (Stable Text)
+
+When a button has consistent, visible text:
+
+```json
+{
+  "type": "interactive",
+  "action": "button",
+  "reftarget": "[Button Text]",
+  "content": "Click **[Button Text]** to [action].",
+  "requirements": ["exists-reftarget"]
+}
+```
+
+**Examples:** "Install", "Save", "Create", "Add", "Apply"
+
+### Button by data-testid (Preferred)
+
+When a button has a `data-testid` attribute:
+
+```json
+{
+  "type": "interactive",
+  "action": "highlight",
+  "reftarget": "[data-testid=\"[testid-value]\"]",
+  "content": "Click **[Button name]** to [action].",
+  "requirements": ["exists-reftarget"]
+}
+```
+
+### Icon-Only Button
+
+For buttons with only an icon (no text), use `aria-label`:
+
+```json
+{
+  "type": "interactive",
+  "action": "highlight",
+  "reftarget": "[aria-label=\"[Action description]\"]",
+  "content": "Click the **[icon name]** icon to [action].",
+  "requirements": ["exists-reftarget"]
+}
+```
+
+---
+
+## Link/Tile Patterns
+
+### Card or Tile Selection
+
+For clickable cards/tiles with href:
+
+```json
+{
+  "type": "interactive",
+  "action": "highlight",
+  "reftarget": "a[href=\"/[path]\"]",
+  "content": "Click the **[Tile name]** tile to select it.",
+  "requirements": ["exists-reftarget"]
+}
+```
+
+---
+
+## Markdown Patterns
+
+### Conditional UI (Multiple Paths)
+
+When user must choose between options:
+
+```json
+{
+  "type": "markdown",
+  "content": "**Choose your option:**\n\n- **Option A**: [description]\n- **Option B**: [description]"
+}
+```
+
+**Why:** Can't predict user's choice.
+
+### External Actions
+
+When user must do something outside the browser:
+
+```json
+{
+  "type": "markdown",
+  "content": "**On your machine:**\n\n1. [Step 1]\n2. [Step 2]\n3. [Step 3]"
+}
+```
+
+**Why:** Can't automate outside the browser.
+
+### Conditional Buttons
+
+When a button only appears after user completes a prior action:
+
+```json
+{
+  "type": "markdown",
+  "content": "After [completing the action], click **[Button]** to continue."
+}
+```
+
+**Why:** Button may not exist when automation runs.
+
+### Verification/Confirmation Steps
+
+When user needs to verify something worked:
+
+```json
+{
+  "type": "markdown",
+  "content": "If successful, you'll see: **[success message]**"
+}
+```
+
+---
+
+## Integration Setup Patterns
+
+These patterns are specific to integration/data source setup learning paths (Linux, Windows, macOS, MySQL, etc.):
+
+### Alloy Installation Expand Button
+
+```json
+{
+  "type": "interactive",
+  "action": "highlight",
+  "reftarget": "[data-testid=\"agent-config-button\"]",
+  "content": "Click **Run Grafana Alloy** to expand the installation options.",
+  "requirements": ["exists-reftarget"]
+}
+```
+
+### Token Creation → Use Markdown
+
+Token dialogs have multiple paths (create new vs use existing):
+
+```json
+{
+  "type": "markdown",
+  "content": "**Create or select a token:**\n\n- **Create new token**: Click \"Create new token\", enter a name, then click \"Create token\".\n- **Use existing token**: Click \"Use an existing token\" and enter your token."
+}
+```
+
+### Test Connection → Use Markdown
+
+Conditional on real-world installation:
+
+```json
+{
+  "type": "markdown",
+  "content": "After installation completes, click **Test connection** to verify."
+}
+```
+
+---
+
+## Quick Decision Guide
+
+| UI Element | Pattern to Use |
+|------------|----------------|
+| Navigate through menus | `multistep` with `navmenu-open` |
+| Search/filter input | `formfill` with `aria-label` |
+| Button with stable text | `button` action |
+| Button with data-testid | `highlight` with data-testid |
+| Clickable card/tile | `highlight` with `a[href="..."]` |
+| User chooses between options | `markdown` |
+| Action outside browser | `markdown` |
+| Button that may not exist yet | `markdown` |

--- a/.cursor/commands/build-interactive-lj/reference/selector-patterns.md
+++ b/.cursor/commands/build-interactive-lj/reference/selector-patterns.md
@@ -1,0 +1,132 @@
+# Selector Patterns and Stability Rules
+
+This document defines how to discover, validate, and ensure stability of CSS selectors for interactive guides.
+
+---
+
+## Selector Priority (Most to Least Stable)
+
+When discovering selectors, try in this order:
+
+| Priority | Selector Type | Example | Confidence |
+|----------|---------------|---------|------------|
+| 1 | `data-testid` | `[data-testid="agent-config-button"]` | 🟢 High |
+| 2 | `aria-label` | `[aria-label="Search connections by name"]` | 🟢 High |
+| 3 | `href` (for links) | `a[href="/connections/add-new-connection"]` | 🟢 High |
+| 4 | `id` | `#my-element` | 🟡 Medium |
+| 5 | Stable class | `.specific-component-class` | 🟡 Medium |
+
+**Avoid:** Generic classes (`.btn`, `.input`), positional selectors (`:nth-child`), text content
+
+---
+
+## Selector Decision Tree
+
+When you find an element, choose selector in this order:
+
+1. Has `data-testid`? → Use `[data-testid="..."]` 🟢
+2. Has `aria-label`? → Use `[aria-label="..."]` 🟢
+3. Is a link with href? → Use `a[href="..."]` 🟢
+4. Is a button with stable text? → Use `action: "button"` 🟡
+5. Has unique id? → Use `#id` 🟡
+6. None of above? → Try class-based, then ask user 🔴
+
+---
+
+## Stability Anti-Patterns
+
+These patterns cause selectors to work for one user but fail for another—even in the same environment:
+
+| Anti-Pattern | Example | Why It Fails | Fix |
+|--------------|---------|--------------|-----|
+| **Position-based** | `:first-of-type`, `:nth-child(4)` | Order depends on data; different users see different lists | Use `data-testid` or `aria-label` |
+| **Data-dependent values** | `[data-testid='select-action-asserts:resource:threshold']` | Only works with specific metrics/services/labels | Use `^=` starts-with: `[data-testid^='select-action-']` |
+| **Hardcoded dynamic IDs** | `label[for='option-traceql-xyz123']` | IDs may include random suffixes | Use `^=` starts-with: `label[for^='option-traceql-']` |
+| **Non-standard CSS** | `:contains()`, `:nth-match()`, `:has-text()` | Playwright/jQuery-only, not standard CSS | Find `data-testid` or `aria-label` instead |
+| **Exact label matches** | `a[aria-label='Select detected_level']` | Label text includes data-specific values | Use `^=` starts-with: `a[aria-label^='Select ']` |
+
+---
+
+## Stability Verification Checklist
+
+**Before committing a selector, ask:**
+
+1. **Does it contain a data value?** (metric name, service name, label value)
+   - ❌ `button[data-testid='select-action-asserts:resource:threshold']`
+   - ✅ `button[data-testid^='select-action-']`
+
+2. **Does it assume position in a list?** (`:first-of-type`, `:nth-child()`)
+   - ❌ `a[data-testid='button-select-service']:first-of-type`
+   - ✅ `a[data-testid^='data-testid button-select-service']`
+
+3. **Is it Playwright/jQuery-specific syntax?**
+   - ❌ `button:contains('Include')` or `input:nth-match(1)`
+   - ✅ `button[data-testid='data-testid button-filter-include']`
+
+4. **Does the ID have a random suffix?**
+   - ❌ `label[for='option-traceql-abc123']`
+   - ✅ `label[for^='option-traceql-']`
+
+> 💡 **Pro tip:** When you find multiple valid selectors for an element, always prefer:
+> `data-testid` (exact) > `data-testid` (starts-with) > `aria-label` > `href` > other attributes
+
+---
+
+## Selector Syntax Limitations
+
+> ⚠️ **Pathfinder uses standard CSS selectors, NOT Playwright-style selectors.**
+
+### These DON'T work in Pathfinder:
+
+| ❌ Doesn't Work | ✅ Use Instead |
+|-----------------|----------------|
+| `label:has-text('Service')` | `label[for="service-option"]` or find a stable attribute |
+| `button:has-text('Submit')` | `action: "button"` with `reftarget: "Submit"` |
+| `div:has(> span.icon)` | Find a direct selector with `data-testid` or `aria-label` |
+| `text=Click here` | Not supported; use element selectors |
+
+### These DO work:
+
+| ✅ Works | Example |
+|----------|---------|
+| Attribute selectors | `[data-testid="my-button"]` |
+| Attribute contains | `[aria-label*='section: Alerts']` |
+| Attribute starts with | `[data-testid^="select-"]` |
+| Combinators | `div > button`, `ul li a` |
+| Standard pseudo-classes | `:first-child`, `:last-child` |
+
+**Key rule:** If you discover a selector using Playwright's `getByText()`, `getByRole()`, or `:has-text()`, you MUST convert it to a standard CSS selector before using it in content.json.
+
+---
+
+## Common Selector Patterns
+
+### Don't Use vs Use Instead
+
+| Don't Use | Use Instead | Why |
+|-----------|-------------|-----|
+| `input[placeholder="..."]` | `[aria-label="..."]` | Placeholder text may change; aria-label is more stable |
+| Generic classes (`.btn`) | `[data-testid="..."]` | Classes change frequently; test IDs are intentional |
+| `:nth-child()` selectors | Specific attributes | Position-based selectors break when UI reorders |
+| `button[aria-label*='section:']` for nav | `a[data-testid='data-testid Nav menu item'][href='/path']` | Nav links work whether sections are expanded/collapsed |
+
+---
+
+## When Markdown Beats Interactive
+
+Some UI patterns are better documented as markdown instructions rather than automated:
+
+- **Conditional dialogs** - Buttons that only appear after user completes a real-world action (e.g., "Test connection" after installing software)
+- **Multi-path flows** - When user must choose between options (create new vs use existing)
+- **External actions** - Steps performed outside the browser (run CLI commands, install software)
+
+---
+
+## Lessons Learned
+
+### Integration-Specific Notes
+
+For **integration setup learning paths** (Linux, Windows, macOS, MySQL, etc.):
+- The "Run Grafana Alloy" expand button works: `[data-testid="agent-config-button"]`
+- Token creation and "Test connection" buttons are conditional — use markdown
+- "Install" button for dashboards/alerts works: `action: "button"` with `reftarget: "Install"`

--- a/.cursor/commands/build-interactive-lj/steps/01-environment.md
+++ b/.cursor/commands/build-interactive-lj/steps/01-environment.md
@@ -1,0 +1,47 @@
+# Step 1: Environment Validation
+
+Verify that the user's setup is ready for creating interactive content.
+
+---
+
+## Tutorial Mode Introduction
+
+```
+**Step 1: Environment Validation**
+
+I'll check that your setup is ready:
+- Three repositories in your workspace (website, interactive-tutorials, grafana-recommender)
+- Playwright browser automation working
+- GitHub CLI authenticated (for filing selector issues if needed)
+
+If anything fails, I'll help you resolve the issue.
+
+Ready to proceed? (Y/N)
+```
+
+Wait for confirmation, then run checks.
+
+---
+
+## Expert Mode
+
+Run checks immediately without introduction.
+
+---
+
+## Run Checks
+
+Check these and display results:
+
+- ✅/❌ `website` repo in workspace
+- ✅/❌ `interactive-tutorials` repo in workspace
+- ✅/❌ `grafana-recommender` repo in workspace
+- ✅/❌ Playwright MCP available
+- ✅/❌ GitHub CLI authenticated
+
+**On any failure:** Help the user resolve the issue before continuing.
+
+**On all pass:**
+```
+✅ Environment ready. Proceeding to Step 2...
+```

--- a/.cursor/commands/build-interactive-lj/steps/02-validation.md
+++ b/.cursor/commands/build-interactive-lj/steps/02-validation.md
@@ -1,0 +1,50 @@
+# Step 2: Learning Path Validation
+
+Locate the learning path and verify it has all the required components.
+
+---
+
+## Tutorial Mode Introduction
+
+```
+**Step 2: Learning Path Validation**
+
+I'll locate the "[slug]" learning path and:
+- Find all milestones (the steps users complete)
+- Check if it's mapped in the recommender (so it appears in Pathfinder)
+
+Ready to proceed? (Y/N)
+```
+
+Wait for confirmation, then validate.
+
+---
+
+## Expert Mode
+
+Validate immediately without introduction.
+
+---
+
+## Validate
+
+1. Find source: `website/content/docs/learning-paths/[slug]/`
+2. List all milestones found
+3. Search `grafana-recommender` for mapping rules
+
+**Display:**
+```
+Found learning path: [title]
+
+Milestones:
+1. [milestone-1-title] (milestone-1-slug)
+2. [milestone-2-title] (milestone-2-slug)
+...
+
+Recommender mapping: ✅ Found / ❌ Not found
+```
+
+**On success:**
+```
+✅ Learning path validated. Ready to scaffold [N] milestones.
+```

--- a/.cursor/commands/build-interactive-lj/steps/03-recommender.md
+++ b/.cursor/commands/build-interactive-lj/steps/03-recommender.md
@@ -1,0 +1,116 @@
+# Step 3: Create Recommender Mapping
+
+Create a recommender mapping so the learning path appears in Pathfinder.
+
+---
+
+## When to Run This Step
+
+Only run this step if Step 2 reported: **Recommender mapping: ❌ Not found**
+
+If the mapping was found (✅), skip to Step 4.
+
+---
+
+## Autonomous Mapping Creation
+
+**Automatically analyze the learning path and create the mapping without asking questions.**
+
+### Decision Logic
+
+1. **Recommender file** - Infer from the learning path's primary context:
+   - Data source setup/connection → `connections-cloud.json` or `connections-oss.json`
+   - Dashboard creation/visualization → `dashboards-cloud.json` or `dashboards-oss.json`
+   - Query/exploration → `explore-cloud.json` or `explore-oss.json`
+   - Alerting → `alerting-cloud.json` or `alerting-oss.json`
+   - Observability features → `observability-cloud.json` or `observability-oss.json`
+
+2. **URL pattern** - Infer from the learning path content:
+   - If it mentions specific data source type → `/connections/datasources/[type]`
+   - If it's about dashboards → `/dashboards`
+   - If it's about exploration → `/explore`
+   - If it's about a specific app plugin → `/a/[plugin-id]`
+   - Default for dashboards → `/dashboards`
+
+3. **Target platform** - Determine from the learning path:
+   - Mentions "Grafana Cloud" throughout → Cloud only
+   - Mentions "self-hosted" or "OSS" → OSS only
+   - Generic/works for both → Both platforms
+
+---
+
+## Create Mapping Entry
+
+Automatically create the mapping JSON:
+
+**For Cloud:**
+- File: `grafana-recommender/internal/configs/state_recommendations/[area]-cloud.json`
+
+**For OSS:**
+- File: `grafana-recommender/internal/configs/state_recommendations/[area]-oss.json`
+
+**For Both:**
+- Add to both `-cloud.json` and `-oss.json` files
+
+**Mapping JSON structure:**
+
+```json
+{
+  "title": "[Learning path title from _index.md]",
+  "url": "https://grafana.com/docs/learning-paths/[slug]/",
+  "description": "Step-by-step guide: [Learning path title].",
+  "type": "learning-journey",
+  "match": {
+    "and": [
+      {
+        "urlPrefix": "[url-pattern]"
+      },
+      {
+        "targetPlatform": "cloud" // or "oss"
+      }
+    ]
+  }
+}
+```
+
+---
+
+## Insert Mapping
+
+1. Read the target recommender file(s)
+2. Parse the JSON
+3. Find an appropriate location in the `rules` array (group with similar learning journeys)
+4. Insert the new mapping entry
+5. Write the updated JSON back to the file
+6. Validate JSON syntax
+
+---
+
+## Display
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+✅ Step 3 complete: Recommender Mapping Created
+
+Added mapping to:
+├── grafana-recommender/internal/configs/state_recommendations/[file].json
+
+Mapping details:
+├── Title: [title]
+├── URL pattern: [pattern]
+├── Platform: [cloud/oss/both]
+└── Context: [area]
+
+⏳ Next: Step 4 - Scaffold Content Files
+   Ready to proceed? (Y/N)
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+
+---
+
+## Important Notes
+
+- **JSON formatting:** Maintain consistent indentation (2 spaces) and formatting
+- **Placement:** Insert learning-journey entries near other learning journeys in the file
+- **Validation:** After editing, validate JSON syntax before proceeding
+- **Multiple platforms:** If "Both" is selected, ensure entries are identical except for `targetPlatform`

--- a/.cursor/commands/build-interactive-lj/steps/04-scaffold.md
+++ b/.cursor/commands/build-interactive-lj/steps/04-scaffold.md
@@ -1,0 +1,161 @@
+# Step 4: Scaffold Content Files
+
+Create the content.json structure for each milestone.
+
+---
+
+## Tutorial Mode Introduction
+
+```
+**Step 4: Scaffold Content Files**
+
+I'll create the content.json structure for each milestone:
+- Read the source markdown from the website repo
+- Create directories in interactive-tutorials/[slug]-lj/
+- Convert steps to interactive blocks (with empty selectors for now)
+
+Ready to proceed? (Y/N)
+```
+
+Wait for confirmation, then scaffold.
+
+---
+
+## Expert Mode
+
+Scaffold immediately without introduction.
+
+---
+
+## Before Starting
+
+> 💡 **Important:** Before scaffolding, consult `reference/proven-patterns.md` for reusable JSON 
+> structures that match common Grafana UI elements (navigation, forms, buttons, etc.).
+
+> 📖 **Critical:** Read `reference/json-schema.md` for complete JSON structure requirements and 
+> field reference. This ensures you use correct field names (`content` not `description`, 
+> `targetvalue` not `formvalue`).
+
+---
+
+## CRITICAL: Scaffold ALL Milestones
+
+**You MUST create content.json for EVERY milestone in the learning path.**
+
+This includes:
+- ✅ Milestones with interactive UI steps (use `interactive` blocks)
+- ✅ Purely conceptual/educational milestones (use `markdown` blocks)
+- ✅ Introduction or overview pages (use `markdown` blocks)
+- ✅ Conclusion/outro pages (use `markdown` blocks)
+- ✅ External-only actions (use `markdown` or `guided` blocks)
+
+**Why scaffold everything?**
+- Pathfinder needs a content.json for every milestone to track progress through the learning path
+- Even non-interactive milestones need to be represented so users can mark them complete
+- Skipping milestones breaks the learning path flow
+
+---
+
+## Scaffolding Process
+
+**For each milestone:**
+
+1. Read `website/content/docs/learning-paths/[slug]/[milestone]/index.md`
+2. Create `interactive-tutorials/[slug]-lj/[milestone]/content.json`
+3. Convert content using these rules:
+
+### For Milestones WITH Interactive UI Steps:
+
+- Numbered steps that reference Grafana UI → `interactive` blocks with `action: "highlight"` and empty `reftarget`
+- Sequential navigation steps (e.g., "Navigate to X > Y > Z") → `multistep` blocks
+- Explanatory text between steps → `markdown` blocks
+
+### For Milestones WITHOUT Interactive UI Steps:
+
+Convert ALL content to `markdown` blocks. Use a single markdown block with the full milestone content.
+
+---
+
+## JSON Schema Requirements
+
+**CRITICAL:** Every content.json file MUST include these top-level fields:
+
+```json
+{
+  "schemaVersion": "1.0.0",
+  "id": "[learning-path-slug]-[milestone-slug]",
+  "title": "[Milestone Title from index.md]",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "[Full milestone content converted from markdown]"
+    }
+  ]
+}
+```
+
+### Field Specifications:
+
+- **`schemaVersion`**: Always `"1.0.0"` (string, required)
+- **`id`**: Format: `[learning-path-slug]-[milestone-slug]` (string, required, kebab-case)
+  - Example: `"billing-usage-navigate-to-billing-dashboard"`
+- **`title`**: Human-readable milestone title from the source markdown (string, required)
+  - Example: `"Navigate to the billing dashboard"`
+- **`blocks`**: Array of content blocks (array, required)
+
+### Example Complete File:
+
+```json
+{
+  "schemaVersion": "1.0.0",
+  "id": "billing-usage-business-value",
+  "title": "Understand the business value",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "Understanding your Grafana Cloud billing..."
+    }
+  ]
+}
+```
+
+---
+
+## Verification Checklist (REQUIRED)
+
+Before proceeding to Step 5, verify EACH content.json file:
+
+- [ ] File includes `"schemaVersion": "1.0.0"` at root level
+- [ ] File includes `"id"` field with format `[learning-path-slug]-[milestone-slug]`
+- [ ] File includes `"title"` field with human-readable milestone title
+- [ ] File includes `"blocks"` array
+- [ ] Every block has a `"type"` field
+- [ ] Instruction text uses `"content"` (NOT `"description"`)
+- [ ] Formfill actions use `"targetvalue"` (NOT `"formvalue"`)
+- [ ] Navigation steps use `"multistep"` blocks
+- [ ] Interactive blocks do NOT have `"requirements": ["exists-reftarget"]` (it's auto-applied)
+- [ ] Interactive blocks have empty `"reftarget": ""` (selectors added in Step 5)
+
+**If any check fails, fix before continuing.**
+
+---
+
+## Display
+
+Use this exact format:
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+✅ Step 4 complete: Scaffold
+
+Created [N] content.json files:
+├── [slug]-lj/milestone-1/content.json ([N] blocks)
+├── [slug]-lj/milestone-2/content.json ([N] blocks)
+└── ...
+
+Verification: All checks passed ✓
+
+⏳ Next: Step 5 - Selector Discovery
+   Ready to open the test environment?
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```

--- a/.cursor/commands/build-interactive-lj/steps/05-selectors.md
+++ b/.cursor/commands/build-interactive-lj/steps/05-selectors.md
@@ -1,0 +1,156 @@
+# Step 5: Selector Discovery
+
+Use browser automation to find CSS selectors for each interactive element.
+
+---
+
+## Before Starting
+
+> 📖 **CRITICAL:** Re-read `reference/selector-patterns.md` before discovering selectors.
+> You MUST try selectors in this order: data-testid → aria-label → href → id → class
+
+---
+
+## Authentication Setup (REQUIRED)
+
+Selector discovery happens by walking through the actual Grafana UI at: `https://learn.grafana-ops.net/`
+
+> ⚠️ **Important:** This is different from testing in Pathfinder (Step 6), which uses 
+> `https://learn.grafana-ops.net/?pathfinder-dev=true`
+
+Playwright opens a **fresh browser with no session**. Before discovering selectors:
+
+1. **Navigate to the test environment** using Playwright: `https://learn.grafana-ops.net/`
+2. **User must manually log in** through the Playwright browser window (Okta SAML)
+3. **Wait for user confirmation** that they are logged in
+4. **Walk through the UI flow** — navigate to pages where the learning path actions happen and inspect the DOM
+
+> ⚠️ **The AI cannot log the user in** — authentication requires manual user action 
+> in the Playwright-controlled browser window.
+
+**Display:**
+```
+I'll open the Grafana UI to discover selectors by walking through the actual pages.
+
+Opening: https://learn.grafana-ops.net/
+
+Please log in when the browser window appears. Let me know when you're logged in. (Y/N)
+```
+
+---
+
+## Tutorial Mode Introduction
+
+```
+**Step 5: Selector Discovery**
+
+I'll use browser automation to find selectors for each interactive element:
+- Navigate to the relevant Grafana pages
+- Inspect the DOM to find stable selectors
+- Update the content.json files with discovered selectors
+
+Selector priority: data-testid > aria-label > id > placeholder > href
+
+Ready to proceed? (Y/N)
+```
+
+Wait for confirmation, then discover.
+
+---
+
+## Expert Mode
+
+Discover immediately without introduction.
+
+---
+
+## Discovery Process
+
+Walk through the actual Grafana UI at `https://learn.grafana-ops.net/` to find selectors:
+
+1. Navigate to the starting page for the learning path (e.g., Dashboards page for dashboard creation flows)
+2. For each interactive block with empty `reftarget`:
+   - Navigate to the relevant page in Grafana
+   - Use Playwright snapshot to inspect the DOM
+   - Find the element and extract the best available selector
+   - Update the content.json with the discovered selector
+3. Continue through the entire UI flow, capturing selectors as you go
+
+---
+
+## Selector Decision Tree
+
+When you find an element, choose selector in this order:
+
+1. Has `data-testid`? → Use `[data-testid="..."]` 🟢
+2. Has `aria-label`? → Use `[aria-label="..."]` 🟢
+3. Is a link with href? → Use `a[href="..."]` 🟢
+4. Is a button with stable text? → Use `action: "button"` 🟡
+5. Has unique id? → Use `#id` 🟡
+6. None of above? → Try class-based, then ask user 🔴
+
+---
+
+## Stability Check (REQUIRED)
+
+After selecting a selector, verify it's stable:
+
+| Check | If Yes... |
+|-------|-----------|
+| Does the selector contain a data value (metric name, service name, label)? | Use `^=` starts-with pattern |
+| Does the selector use position (`:first-of-type`, `:nth-child`)? | Find a `data-testid` or `aria-label` instead |
+| Does the selector use `:contains()` or `:nth-match()`? | Convert to standard CSS with `data-testid` |
+| Does the `id` or `for` attribute have random characters? | Use `^=` starts-with pattern |
+
+> ⚠️ **Why this matters:** Selectors that work for you may fail for colleagues with different data. Always prefer patterns that work regardless of the specific data displayed.
+
+---
+
+## Display Progress
+
+Use this exact format:
+
+```
+Discovering selectors for [milestone-name]...
+├── [element description] → [selector] 🟢
+├── [element description] → [selector] 🟡
+└── [element description] → FAILED ❌
+    Attempt 1: [selector tried] - [why it failed]
+    Attempt 2: [selector tried] - [why it failed]
+```
+
+---
+
+## Verification Checklist (REQUIRED)
+
+Before proceeding to Step 6, verify:
+
+- [ ] All interactive blocks have real selectors (no placeholders)
+- [ ] No `"[selector]"` or `"TODO"` strings remain
+- [ ] Selectors follow priority order (data-testid preferred)
+- [ ] Failed selectors are noted for user decision
+
+---
+
+## Display
+
+Use this exact format:
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+✅ Step 5 complete: Selector Discovery
+
+Results by milestone:
+├── [milestone-1]: [N] selectors found
+├── [milestone-2]: [N] selectors found
+└── ...
+
+Selector quality:
+├── 🟢 High confidence: [N]
+├── 🟡 Medium confidence: [N]
+└── 🔴 Failed/needs review: [N]
+
+⏳ Next: Step 6 - Test in Pathfinder
+   Ready to test? (Y/N)
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```

--- a/.cursor/commands/build-interactive-lj/steps/06-testing.md
+++ b/.cursor/commands/build-interactive-lj/steps/06-testing.md
@@ -1,0 +1,267 @@
+# Step 6: Test in Pathfinder (Collaborative Testing)
+
+Collaboratively test each milestone in Pathfinder's Block Editor.
+
+---
+
+## ⛔ CRITICAL: AI Must NOT Test
+
+> **THE AI MUST NEVER CLICK "Show me", "Do it", OR ANY INTERACTIVE BUTTONS.**
+> 
+> The user does ALL testing. The AI only imports JSON and waits for feedback.
+
+Testing is a **collaborative process** where AI and user work together:
+
+- **AI's job:** Load JSON into Pathfinder, switch to Preview mode, then **STOP AND WAIT**
+- **User's job:** Click "Show me" / "Do it" buttons (user is faster and catches visual issues)
+- **User reports:** "This doesn't work" if a selector fails
+- **AI fixes:** Inspect DOM, find correct selector, update JSON, reload
+
+**Why this rule exists:** Users can test faster and catch visual/UX problems that automated clicking misses. The AI clicking buttons wastes time and prevents the user from seeing the actual behavior.
+
+**You MUST follow this pattern:**
+1. Load ONE milestone's JSON into Pathfinder
+2. Switch to Preview mode
+3. **Tell the user it's ready for testing**
+4. **WAIT** for user to report results (pass or "this doesn't work")
+5. If user reports a failure, help fix it
+6. After milestone passes, **ASK** before loading the next milestone
+
+---
+
+## Access the Block Editor
+
+Testing happens in **Pathfinder Dev Mode** at: `https://learn.grafana-ops.net/?pathfinder-dev=true`
+
+> ⚠️ **Important:** This is different from selector discovery (Step 5), which uses 
+> `https://learn.grafana-ops.net/` to walk through the actual UI.
+
+Dev mode must be enabled before you can access the Block Editor. If this is the user's first time, direct them to SETUP.md section 4.
+
+**Display:**
+```
+Have you enabled Dev Mode before? (If not, see SETUP.md section 4 for first-time setup)
+
+I'll navigate to Pathfinder in dev mode for testing.
+
+Opening: https://learn.grafana-ops.net/?pathfinder-dev=true
+
+Once the page loads, the Pathfinder sidebar should open automatically with Dev Tools visible.
+Click on "Interactive guide editor" to open the Block Editor.
+
+Let me know when you're in the Block Editor. (Y/N)
+```
+
+> ⚠️ **First-time users:** Must enable dev mode first at:
+> `https://learn.grafana-ops.net/plugins/grafana-pathfinder-app?dev=true`
+> See SETUP.md section 4 for full instructions.
+
+---
+
+## Tutorial Mode Introduction
+
+```
+**Step 6: Test in Pathfinder**
+
+We'll test collaboratively ONE MILESTONE AT A TIME:
+- I'll identify which milestones have interactive steps (skipping markdown-only ones)
+- I'll load each interactive milestone's content.json and switch to Preview mode
+- YOU click through "Show me" / "Do it" buttons (you're quicker!)
+- Tell me if anything doesn't work
+- I'll help fix any issues
+
+Note: We only test milestones with interactive steps. Markdown-only milestones 
+(like introductions or conceptual content) don't need testing.
+
+Ready to test the first interactive milestone? (Y/N)
+```
+
+Wait for confirmation, then load the first milestone with interactive steps.
+
+---
+
+## Expert Mode
+
+Same behavior — load milestone, user tests, fix issues as reported.
+
+---
+
+## Which Milestones to Test
+
+**CRITICAL: Only test milestones that contain interactive steps.**
+
+Before loading any JSON, check the milestone's content.json:
+
+- ✅ **Test if:** Contains `interactive`, `multistep`, or `guided` blocks with `reftarget` values
+- ❌ **Skip if:** Contains ONLY `markdown` blocks (purely conceptual content)
+
+**Why skip markdown-only milestones?**
+- No interactive steps = nothing to test
+- Markdown content renders correctly by default
+- Testing wastes time on non-interactive content
+
+**Example:**
+```json
+// ❌ SKIP - No interactive steps to test
+{
+  "schemaVersion": "1.0.0",
+  "id": "billing-usage-business-value",
+  "title": "Understand the business value",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "Understanding your Grafana Cloud billing..."
+    }
+  ]
+}
+
+// ✅ TEST - Has interactive steps
+{
+  "schemaVersion": "1.0.0",
+  "id": "billing-usage-navigate-to-billing-dashboard",
+  "title": "Navigate to the billing dashboard",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "The Grafana Cloud billing dashboard..."
+    },
+    {
+      "type": "interactive",
+      "action": "button",
+      "reftarget": "GrafanaCloud",
+      "content": "Open the **GrafanaCloud** folder."
+    }
+  ]
+}
+```
+
+---
+
+## Test Procedure (Per Interactive Milestone)
+
+**For EACH milestone with interactive steps (one at a time):**
+
+1. **First, check if milestone has interactive steps** (see "Which Milestones to Test" above)
+2. If no interactive steps, **skip to next milestone** and inform user
+3. Navigate to `https://learn.grafana-ops.net/?pathfinder-dev=true` (if not already there)
+4. Open the Block Editor from the Pathfinder sidebar (Dev tools → Interactive guide editor)
+5. **Load the JSON using "Edit JSON" method:**
+   - Click "Start new guide" to clear the editor (if needed)
+   - Click "Edit JSON" button
+   - Read the content.json file for this milestone
+   - Use browser automation to paste the JSON into the editor
+   - Save/apply the JSON
+6. Switch to Preview mode
+7. **Tell user: "Ready for testing! Please click through the Show me / Do it buttons and let me know what works and what doesn't."**
+8. **STOP. WAIT. Do nothing until the user responds.** — The AI must NOT click any buttons.
+9. If user reports "this doesn't work": help fix the selector (see below)
+10. After user confirms milestone passes, **ASK** before loading next milestone
+
+> ⚠️ **Reminder:** After step 7, the AI's job is done until the user provides feedback. Do not proceed, do not click buttons, do not test. Just wait.
+
+> 💡 **Technical note:** Use "Edit JSON" button instead of "Import JSON guide" to avoid file upload dialogs. The Edit JSON approach allows direct text input via browser automation.
+
+---
+
+## When a Selector Fails
+
+**CRITICAL: Do NOT automatically attempt fixes.** When you find a broken selector:
+
+1. **STOP immediately**
+2. **Report the problem clearly:**
+   ```
+   ❌ SELECTOR ISSUE FOUND
+   
+   Block: [description of the interactive step]
+   Current selector: [the reftarget value]
+   Problem: [why it failed - element not found, wrong element, etc.]
+   
+   Proposed fix:
+   - I will use Playwright to inspect the DOM and find the correct selector
+   - Once found, I will update the content.json with: [new selector]
+   - Then re-import and re-test this specific block
+   
+   Proceed with fix? (Y/N)
+   ```
+3. **Wait for user approval** before making any changes
+4. After user approves, attempt the fix and report results
+5. If fix doesn't work after 2 attempts, ask user for guidance (see "Handling Persistent Failures")
+
+---
+
+## Display Per Milestone
+
+**When skipping a markdown-only milestone:**
+```
+⏭️ Skipping: [milestone-name] (markdown-only, no interactive steps)
+```
+
+**When testing an interactive milestone:**
+
+Use this exact format:
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Testing: [milestone-name] ([N] of [total interactive])
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+├── Block 1: [description] ✅
+├── Block 2: [description] ✅
+├── Block 3: [description] ❌ FAILED (awaiting approval to fix)
+└── Block 4: [description] (not yet tested)
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+
+**After EACH milestone (if all blocks pass), ALWAYS ask:**
+```
+✅ Milestone "[name]" complete.
+
+Ready to test the next interactive milestone: "[next-name]"? (Y/N)
+```
+
+**Wait for user confirmation before proceeding to the next milestone.**
+
+---
+
+## Handling Persistent Failures
+
+When a step fails after 2 fix attempts, ask user:
+```
+Block [N] failed after 2 attempts.
+Selector tried: [list selectors]
+
+Options:
+1. Convert to markdown (remove interactivity)
+2. File issue at https://github.com/grafana/interactive-tutorials/issues
+3. Skip and continue
+
+Which would you prefer? (1/2/3)
+```
+
+---
+
+## Final Summary (After ALL Interactive Milestones Tested)
+
+Only after all interactive milestones have been tested and user has confirmed each one:
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+✅ Step 6 Complete: All Interactive Milestones Tested
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Total milestones: [N]
+├── Interactive milestones tested: [N]
+└── Markdown-only milestones skipped: [N]
+
+Test Results:
+├── [milestone-1]: ⏭️ Skipped (markdown-only)
+├── [milestone-2]: ✅ All blocks passed
+├── [milestone-3]: 🟡 [N] blocks needed fixes
+├── [milestone-4]: ✅ All blocks passed
+├── [milestone-5]: ⏭️ Skipped (markdown-only)
+└── [milestone-6]: ✅ All blocks passed
+
+Proceeding to Step 7: Final Summary...
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```

--- a/.cursor/commands/build-interactive-lj/steps/07-report.md
+++ b/.cursor/commands/build-interactive-lj/steps/07-report.md
@@ -1,0 +1,121 @@
+# Step 7: Report and Next Steps
+
+Summarize the session and provide guidance for creating a PR.
+
+---
+
+## Summary
+
+Use this exact format:
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+🎉 BUILD COMPLETE: [slug] Interactive Learning Path
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+RESULTS
+├── Total milestones: [N]
+├── Fully interactive: [N] ✅
+├── Partial (some markdown): [N] 🟡
+└── Issues filed: [N] 📝
+
+FILES CREATED
+├── [slug]-lj/milestone-1/content.json ✅
+├── [slug]-lj/milestone-2/content.json ✅
+└── ...
+
+ISSUES FILED (if any)
+├── #[N]: [element] - [brief description]
+└── ...
+
+NEXT STEPS
+1. Review the content.json files in your editor
+2. Stage files: git add [slug]-lj/
+3. Commit with message: "Add interactive content for [slug] learning path"
+4. Push and create PR
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+
+---
+
+## Slack-Ready Summary
+
+Offer to provide a copy-paste summary for Slack:
+
+```
+Would you like a Slack-ready summary? (Y/N)
+```
+
+If yes, display:
+```
+🎯 Interactive learning path complete: [slug]
+✅ [N]/[N] milestones interactive
+📝 [N] issues filed for broken selectors
+🔗 Ready for PR
+```
+
+---
+
+## PR Description
+
+When the user asks for a PR description, ALWAYS provide it in a markdown code block so they can copy it easily:
+
+````
+```markdown
+## Add interactive content for `[slug]` learning path
+
+### Summary
+
+[Description of what this PR adds]
+
+### Changes
+
+| Milestone | File | Blocks | Description |
+|-----------|------|--------|-------------|
+| [name] | `[file]` | [N] | [description] |
+...
+
+### Interactive features
+
+- [Key features, selectors used, etc.]
+
+### Testing
+
+- ✅ JSON validation passed
+- ✅ All highlights working correctly
+- ✅ Show me buttons functional
+
+### Related
+
+- Learning path: `/docs/learning-paths/[slug]/`
+```
+````
+
+**IMPORTANT:** The user should NEVER have to ask "please provide in markdown" — always use the code block format by default.
+
+---
+
+## Filing GitHub Issues
+
+For broken selectors that need Pathfinder team attention, file at:
+https://github.com/grafana/interactive-tutorials/issues
+
+Use this template:
+```
+gh issue create \
+  --repo grafana/interactive-tutorials \
+  --title "[Selector] [element] in [learning path name]" \
+  --body "## Element
+[Description of the UI element]
+
+## Selectors Tried
+1. \`[selector-1]\` - [why it failed]
+2. \`[selector-2]\` - [why it failed]
+
+## Page URL
+[Grafana page where element appears]
+
+## Suggested Fix
+[If you have ideas, otherwise: Needs data-testid added]"
+```


### PR DESCRIPTION

**Key improvements:**
- Separated workflow steps from reference documentation
- Each file has a single, clear purpose
- AI agents can load only relevant sections (better token efficiency)
- Easier to update selector patterns without touching workflow logic
- Better for onboarding new team members

**Additional fixes:**
- Fixed Step 3 verification checklist contradiction (empty selectors expected at scaffolding, checked in Step 4)
- Updated terminology from "learning journey" to "learning path" throughout
- Added autonomous recommender mapping creation (Step 3)
- Clarified that ALL milestones need content.json (even conceptual ones)

### Testing

- ✅ All content preserved from original file
- ✅ No functionality changes, only structural improvements
- ✅ Command invocation remains the same: `/build-interactive-lj`

### Related

- Original file backed up as `build-interactive-lj.md.backup`
- Total: 13 files changed, 2158 insertions(+), 68 deletions(-)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only restructuring and instruction tweaks; main risk is behavioral drift for agents/users due to updated step order and stronger rules, not runtime code changes.
> 
> **Overview**
> Refactors the `/build-interactive-lj` Cursor command from a single large markdown file into a modular layout: a `README.md` orchestrator, step files (`steps/01-07`), and reference docs (`reference/json-schema.md`, `reference/selector-patterns.md`, `reference/proven-patterns.md`), with the original preserved as `build-interactive-lj.md.backup` plus a `REFACTORING_SUMMARY.md`.
> 
> Updates the workflow semantics and guidance: renames “learning journey” to **learning path** throughout, inserts an explicit Step 3 for *autonomous* recommender mapping creation when missing, clarifies that **all milestones** must get a `content.json` (markdown-only allowed), tightens selector stability rules, and adjusts Pathfinder testing instructions (including using the “Edit JSON” flow and reaffirming the AI must not click interactive buttons).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1dbb0bca5f2fad071d7e4a8fd2bb55a22a733499. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->