### PR TITLE
Add interactive content for adaptive-logs learning path

### DIFF
--- a/adaptive-logs-lj/content.json
+++ b/adaptive-logs-lj/content.json
@@ -1,0 +1,127 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "adaptive-logs-lj",
+  "title": "Optimize your logs with Adaptive Logs",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "Use this interactive guide to learn how **Adaptive Logs** helps you reduce log volume safely by recommending drop rates for underused log patterns. You'll explore where Adaptive Logs lives in Grafana Cloud, review how recommendations are generated from query usage, and understand your options for reviewing, applying, or customizing drop rates."
+    },
+    {
+      "type": "section",
+      "id": "navigate-to-adaptive-logs",
+      "title": "Get oriented with Adaptive Logs",
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "a[data-testid='data-testid Nav menu item'][href='adaptive-telemetry']",
+          "content": "Adaptive Logs is part of Adaptive Telemetry. Start by opening **Adaptive Telemetry** to see where Grafana Cloud helps you optimize metrics, logs, and traces based on real usage.",
+          "requirements": [
+            "navmenu-open"
+          ]
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "a[href*='adaptive-logs']",
+          "content": "Select **Adaptive Logs** to open log optimization recommendations. Adaptive Logs analyzes your log ingest and query behavior to suggest safe drop rates that reduce volume and cost while preserving observability."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='data-testid Tab Patterns']",
+          "content": "Open the **Patterns** tab to review recommendations for log drop rates. This is where you review, filter, and decide which changes to apply."
+        }
+      ]
+    },
+    {
+      "type": "section",
+      "id": "review-patterns",
+      "title": "Review patterns and recommendations",
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "The patterns table lists log patterns, query frequency, volume, current and recommended drop rates, and projected savings. Use the filters to narrow results by service or frequency."
+        },
+        {
+          "type": "markdown",
+          "content": "Each row shows:\n\n- **Pattern** — the detected log pattern\n- **Recommended** — the recommended percentage of log lines to drop\n- **Current(%)** — the percentage currently being dropped\n- **Volume** and **Savings** — projected impact of applying the recommendation\n\nExpand a pattern to see a per-service breakdown. Click the **Open in Explore** icon to see matching log lines."
+        },
+        {
+          "type": "interactive",
+          "action": "button",
+          "reftarget": "Apply all recommendations",
+          "content": "Click **Apply all recommendations** to apply the suggested drop rates across all patterns.",
+          "doIt": false
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Review the projected savings in the confirmation dialog, then click **Apply** to confirm."
+        }
+      ]
+    },
+    {
+      "type": "section",
+      "id": "create-exemptions",
+      "title": "Create exemptions for critical logs",
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='data-testid Tab Exemptions']",
+          "content": "Select the **Exemptions** tab to protect specific log streams from being dropped."
+        },
+        {
+          "type": "interactive",
+          "action": "button",
+          "reftarget": "Add new exemption",
+          "content": "Click **Add new exemption** to create an exemption rule."
+        },
+        {
+          "type": "interactive",
+          "action": "formfill",
+          "reftarget": "[data-testid='stream-selector-input']",
+          "targetvalue": "",
+          "content": "Enter a valid stream selector to match the logs you want to protect from dropping.",
+          "doIt": false
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Optionally provide business context in the **Reason** field, then click **Save**."
+        }
+      ]
+    },
+    {
+      "type": "section",
+      "id": "create-segments",
+      "title": "Segment logs by team or service",
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='data-testid Tab Segments']",
+          "content": "Select the **Segments** tab to manage Adaptive Logs per team, service, or system."
+        },
+        {
+          "type": "interactive",
+          "action": "button",
+          "reftarget": "Add new segment",
+          "content": "Click **Add new segment** to create a segment."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Enter a descriptive name, select a log stream label (for example, `namespace`), and specify the values that match the team's logs. Click **Add** to save."
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "You now know how to navigate Adaptive Logs, review and apply drop rate recommendations, create exemptions to protect critical streams, and segment logs by team. Use the **Overview** tab to monitor dropped volume and validate that your configuration is delivering the expected results."
+    }
+  ]
+}

