### PR TITLE
Add new guide content in content.json

### DIFF
--- a/new-guide/content.json
+++ b/new-guide/content.json
@@ -1,0 +1,74 @@
+{
+  "id": "new-guide",
+  "title": "New Guide",
+  "blocks": [
+    {
+      "type": "interactive",
+      "action": "highlight",
+      "reftarget": "a[data-testid='data-testid Nav menu item'][href='/connections']",
+      "content": "Click Connections.",
+      "requirements": [
+        "exists-reftarget",
+        "navmenu-open"
+      ]
+    },
+    {
+      "type": "interactive",
+      "action": "highlight",
+      "reftarget": "#pageContent > div.css-15uwgyz > div > div > div.css-1736fpx-page-content > div > section > div:nth-child(1)",
+      "content": "Click Add new connection.",
+      "requirements": [
+        "exists-reftarget"
+      ]
+    },
+    {
+      "type": "interactive",
+      "action": "formfill",
+      "reftarget": "#pageContent > div.css-15uwgyz > div > div > div.css-1736fpx-page-content > div > div.css-fkkxk7 > div.css-1fhd082 > div > div",
+      "content": "Search for PostgreSQL.",
+      "targetvalue": "PostgreSQL"
+    },
+    {
+      "type": "interactive",
+      "action": "highlight",
+      "reftarget": "a[href='/connections/add-new-connection/postgres']",
+      "content": "Select the PostgreSQL tile.",
+      "requirements": [
+        "exists-reftarget"
+      ]
+    },
+    {
+      "type": "interactive",
+      "action": "highlight",
+      "reftarget": "input:nth-of-type(1)",
+      "content": "Select your operating system.",
+      "requirements": [
+        "exists-reftarget"
+      ]
+    },
+    {
+      "type": "interactive",
+      "action": "highlight",
+      "reftarget": "#pageContent > div.css-15uwgyz > div > div > div.css-1736fpx-page-content > div > div.css-1s2c5hx > div > div > ol > li:nth-child(1) > div > div > div > div:nth-child(2) > div:nth-child(2) > div > div > div",
+      "content": "Select your architecture.",
+      "requirements": [
+        "exists-reftarget"
+      ]
+    },
+    {
+      "type": "interactive",
+      "action": "highlight",
+      "reftarget": "button[data-testid='agent-config-button']",
+      "content": "Click Install Grafana Alloy.",
+      "requirements": [
+        "exists-reftarget"
+      ]
+    },
+    {
+      "type": "interactive",
+      "action": "highlight",
+      "reftarget": "button[data-testid='generate-token-submit-button']",
+      "content": "Click Create token."
+    }
+  ]
+}

--- a/new-guide/content.json
+++ b/new-guide/content.json
@@ -22,8 +22,8 @@
         },
         {
           "type": "interactive",
-          "action": "button",
-          "reftarget": "Add new connection",
+          "action": "highlight",
+          "reftarget": "div[role='button']:has(h3:contains('Add new connection'))",
           "content": "Click **Add new connection**.",
           "requirements": [
             "on-page:/connections"
@@ -32,7 +32,7 @@
         {
           "type": "interactive",
           "action": "formfill",
-          "reftarget": "input[placeholder*='Search']",
+          "reftarget": "input[data-testid='search-input-input']",
           "content": "Search for **PostgreSQL**.",
           "targetvalue": "PostgreSQL",
           "requirements": [
@@ -54,9 +54,6 @@
       "type": "section",
       "id": "configure-environment",
       "title": "Configure Your Environment",
-      "requirements": [
-        "section-completed:navigate-to-connections"
-      ],
       "blocks": [
         {
           "type": "markdown",
@@ -65,22 +62,23 @@
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "div[data-testid='os-selector'], [role='radiogroup']:has(label:contains('Linux'))",
+          "reftarget": "div[data-testid='collector-os-selection'] input",
           "content": "Select your operating system.",
-          "doIt": false,
           "requirements": [
-            "on-page:/connections/add-new-connection/postgres"
-          ]
+            "exists-reftarget"
+          ],
+          "doIt": false
         },
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "div[data-testid='arch-selector'], [role='radiogroup']:has(label:contains('amd64'))",
+          "reftarget": "div[data-testid='collector-arch-selection'] input",
           "content": "Select your architecture.",
-          "doIt": false,
           "requirements": [
-            "on-page:/connections/add-new-connection/postgres"
-          ]
+            "on-page:/connections/add-new-connection/postgres",
+            "exists-reftarget"
+          ],
+          "doIt": false
         }
       ]
     },