--- a/adaptive-logs-lj/content.json
+++ b/adaptive-logs-lj/content.json
@@ -5,7 +5,19 @@
   "blocks": [
     {
       "type": "markdown",
-      "content": "Use this interactive guide to learn how **Adaptive Logs** helps you reduce log volume safely by recommending drop rates for underused log patterns. You'll explore where Adaptive Logs lives in Grafana Cloud, review how recommendations are generated from query usage, and understand your options for reviewing, applying, or customizing drop rates."
+      "content": "Use this interactive guide to learn how **Adaptive Logs** helps you reduce log volume safely by recommending drop rates for underused log patterns."
+    },
+    {
+      "type": "markdown",
+      "content": "You'll explore where Adaptive Logs lives in Grafana Cloud, review how recommendations are generated from query usage, and understand your options for reviewing, applying, or customizing drop rates."
+    },
+    {
+      "type": "markdown",
+      "content": "### Before you begin"
+    },
+    {
+      "type": "markdown",
+      "content": "Before you start, ensure you have:\n\n- A Grafana Cloud account. Refer to [Grafana Cloud](https://grafana.com/signup/cloud/connect-account).\n- Logs ingested into Grafana Cloud.\n- Basic familiarity with querying and exploring logs in Grafana.\n- An understanding of how log volume, query behavior, and patterns affect storage and cost."
     },
     {
       "type": "section",
@@ -122,6 +134,22 @@
     {
       "type": "markdown",
       "content": "You now know how to navigate Adaptive Logs, review and apply drop rate recommendations, create exemptions to protect critical streams, and segment logs by team. Use the **Overview** tab to monitor dropped volume and validate that your configuration is delivering the expected results."
+    },
+    {
+      "type": "markdown",
+      "content": "---\n\n### Troubleshooting"
+    },
+    {
+      "type": "markdown",
+      "content": "If you get stuck, we've got your back! Where appropriate, troubleshooting information is just a click away."
+    },
+    {
+      "type": "markdown",
+      "content": "### More to explore (optional)"
+    },
+    {
+      "type": "markdown",
+      "content": "We understand you might want to explore other capabilities not strictly on this path. We'll provide you opportunities where it makes sense."
     }
   ]
 }

--- a/adaptive-logs-lj/end-journey/content.json
+++ b/adaptive-logs-lj/end-journey/content.json
@@ -1,0 +1,23 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "adaptive-logs-end-journey",
+  "title": "Destination reached!",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "Congratulations on completing this journey! Job well done!"
+    },
+    {
+      "type": "markdown",
+      "content": "We hope you've enjoyed traveling with us as you:\n\n- Reduced log volume while preserving dashboard and alert fidelity\n- Reviewed and safely applied optimization recommendations\n- Created exemptions to protect critical streams\n- Segmented logs for team and service ownership\n- Monitored results to validate cost and performance impact"
+    },
+    {
+      "type": "markdown",
+      "content": "## Where to next?\n\nNow that your logs are optimized, you can:\n\n- Optimize metrics to control time series growth with **Adaptive Metrics**: Refer to [Adaptive Metrics](/docs/grafana-cloud/adaptive-telemetry/adaptive-metrics/)\n- Sample and prioritize trace data efficiently using **Adaptive Traces**: Refer to [Adaptive Traces](/docs/grafana-cloud/adaptive-telemetry/adaptive-traces/)\n- Monitor long-term savings and usage trends: Refer to [Understand logs usage and cost](/docs/grafana-cloud/cost-management-and-billing/understand-usage-cost/logs/)"
+    },
+    {
+      "type": "markdown",
+      "content": "---\n\n### More to explore (optional)\n\nAt this point in your journey, you can explore the following paths:\n\n- [Adaptive Metrics](/docs/grafana-cloud/adaptive-telemetry/adaptive-metrics/)\n- [Adaptive Traces](/docs/grafana-cloud/adaptive-telemetry/adaptive-traces/)\n- [Understand logs usage and cost](/docs/grafana-cloud/cost-management-and-billing/understand-usage-cost/logs/)"
+    }
+  ]
+}

--- a/adaptive-logs-lj/end-journey/content.json
+++ b/adaptive-logs-lj/end-journey/content.json
@@ -17,7 +17,11 @@
     },
     {
       "type": "markdown",
-      "content": "---\n\n### More to explore (optional)\n\nAt this point in your journey, you can explore the following paths:\n\n- [Adaptive Metrics](/docs/grafana-cloud/adaptive-telemetry/adaptive-metrics/)\n- [Adaptive Traces](/docs/grafana-cloud/adaptive-telemetry/adaptive-traces/)\n- [Understand logs usage and cost](/docs/grafana-cloud/cost-management-and-billing/understand-usage-cost/logs/)"
+      "content": "---\n\n### More to explore (optional)"
+    },
+    {
+      "type": "markdown",
+      "content": "At this point in your journey, you can explore the following paths:\n\n- [Adaptive Metrics](/docs/grafana-cloud/adaptive-telemetry/adaptive-metrics/)\n- [Adaptive Traces](/docs/grafana-cloud/adaptive-telemetry/adaptive-traces/)\n- [Understand logs usage and cost](/docs/grafana-cloud/cost-management-and-billing/understand-usage-cost/logs/)"
     }
   ]
 }

--- a/adaptive-logs-lj/exemptions/content.json
+++ b/adaptive-logs-lj/exemptions/content.json
@@ -18,13 +18,13 @@
         },
         {
           "type": "interactive",
-          "action": "button",
+          "action": "noop",
           "reftarget": "Add new exemption",
           "content": "Click **Add new exemption**."
         },
         {
           "type": "interactive",
-          "action": "formfill",
+          "action": "noop",
           "reftarget": "[data-testid='stream-selector-input']",
           "targetvalue": "",
           "content": "In the Add exemption window, enter a valid stream selector.",
@@ -37,7 +37,7 @@
         },
         {
           "type": "interactive",
-          "action": "highlight",
+          "action": "noop",
           "reftarget": "[data-testid='data-testid Confirm Modal Danger Button']",
           "content": "Click **Save**.",
           "doIt": false

--- a/adaptive-logs-lj/exemptions/content.json
+++ b/adaptive-logs-lj/exemptions/content.json
@@ -54,7 +54,11 @@
     },
     {
       "type": "markdown",
-      "content": "---\n\n### More to explore (optional)\n\nAt this point in your journey, you can explore the following paths:\n\n- [Create exemptions](/docs/grafana-cloud/adaptive-telemetry/adaptive-logs/create-exemptions/)\n- [Pause Adaptive Logs](/docs/grafana-cloud/adaptive-telemetry/adaptive-logs/create-exemptions/pause-adaptive-logs/)"
+      "content": "---\n\n### More to explore (optional)"
+    },
+    {
+      "type": "markdown",
+      "content": "At this point in your journey, you can explore the following paths:\n\n- [Create exemptions](/docs/grafana-cloud/adaptive-telemetry/adaptive-logs/create-exemptions/)\n- [Pause Adaptive Logs](/docs/grafana-cloud/adaptive-telemetry/adaptive-logs/create-exemptions/pause-adaptive-logs/)"
     }
   ]
 }

--- a/adaptive-logs-lj/exemptions/content.json
+++ b/adaptive-logs-lj/exemptions/content.json
@@ -1,0 +1,60 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "adaptive-logs-exemptions",
+  "title": "Create exemptions",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "Prevent certain logs from being dropped even if they are not being queried heavily.\n\nTo create a new exemption, complete the following steps."
+    },
+    {
+      "type": "section",
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='data-testid Tab Exemptions']",
+          "content": "Select the **Exemptions** tab."
+        },
+        {
+          "type": "interactive",
+          "action": "button",
+          "reftarget": "Add new exemption",
+          "content": "Click **Add new exemption**."
+        },
+        {
+          "type": "interactive",
+          "action": "formfill",
+          "reftarget": "[data-testid='stream-selector-input']",
+          "targetvalue": "",
+          "content": "In the Add exemption window, enter a valid stream selector.",
+          "doIt": false
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Optionally provide business context in the **Reason** field."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='data-testid Confirm Modal Danger Button']",
+          "content": "Click **Save**.",
+          "doIt": false
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "You can remove or update exemptions at any time.\n\nIt may take up to fifteen days for an exempted pattern to disappear from the Adaptive Logs user interface, but any attempts to apply recommendations to an exempted pattern has no effect and logs matching an exempted pattern are not dropped."
+    },
+    {
+      "type": "markdown",
+      "content": "In the next milestone, you'll learn how segmentation helps teams manage Adaptive Logs for their own services."
+    },
+    {
+      "type": "markdown",
+      "content": "---\n\n### More to explore (optional)\n\nAt this point in your journey, you can explore the following paths:\n\n- [Create exemptions](/docs/grafana-cloud/adaptive-telemetry/adaptive-logs/create-exemptions/)\n- [Pause Adaptive Logs](/docs/grafana-cloud/adaptive-telemetry/adaptive-logs/create-exemptions/pause-adaptive-logs/)"
+    }
+  ]
+}