@@ -88,58 +86,41 @@
       "type": "section",
       "id": "install-alloy",
       "title": "Install Grafana Alloy",
-      "requirements": [
-        "section-completed:configure-environment"
-      ],
       "blocks": [
         {
           "type": "markdown",
-          "content": "Follow these steps to install and configure Grafana Alloy for collecting PostgreSQL metrics."
-        },
-        {
-          "type": "multistep",
-          "content": "Generate an API token for Alloy.",
-          "requirements": [
-            "on-page:/connections/add-new-connection/postgres"
-          ],
-          "steps": [
-            {
-              "action": "button",
-              "reftarget": "Run Grafana Alloy"
-            },
-            {
-              "action": "formfill",
-              "reftarget": "input[data-testid='generate-token-name-input']",
-              "targetvalue": "testing-token-alloy"
-            },
-            {
-              "action": "button",
-              "reftarget": "Create token"
-            }
-          ]
+          "content": "Install Grafana Alloy to collect PostgreSQL metrics and forward them to Grafana Cloud."
         },
         {
           "type": "interactive",
-          "action": "noop",
-          "content": "Copy the installation commands shown on screen and run them in your terminal to install Grafana Alloy."
+          "action": "highlight",
+          "reftarget": "button[data-testid='agent-config-button']",
+          "requirements": ["exists-reftarget"],
+          "content": "In the **Install Alloy** section, click **Run Grafana Alloy**."
         },
         {
-          "type": "multistep",
-          "content": "Test the Alloy connection and proceed.",
-          "requirements": [
-            "on-page:/connections/add-new-connection/postgres"
-          ],
-          "steps": [
-            {
-              "action": "button",
-              "reftarget": "Test Alloy connection"
-            },
-            {
-              "action": "button",
-              "reftarget": "Proceed to install integration"
-            }
-          ],
-          "verify": "on-page:/connections"
+          "type": "markdown",
+          "content": "Perform one of the following:\n\n| If you want to | Then |\n| --- | --- |\n| Create a new token | Click **Create new token**, enter a meaningful token name (e.g., `postgres-alloy`), then click **Create token**. |\n| Use an existing token | Click **Use an existing token** and enter a token you have created in the past. |"
+        },
+        {
+          "type": "markdown",
+          "content": "Verify that the **Enable Remote Configuration** toggle is set to on."
+        },
+        {
+          "type": "markdown",
+          "content": "In the **Install and run Grafana Alloy** section, click **Copy to Clipboard**."
+        },
+        {
+          "type": "markdown",
+          "content": "Log into the machine where you are installing Grafana Alloy, open the Terminal, and paste the contents of the clipboard. Press **Enter** to install Grafana Alloy.\n\nWhen the installation is complete, you'll see `Alloy is now running!`"
+        },
+        {
+          "type": "markdown",
+          "content": "To verify that Grafana Alloy is installed correctly, click **Test Alloy connection**.\n\nIf Grafana Alloy is installed correctly, you'll see `Awesome! Grafana Alloy is good to go`."
+        },
+        {
+          "type": "markdown",
+          "content": "If Alloy is successfully installed, click **Proceed to install integration**."
         }
       ]
     },
@@ -147,41 +128,59 @@
       "type": "section",
       "id": "configure-alloy",
       "title": "Configure Grafana Alloy",