--- a/adaptive-logs-lj/how-it-works/content.json
+++ b/adaptive-logs-lj/how-it-works/content.json
@@ -14,11 +14,7 @@
     },
     {
       "type": "markdown",
-      "content": "## How it works at a glance\n\n1. **Adaptive Logs analyzes your logs** — It looks at your incoming logs and groups log lines into patterns.\n\n2. **Adaptive Logs checks how you use your logs** — It checks which log patterns you actually query over the past 15 days.\n\n3. **Adaptive Logs suggests which logs to drop** — Based on what it finds, Adaptive Logs generates recommendations suggesting a drop rate, or percentage of those logs that can safely be dropped without impacting your observability needs."
-    },
-    {
-      "type": "markdown",
-      "content": "4. **You review, apply, or adjust the recommendations** — Using the Adaptive Logs user interface, you review the recommendations and suggested drop rates. You can also choose to keep certain logs that Adaptive Logs suggests dropping.\n\n5. **After reviewing the suggestions, you tell Adaptive Logs to start dropping those logs.**\n\n6. **Grafana Cloud drops the unneeded logs** — Grafana Cloud automatically gets rid of the unneeded logs, filtering them out and discarding them before they are indexed and stored, reducing your log ingest and associated costs."
+      "content": "## How it works at a glance\n\n1. **Adaptive Logs analyzes your logs** — It looks at your incoming logs and groups log lines into patterns.\n\n2. **Adaptive Logs checks how you use your logs** — It checks which log patterns you actually query over the past 15 days.\n\n3. **Adaptive Logs suggests which logs to drop** — Based on what it finds, Adaptive Logs generates recommendations suggesting a drop rate, or percentage of those logs that can safely be dropped without impacting your observability needs.\n\n4. **You review, apply, or adjust the recommendations** — Using the Adaptive Logs user interface, you review the recommendations and suggested drop rates. You can also choose to keep certain logs that Adaptive Logs suggests dropping.\n\n5. **After reviewing the suggestions, you tell Adaptive Logs to start dropping those logs.**\n\n6. **Grafana Cloud drops the unneeded logs** — Grafana Cloud automatically gets rid of the unneeded logs, filtering them out and discarding them before they are indexed and stored, reducing your log ingest and associated costs."
     },
     {
       "type": "markdown",

--- a/adaptive-logs-lj/how-it-works/content.json
+++ b/adaptive-logs-lj/how-it-works/content.json
@@ -1,0 +1,28 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "adaptive-logs-how-it-works",
+  "title": "How Adaptive Logs works",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "The following diagram gives you an overview of Adaptive Logs and introduces you to some of the fundamental features that are the principles of how Adaptive Logs works."
+    },
+    {
+      "type": "image",
+      "src": "/media/docs/adaptive-logs/how-adaptive-logs-works.png",
+      "alt": "An image showing how Adaptive Logs works."
+    },
+    {
+      "type": "markdown",
+      "content": "## How it works at a glance\n\n1. **Adaptive Logs analyzes your logs** — It looks at your incoming logs and groups log lines into patterns.\n\n2. **Adaptive Logs checks how you use your logs** — It checks which log patterns you actually query over the past 15 days.\n\n3. **Adaptive Logs suggests which logs to drop** — Based on what it finds, Adaptive Logs generates recommendations suggesting a drop rate, or percentage of those logs that can safely be dropped without impacting your observability needs."
+    },
+    {
+      "type": "markdown",
+      "content": "4. **You review, apply, or adjust the recommendations** — Using the Adaptive Logs user interface, you review the recommendations and suggested drop rates. You can also choose to keep certain logs that Adaptive Logs suggests dropping.\n\n5. **After reviewing the suggestions, you tell Adaptive Logs to start dropping those logs.**\n\n6. **Grafana Cloud drops the unneeded logs** — Grafana Cloud automatically gets rid of the unneeded logs, filtering them out and discarding them before they are indexed and stored, reducing your log ingest and associated costs."
+    },
+    {
+      "type": "markdown",
+      "content": "In the next milestone, you'll review and apply recommendations to reduce log volume while keeping dashboards and alerts working."
+    }
+  ]
+}

--- a/adaptive-logs-lj/monitor-validate/content.json
+++ b/adaptive-logs-lj/monitor-validate/content.json
@@ -1,0 +1,43 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "adaptive-logs-monitor-validate",
+  "title": "Monitor and validate results",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "After reviewing and applying recommendations, or using other customization options, you can now verify that your setup is delivering the results you expect.\n\nUse the overview dashboard for a quick, visual summary of how your applied drop rates and exemptions are reducing log volume."
+    },
+    {
+      "type": "markdown",
+      "content": "To access the overview dashboard, navigate to **Adaptive Telemetry** > **Adaptive Logs** > **Overview**."
+    },
+    {
+      "type": "markdown",
+      "content": "You can adjust the time range using the time picker in the upper-right corner of the dashboard to analyze recent behavior or investigate longer-term trends. Changing the time range helps you compare activity before and after deployments, configuration changes, or incidents."
+    },
+    {
+      "type": "markdown",
+      "content": "## Dropped log volume\n\nThis panel shows the percentage of incoming log data that Adaptive Logs is dropping during the selected time range.\n\nUse this panel to:\n\n- Understand the overall effectiveness of Adaptive Logs in reducing log lines\n- Identify unexpected increases or decreases in dropped volume\n- Verify that Adaptive Logs is actively filtering log noise\n\nA consistently high dropped percentage indicates that repetitive or low-value logs are being successfully removed. Sudden changes may indicate upstream logging changes or configuration updates."
+    },
+    {
+      "type": "markdown",
+      "content": "## Total dropped\n\nThis panel displays the total volume of log data that has been dropped over the selected time range.\n\nUse this panel to:\n\n- Quantify the absolute volume of data being removed\n- Estimate cost savings from reduced log ingestion\n- Compare dropped volume across different time windows"
+    },
+    {
+      "type": "markdown",
+      "content": "## Total received\n\nThis panel shows the total volume of log data received by Adaptive Logs before any dropping occurs.\n\nUse this panel to:\n\n- Understand how much raw log data your systems are producing\n- Detect spikes or drops in log generation\n- Correlate changes in received volume with deployments or incidents"
+    },
+    {
+      "type": "markdown",
+      "content": "## Volume rates\n\nThis graph shows the rate of log data per second, split into **Received** and **Dropped** log volume.\n\nUse this panel to:\n\n- Compare incoming versus dropped log rates over time\n- Visualize how Adaptive Logs reacts to changes in log traffic\n- Identify sustained periods of high drop activity or sudden shifts in volume\n\nThe difference between received and dropped rates represents the log data that is retained."
+    },
+    {
+      "type": "markdown",
+      "content": "In the next milestone, you'll reach your journey conclusion."
+    },
+    {
+      "type": "markdown",
+      "content": "---\n\n### More to explore (optional)\n\nAt this point in your journey, you can explore the following paths:\n\n- [Understand logs usage and cost](/docs/grafana-cloud/cost-management-and-billing/understand-usage-cost/logs/)"
+    }
+  ]
+}