-      "requirements": [
-        "section-completed:install-alloy"
-      ],
       "blocks": [
         {
           "type": "markdown",
-          "content": "Copy the configuration snippets and restart Alloy to complete the setup."
+          "content": "Configure Grafana Alloy to collect PostgreSQL metrics and send them to Grafana Cloud.\n\nTo configure Alloy for PostgreSQL monitoring:"
+        },
+        {
+          "type": "markdown",
+          "content": "Review the **Check prerequisites specific to the PostgreSQL integration** section and verify your PostgreSQL instance meets the requirements."
+        },
+        {
+          "type": "markdown",
+          "content": "Scroll to the **Set up Grafana Alloy to use the PostgreSQL integration** section and click **Copy to clipboard**."
         },
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "div[data-testid='alloy-simple-block']+button, button:contains('Copy')",
-          "content": "Copy the Grafana Alloy configuration snippet and append it to your Alloy configuration file.",
+          "reftarget": "div[data-testid='alloy-simple-block']+button",
+          "content": "Click **Copy to clipboard**.",
           "lazyRender": true
         },
         {
-          "type": "multistep",
-          "content": "Restart Grafana Alloy and test the connection.",
-          "steps": [
-            {
-              "action": "highlight",
-              "reftarget": "div[data-testid='restart-command']+button, button:contains('Copy'):nth-match(2)",
-              "lazyRender": true
-            },
-            {
-              "action": "button",
-              "reftarget": "Test connection",
-              "lazyRender": true
-            }
-          ],
-          "verify": "has-datasource:postgres"
+          "type": "markdown",
+          "content": "Open the Grafana Alloy configuration file on your system, paste the configuration snippet, and save the file."
         },
         {
           "type": "markdown",
-          "content": "You have successfully configured PostgreSQL monitoring with Grafana Alloy."
+          "content": "Scroll down to the **Restart Grafana Alloy** section."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "div[data-testid='restart-command']+button",
+          "content": "Click **Copy to clipboard** to copy the restart command.",
+          "lazyRender": true
+        },
+        {
+          "type": "markdown",
+          "content": "Run the restart command on your Alloy machine."
+        },
+        {
+          "type": "markdown",
+          "content": "After restarting Alloy, test the connection."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "button[data-testid='test-connection-button']",
+          "content": "Click **Test connection** to verify the PostgreSQL integration.",
+          "lazyRender": true
+        },
+        {
+          "type": "markdown",
+          "content": "If successful, you'll see a confirmation message. You have successfully configured PostgreSQL monitoring with Grafana Alloy."
         }
       ]
     }

--- a/new-guide/content.json
+++ b/new-guide/content.json
@@ -56,19 +56,70 @@
       ]
     },
     {
-      "type": "interactive",
-      "action": "highlight",
-      "reftarget": "button[data-testid='agent-config-button']",
-      "content": "Click Install Grafana Alloy.",
-      "requirements": [
-        "exists-reftarget"
+      "type": "multistep",
+      "content": "Install Grafana Alloy.",
+      "steps": [
+        {
+          "action": "highlight",
+          "reftarget": "button[data-testid='agent-config-button']"
+        },
+        {
+          "action": "highlight",
+          "reftarget": "button[data-testid='generate-token-submit-button']"
+        },
+        {
+          "action": "formfill",
+          "reftarget": "input[data-testid='generate-token-name-input']",
+          "targetvalue": "testing-token-alloy"
+        },
+        {
+          "action": "highlight",
+          "reftarget": "button[data-testid='generate-token-submit-button']"
+        },
+        {
+          "action": "highlight",
+          "reftarget": "#\\:r5u\\: > div.css-1ho5tbd > ol > li:nth-child(3) > div > button",
+          "lazyRender": true
+        },
+        {
+          "action": "noop",
+          "reftarget": ""
+        },
+        {
+          "action": "button",
+          "reftarget": "Test Alloy connection"
+        },
+        {
+          "action": "button",
+          "reftarget": "Proceed to install integration"
+        }
       ]
     },
     {
       "type": "interactive",
       "action": "highlight",
-      "reftarget": "button[data-testid='generate-token-submit-button']",
-      "content": "Click Create token."
+      "reftarget": "div[data-testid='alloy-simple-block']+button",
+      "content": "Manually copy and append the Grafana Alloy configuration snippets into your Grafana Alloy configuration file.",
+      "requirements": [
+        "exists-reftarget"
+      ],
+      "lazyRender": true
+    },
+    {
+      "type": "multistep",
+      "content": "Restart Grafana Alloy and test configurations.",
+      "steps": [
+        {
+          "action": "highlight",
+          "reftarget": "div[data-testid='restart-command']+button",
+          "lazyRender": true
+        },
+        {
+          "action": "highlight",
+          "reftarget": "button[data-testid='test-connection-button']",
+          "lazyRender": true
+        }
+      ]
     }
   ]
 }

--- a/new-guide/content.json
+++ b/new-guide/content.json
@@ -3,121 +3,185 @@
   "title": "New Guide",
   "blocks": [
     {
-      "type": "interactive",
-      "action": "highlight",
-      "reftarget": "a[data-testid='data-testid Nav menu item'][href='/connections']",
-      "content": "Click Connections.",
-      "requirements": [
-        "exists-reftarget",
-        "navmenu-open"
-      ]
-    },
-    {
-      "type": "interactive",
-      "action": "highlight",
-      "reftarget": "#pageContent > div.css-15uwgyz > div > div > div.css-1736fpx-page-content > div > section > div:nth-child(1)",
-      "content": "Click Add new connection.",
-      "requirements": [
-        "exists-reftarget"
-      ]
-    },
-    {
-      "type": "interactive",
-      "action": "formfill",
-      "reftarget": "#pageContent > div.css-15uwgyz > div > div > div.css-1736fpx-page-content > div > div.css-fkkxk7 > div.css-1fhd082 > div > div",
-      "content": "Search for PostgreSQL.",
-      "targetvalue": "PostgreSQL"
-    },
-    {
-      "type": "interactive",
-      "action": "highlight",
-      "reftarget": "a[href='/connections/add-new-connection/postgres']",
-      "content": "Select the PostgreSQL tile.",
-      "requirements": [
-        "exists-reftarget"
-      ]
-    },
-    {
-      "type": "interactive",
-      "action": "highlight",
-      "reftarget": "input:nth-of-type(1)",
-      "content": "Select your operating system.",
-      "requirements": [
-        "exists-reftarget"
-      ]
-    },
-    {
-      "type": "interactive",
-      "action": "highlight",
-      "reftarget": "#pageContent > div.css-15uwgyz > div > div > div.css-1736fpx-page-content > div > div.css-1s2c5hx > div > div > ol > li:nth-child(1) > div > div > div > div:nth-child(2) > div:nth-child(2) > div > div > div",
-      "content": "Select your architecture.",
-      "requirements": [
-        "exists-reftarget"
-      ]
-    },
-    {
-      "type": "multistep",
-      "content": "Install Grafana Alloy.",
-      "steps": [
+      "type": "section",
+      "id": "navigate-to-connections",
+      "title": "Navigate to Connections",
+      "blocks": [
         {
-          "action": "highlight",
-          "reftarget": "button[data-testid='agent-config-button']"
+          "type": "markdown",
+          "content": "In this section, you'll navigate to the Connections page and search for the PostgreSQL integration."
         },
         {
+          "type": "interactive",
           "action": "highlight",
-          "reftarget": "button[data-testid='generate-token-submit-button']"
+          "reftarget": "a[data-testid='data-testid Nav menu item'][href='/connections']",
+          "content": "Click **Connections**.",
+          "requirements": [
+            "navmenu-open"
+          ]
         },
         {
+          "type": "interactive",
+          "action": "button",
+          "reftarget": "Add new connection",
+          "content": "Click **Add new connection**.",
+          "requirements": [
+            "on-page:/connections"
+          ]
+        },
+        {
+          "type": "interactive",
           "action": "formfill",
-          "reftarget": "input[data-testid='generate-token-name-input']",
-          "targetvalue": "testing-token-alloy"
+          "reftarget": "input[placeholder*='Search']",
+          "content": "Search for **PostgreSQL**.",
+          "targetvalue": "PostgreSQL",
+          "requirements": [
+            "on-page:/connections"
+          ]
         },
         {
+          "type": "interactive",
           "action": "highlight",
-          "reftarget": "button[data-testid='generate-token-submit-button']"
-        },
-        {
-          "action": "highlight",
-          "reftarget": "#\\:r5u\\: > div.css-1ho5tbd > ol > li:nth-child(3) > div > button",
-          "lazyRender": true
-        },
-        {
-          "action": "noop",
-          "reftarget": ""
-        },
-        {
-          "action": "button",
-          "reftarget": "Test Alloy connection"
-        },
-        {
-          "action": "button",
-          "reftarget": "Proceed to install integration"
+          "reftarget": "a[href='/connections/add-new-connection/postgres']",
+          "content": "Select the **PostgreSQL** tile.",
+          "requirements": [
+            "on-page:/connections"
+          ]
         }
       ]
     },
     {
-      "type": "interactive",
-      "action": "highlight",
-      "reftarget": "div[data-testid='alloy-simple-block']+button",
-      "content": "Manually copy and append the Grafana Alloy configuration snippets into your Grafana Alloy configuration file.",
+      "type": "section",
+      "id": "configure-environment",
+      "title": "Configure Your Environment",
       "requirements": [
-        "exists-reftarget"
+        "section-completed:navigate-to-connections"
       ],
-      "lazyRender": true
+      "blocks": [
+        {
+          "type": "markdown",
+          "content": "Select your operating system and architecture to get the correct installation instructions."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "div[data-testid='os-selector'], [role='radiogroup']:has(label:contains('Linux'))",
+          "content": "Select your operating system.",
+          "doIt": false,
+          "requirements": [
+            "on-page:/connections/add-new-connection/postgres"
+          ]
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "div[data-testid='arch-selector'], [role='radiogroup']:has(label:contains('amd64'))",
+          "content": "Select your architecture.",
+          "doIt": false,
+          "requirements": [
+            "on-page:/connections/add-new-connection/postgres"
+          ]
+        }
+      ]
     },
     {
-      "type": "multistep",
-      "content": "Restart Grafana Alloy and test configurations.",
-      "steps": [
+      "type": "section",
+      "id": "install-alloy",
+      "title": "Install Grafana Alloy",
+      "requirements": [
+        "section-completed:configure-environment"
+      ],
+      "blocks": [
         {
+          "type": "markdown",
+          "content": "Follow these steps to install and configure Grafana Alloy for collecting PostgreSQL metrics."
+        },
+        {
+          "type": "multistep",
+          "content": "Generate an API token for Alloy.",
+          "requirements": [
+            "on-page:/connections/add-new-connection/postgres"
+          ],
+          "steps": [
+            {
+              "action": "button",
+              "reftarget": "Run Grafana Alloy"
+            },
+            {
+              "action": "formfill",
+              "reftarget": "input[data-testid='generate-token-name-input']",
+              "targetvalue": "testing-token-alloy"
+            },
+            {
+              "action": "button",
+              "reftarget": "Create token"
+            }
+          ]
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Copy the installation commands shown on screen and run them in your terminal to install Grafana Alloy."
+        },
+        {
+          "type": "multistep",
+          "content": "Test the Alloy connection and proceed.",
+          "requirements": [
+            "on-page:/connections/add-new-connection/postgres"
+          ],
+          "steps": [
+            {
+              "action": "button",
+              "reftarget": "Test Alloy connection"
+            },
+            {
+              "action": "button",
+              "reftarget": "Proceed to install integration"
+            }
+          ],
+          "verify": "on-page:/connections"
+        }
+      ]
+    },
+    {
+      "type": "section",
+      "id": "configure-alloy",
+      "title": "Configure Grafana Alloy",
+      "requirements": [
+        "section-completed:install-alloy"
+      ],
+      "blocks": [
+        {
+          "type": "markdown",
+          "content": "Copy the configuration snippets and restart Alloy to complete the setup."
+        },
+        {
+          "type": "interactive",
           "action": "highlight",
-          "reftarget": "div[data-testid='restart-command']+button",
+          "reftarget": "div[data-testid='alloy-simple-block']+button, button:contains('Copy')",
+          "content": "Copy the Grafana Alloy configuration snippet and append it to your Alloy configuration file.",
           "lazyRender": true
         },
         {
-          "action": "highlight",
-          "reftarget": "button[data-testid='test-connection-button']",
-          "lazyRender": true
+          "type": "multistep",
+          "content": "Restart Grafana Alloy and test the connection.",
+          "steps": [
+            {
+              "action": "highlight",
+              "reftarget": "div[data-testid='restart-command']+button, button:contains('Copy'):nth-match(2)",
+              "lazyRender": true
+            },
+            {
+              "action": "button",
+              "reftarget": "Test connection",
+              "lazyRender": true
+            }
+          ],
+          "verify": "has-datasource:postgres"
+        },
+        {
+          "type": "markdown",
+          "content": "You have successfully configured PostgreSQL monitoring with Grafana Alloy."
         }
       ]
     }

--- a/new-guide/content.json
+++ b/new-guide/content.json
@@ -183,6 +183,39 @@
           "content": "If successful, you'll see a confirmation message. You have successfully configured PostgreSQL monitoring with Grafana Alloy."
         }
       ]
+    },
+    {
+      "type": "section",
+      "id": "install-dashboards-alerts",
+      "title": "Install Dashboards and Alerts",
+      "blocks": [
+        {
+          "type": "markdown",
+          "content": "The PostgreSQL integration includes pre-built dashboards and alert rules that provide immediate visibility into your database performance.\n\nTo install the PostgreSQL dashboards and alerts:"
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "button[data-testid='install-button']",
+          "content": "In the **Install dashboards and alerts** section, click **Install**.",
+          "lazyRender": true
+        },
+        {
+          "type": "markdown",
+          "content": "You should see the message: **Dashboards and alerts have been installed.**"
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "a[data-testid='view-dashboards-button']",
+          "content": "Click **View Dashboards** to see the installed PostgreSQL dashboards.",
+          "doIt": false
+        },
+        {
+          "type": "markdown",
+          "content": "To see the installed alerts, navigate to **Alerts & IRM > Alerting > Alert rules**.\n\nPostgreSQL integration alerts typically begin with `PostgreSQL`.\n\n**Congratulations!** You've successfully set up PostgreSQL monitoring with Grafana Cloud."
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## New interactive guide: New Guide

### Description

Adds a new interactive tutorial for setting up a **PostgreSQL connection** and installing **Grafana Alloy**.

The guide walks users through:

- Navigating to **Connections → Add new connection**
- Selecting the **PostgreSQL** integration
- Generating an Alloy token
- Adding the provided configuration to the Alloy config file
- Restarting Alloy and testing the connection
- Dashboards

### Checklist
- [ ] Guide JSON is valid and renders correctly in the block editor
- [ ] All selectors have been tested in the target Grafana version
- [ ] Guide has appropriate requirements for each step

### Index registration
To make this guide discoverable by the recommender, add an entry to `index.json`:

```json
{
  "id": "new-guide",
  "title": "New Guide",
  "type": "docs-page",
  "url": "https://interactive-learning.grafana.net/new-guide/content.json",
  "match": {
    "urlPrefix": ["/connections"]
  }
}
```

<!-- Adjust urlPrefix based on where this guide should appear -->