--- a/adaptive-logs-lj/monitor-validate/content.json
+++ b/adaptive-logs-lj/monitor-validate/content.json
@@ -37,7 +37,11 @@
     },
     {
       "type": "markdown",
-      "content": "---\n\n### More to explore (optional)\n\nAt this point in your journey, you can explore the following paths:\n\n- [Understand logs usage and cost](/docs/grafana-cloud/cost-management-and-billing/understand-usage-cost/logs/)"
+      "content": "---\n\n### More to explore (optional)"
+    },
+    {
+      "type": "markdown",
+      "content": "At this point in your journey, you can explore the following paths:\n\n- [Understand logs usage and cost](/docs/grafana-cloud/cost-management-and-billing/understand-usage-cost/logs/)"
     }
   ]
 }

--- a/adaptive-logs-lj/review-apply/content.json
+++ b/adaptive-logs-lj/review-apply/content.json
@@ -5,7 +5,11 @@
   "blocks": [
     {
       "type": "markdown",
-      "content": "Adaptive Logs provides you with a list of patterns and recommendations on which logs to drop based on usage patterns. You can filter, review, and edit drop rates to suit your needs.\n\nAfter reviewing, you apply the drop rates to implement the changes. The logs are then dropped upon ingestion into Grafana Cloud, reducing unnecessary log storage costs while ensuring that your observability remains intact."
+      "content": "Adaptive Logs provides you with a list of patterns and recommendations on which logs to drop based on usage patterns. You can filter, review, and edit drop rates to suit your needs."
+    },
+    {
+      "type": "markdown",
+      "content": "After reviewing, you apply the drop rates to implement the changes. The logs are then dropped upon ingestion into Grafana Cloud, reducing unnecessary log storage costs while ensuring that your observability remains intact."
     },
     {
       "type": "markdown",
@@ -59,7 +63,11 @@
     },
     {
       "type": "markdown",
-      "content": "---\n\n### More to explore (optional)\n\nAt this point in your journey, you can explore the following paths:\n\n- [Review and apply recommendations](/docs/grafana-cloud/adaptive-telemetry/adaptive-logs/manage-recommendations/)"
+      "content": "---\n\n### More to explore (optional)"
+    },
+    {
+      "type": "markdown",
+      "content": "At this point in your journey, you can explore the following paths:\n\n- [Review and apply recommendations](/docs/grafana-cloud/adaptive-telemetry/adaptive-logs/manage-recommendations/)"
     }
   ]
 }

--- a/adaptive-logs-lj/review-apply/content.json
+++ b/adaptive-logs-lj/review-apply/content.json
@@ -55,7 +55,7 @@
     },
     {
       "type": "markdown",
-      "content": "In the next milestone, you'll learn how to create drop rules and label filters."
+      "content": "In the next milestone, you'll learn how to create exemptions to protect critical log streams from being dropped."
     },
     {
       "type": "markdown",

--- a/adaptive-logs-lj/review-apply/content.json
+++ b/adaptive-logs-lj/review-apply/content.json
@@ -16,6 +16,15 @@
       "content": "Adaptive Logs recalculates its pattern list and recommended drop rates every 24 hours using a rolling 15-day window of your log ingest and query behavior. When a pattern is first detected, Adaptive Logs delays displaying it for 7 days to gather enough usage information to recommend a reasonable drop rate."
     },
     {
+      "type": "multistep",
+      "content": "Navigate to **Adaptive Telemetry > Adaptive Logs**.",
+      "requirements": ["navmenu-open"],
+      "steps": [
+        { "action": "highlight", "reftarget": "a[data-testid='data-testid Nav menu item'][href='/adaptive-telemetry']" },
+        { "action": "highlight", "reftarget": "a[data-testid='data-testid Nav menu item'][href='/a/grafana-adaptivelogs-app/overview']" }
+      ]
+    },
+    {
       "type": "interactive",
       "action": "highlight",
       "reftarget": "[data-testid='data-testid Tab Patterns']",

--- a/adaptive-logs-lj/review-apply/content.json
+++ b/adaptive-logs-lj/review-apply/content.json
@@ -1,0 +1,65 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "adaptive-logs-review-apply",
+  "title": "Review and apply recommendations",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "Adaptive Logs provides you with a list of patterns and recommendations on which logs to drop based on usage patterns. You can filter, review, and edit drop rates to suit your needs.\n\nAfter reviewing, you apply the drop rates to implement the changes. The logs are then dropped upon ingestion into Grafana Cloud, reducing unnecessary log storage costs while ensuring that your observability remains intact."
+    },
+    {
+      "type": "markdown",
+      "content": "Adaptive Logs recalculates its pattern list and recommended drop rates every 24 hours using a rolling 15-day window of your log ingest and query behavior. When a pattern is first detected, Adaptive Logs delays displaying it for 7 days to gather enough usage information to recommend a reasonable drop rate."
+    },
+    {
+      "type": "interactive",
+      "action": "highlight",
+      "reftarget": "[data-testid='data-testid Tab Patterns']",
+      "content": "Select the **Patterns** tab to review patterns and recommendations for drop rates."
+    },
+    {
+      "type": "markdown",
+      "content": "On the **Patterns** tab, you can:\n\n- Filter patterns by service and frequency, making it easier to decide which log lines to drop\n- View the query frequency, volume, drop rate, recommended rate, and projected savings for each pattern\n- The **Recommended** column shows the recommended percentage of log lines to drop\n- The **Current(%)** column shows the percentage of lines currently being dropped\n- Expand a pattern to view a breakdown per service, including service name, percentage, savings, and volume\n- Click the **Open in Explore** icon to see log lines matching a pattern"
+    },
+    {
+      "type": "markdown",
+      "content": "## Apply all recommendations\n\nApplying all recommendations is the most effective and efficient way to optimize your log management. It saves time compared to manually reviewing each recommendation individually and gives you immediate cost savings."
+    },
+    {
+      "type": "section",
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "button",
+          "reftarget": "Apply all recommendations",
+          "content": "Click **Apply all recommendations** from the Adaptive Logs user interface.",
+          "doIt": false
+        },
+        {
+          "type": "markdown",
+          "content": "The **Apply recommended drop rate(s)** dialog box provides information about ingest volume vs projected volume and the projected savings of applying the recommendations."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Review the recommended drop rates in the dialog."
+        },
+        {
+          "type": "interactive",
+          "action": "button",
+          "reftarget": "Apply",
+          "content": "Click **Apply** to confirm.",
+          "doIt": false
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "In the next milestone, you'll learn how to create drop rules and label filters."
+    },
+    {
+      "type": "markdown",
+      "content": "---\n\n### More to explore (optional)\n\nAt this point in your journey, you can explore the following paths:\n\n- [Review and apply recommendations](/docs/grafana-cloud/adaptive-telemetry/adaptive-logs/manage-recommendations/)"
+    }
+  ]
+}

--- a/adaptive-logs-lj/segmentation/content.json
+++ b/adaptive-logs-lj/segmentation/content.json
@@ -138,7 +138,11 @@
     },
     {
       "type": "markdown",
-      "content": "---\n\n### More to explore (optional)\n\nAt this point in your journey, you can explore the following paths:\n\n- [Configure segments](/docs/grafana-cloud/adaptive-telemetry/adaptive-logs/additional-configuration/create-segment-overrides/)"
+      "content": "---\n\n### More to explore (optional)"
+    },
+    {
+      "type": "markdown",
+      "content": "At this point in your journey, you can explore the following paths:\n\n- [Configure segments](/docs/grafana-cloud/adaptive-telemetry/adaptive-logs/additional-configuration/create-segment-overrides/)"
     }
   ]
 }

--- a/adaptive-logs-lj/segmentation/content.json
+++ b/adaptive-logs-lj/segmentation/content.json
@@ -134,7 +134,7 @@
     },
     {
       "type": "markdown",
-      "content": "In the next milestone, you'll learn how to automatically apply recommendations."
+      "content": "In the next milestone, you'll learn how to monitor and validate that your configuration is delivering the expected results."
     },
     {
       "type": "markdown",

--- a/adaptive-logs-lj/segmentation/content.json
+++ b/adaptive-logs-lj/segmentation/content.json
@@ -1,0 +1,144 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "adaptive-logs-segmentation",
+  "title": "Create segments for teams",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "As organizations grow, you can use segmentation to manage Adaptive Logs per team, service, department, or system.\n\nTo create a new segment, complete the following steps."
+    },
+    {
+      "type": "section",
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='data-testid Tab Segments']",
+          "content": "Select the **Segments** tab."
+        },
+        {
+          "type": "interactive",
+          "action": "button",
+          "reftarget": "Add new segment",
+          "content": "Click **Add new segment**."
+        },
+        {
+          "type": "interactive",
+          "action": "formfill",
+          "reftarget": "#segment-name",
+          "targetvalue": "",
+          "content": "Enter a descriptive name that clearly identifies the team this segment applies to.",
+          "doIt": false
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "#segment-label",
+          "content": "Select the log stream label that distinguishes the metrics belonging to a particular team (for example, `namespace` in Kubernetes).",
+          "doIt": false
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "#segment-value",
+          "content": "Enter the values that match the label you specified (for example, `web-frontend`, `web-backend`). Each value can only be used once across segments.",
+          "doIt": false
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "(Optional) Select **Fallback to default pattern configuration** to apply default drop rates to log streams outside any segment."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='data-testid Confirm Modal Danger Button']",
+          "content": "Click **Add**.",
+          "doIt": false
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "## Set a per-segment drop rate for multiple patterns\n\nUse per-segment drop rate overrides to apply drop rates to patterns for specific segments."
+    },
+    {
+      "type": "section",
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Select the segment you want to set drop rates for."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Select the patterns for that particular segment."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[aria-label='drop-rate-edit']",
+          "content": "Click **Bulk edit service drop rates**.",
+          "doIt": false
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Enter the percentage drop rate you want to set for the segment. The projected savings after you apply changes is displayed."
+        },
+        {
+          "type": "interactive",
+          "action": "button",
+          "reftarget": "Apply",
+          "content": "Click **Apply**.",
+          "doIt": false
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "## Set per-segment drop rates within a specific pattern\n\nTo create drop rates for multiple segments producing logs with the same pattern, complete the following steps."
+    },
+    {
+      "type": "section",
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "On the **Pattern** tab, expand a pattern."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Review which services are producing logs with that pattern."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Click the **Edit** icon to edit drop rates."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Enter the percentage drop rate you want to add for each service. The projected savings after you apply changes is displayed."
+        },
+        {
+          "type": "interactive",
+          "action": "button",
+          "reftarget": "Apply",
+          "content": "Click **Apply**.",
+          "doIt": false
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "In the next milestone, you'll learn how to automatically apply recommendations."
+    },
+    {
+      "type": "markdown",
+      "content": "---\n\n### More to explore (optional)\n\nAt this point in your journey, you can explore the following paths:\n\n- [Configure segments](/docs/grafana-cloud/adaptive-telemetry/adaptive-logs/additional-configuration/create-segment-overrides/)"
+    }
+  ]
+}

--- a/adaptive-logs-lj/segmentation/content.json
+++ b/adaptive-logs-lj/segmentation/content.json
@@ -18,13 +18,13 @@
         },
         {
           "type": "interactive",
-          "action": "button",
+          "action": "noop",
           "reftarget": "Add new segment",
           "content": "Click **Add new segment**."
         },
         {
           "type": "interactive",
-          "action": "formfill",
+          "action": "noop",
           "reftarget": "#segment-name",
           "targetvalue": "",
           "content": "Enter a descriptive name that clearly identifies the team this segment applies to.",
@@ -32,14 +32,14 @@
         },
         {
           "type": "interactive",
-          "action": "highlight",
+          "action": "noop",
           "reftarget": "#segment-label",
           "content": "Select the log stream label that distinguishes the metrics belonging to a particular team (for example, `namespace` in Kubernetes).",
           "doIt": false
         },
         {
           "type": "interactive",
-          "action": "highlight",
+          "action": "noop",
           "reftarget": "#segment-value",
           "content": "Enter the values that match the label you specified (for example, `web-frontend`, `web-backend`). Each value can only be used once across segments.",
           "doIt": false
@@ -51,7 +51,7 @@
         },
         {
           "type": "interactive",
-          "action": "highlight",
+          "action": "noop",
           "reftarget": "[data-testid='data-testid Confirm Modal Danger Button']",
           "content": "Click **Add**.",
           "doIt": false
@@ -77,7 +77,7 @@
         },
         {
           "type": "interactive",
-          "action": "highlight",
+          "action": "noop",
           "reftarget": "[aria-label='drop-rate-edit']",
           "content": "Click **Bulk edit service drop rates**.",
           "doIt": false
@@ -89,7 +89,7 @@
         },
         {
           "type": "interactive",
-          "action": "button",
+          "action": "noop",
           "reftarget": "Apply",
           "content": "Click **Apply**.",
           "doIt": false

--- a/adaptive-logs-lj/value-adaptive-logs/content.json
+++ b/adaptive-logs-lj/value-adaptive-logs/content.json
@@ -1,0 +1,31 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "adaptive-logs-value-adaptive-logs",
+  "title": "The value of Adaptive Logs",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "As your observability footprint grows, log data can multiply fast — often faster than you need it to.\n\nAdaptive Logs is enabled by default, continuously analyzing your log patterns in the background to find optimization opportunities."
+    },
+    {
+      "type": "markdown",
+      "content": "This helps you:\n\n- Lower ingestion and storage costs\n- Speed up Explore queries and dashboards that render logs\n- Maintain observability quality as your environment grows\n- Automate ongoing optimization to prevent log sprawl"
+    },
+    {
+      "type": "markdown",
+      "content": "You can arrive at Adaptive Logs from different Grafana workflows depending on the problem you're trying to solve.\n\nNo matter where you begin, this journey shows how to analyze and optimize logs, so you keep only the data that delivers value."
+    },
+    {
+      "type": "markdown",
+      "content": "## Common entry points\n\n| Problem | Entry Point | Why Use Adaptive Logs |\n| ------- | ----------- | --------------------- |\n| You see a spike in log ingestion or cost, or receive a Billing & Usage alert | Cost Management & Billing | Identify which streams drive the increase and reduce redundant events or overly granular labels to lower cost |\n| Explore searches feel slow or time out | Explore | Find and optimize high-volume log patterns causing performance issues |\n| Alerts or SLO tracking tied to logs seem noisy or unstable | Alerting or SLOs | Remove duplicate, low-value, or overly granular logs that distort alert conditions |\n| You want to maintain consistent performance and cost control | Routine observability hygiene | Review recommendations and automate log optimization on a schedule |"
+    },
+    {
+      "type": "markdown",
+      "content": "In the next milestone, you learn how Adaptive Logs works."
+    },
+    {
+      "type": "markdown",
+      "content": "---\n\n### More to explore (optional)\n\nAt this point in your journey, you can explore the following paths:\n\n- [Adaptive Telemetry](/docs/grafana-cloud/adaptive-telemetry/)"
+    }
+  ]
+}

--- a/adaptive-logs-lj/value-adaptive-logs/content.json
+++ b/adaptive-logs-lj/value-adaptive-logs/content.json
@@ -25,7 +25,11 @@
     },
     {
       "type": "markdown",
-      "content": "---\n\n### More to explore (optional)\n\nAt this point in your journey, you can explore the following paths:\n\n- [Adaptive Telemetry](/docs/grafana-cloud/adaptive-telemetry/)"
+      "content": "---\n\n### More to explore (optional)"
+    },
+    {
+      "type": "markdown",
+      "content": "At this point in your journey, you can explore the following paths:\n\n- [Adaptive Telemetry](/docs/grafana-cloud/adaptive-telemetry/)"
     }
   ]
 }

--- a/index.json
+++ b/index.json
@@ -222,6 +222,24 @@
             }
         },
         {
+            "title": "Optimize your logs with Adaptive Logs",
+            "type": "interactive",
+            "description": "Step-by-step guide: Optimize your logs with Adaptive Logs.",
+            "url": "https://interactive-learning.grafana.net/guides/adaptive-logs-lj/content.json",
+            "match": {
+                "and": [
+                    { "targetPlatform": "cloud" },
+                    {
+                        "urlPrefixIn": [
+                            "/adaptive-telemetry",
+                            "/a/grafana-adaptivelogs-app",
+                            "/a/grafana-costmanagementui-app/logs"
+                        ]
+                    }
+                ]
+            }
+        },
+        {
             "title": "Reduce metrics volume using Adaptive Metrics recommendations",
             "type": "interactive",
             "description": "Hands-on guide: Reduce metrics volume safely with Adaptive Metrics.",


### PR DESCRIPTION
Scaffold 7 milestone content.json files for the Adaptive Logs learning journey with interactive Pathfinder steps for review-apply, exemptions, and segmentation milestones. Add recommendation entry to index.json.

Made-with: Cursor

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds new interactive-learning JSON content and a new `index.json` rule; no runtime logic changes beyond guide discovery/matching.
> 
> **Overview**
> Adds a new **Adaptive Logs learning journey** (`adaptive-logs-lj/*`) with milestone `content.json` files that walk users through reviewing/applying recommendations, creating exemptions, segmenting logs, monitoring results, and completing the journey.
> 
> Registers the journey in `index.json` so it can be surfaced in Grafana Cloud when users visit Adaptive Telemetry/Adaptive Logs (and Cost Management logs) via updated URL prefix matching.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b86ef6c9f8360637d1b1bfb270b890d96e68e474. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->