### PR TITLE
Add interactive guide for reverting pipeline versions

### DIFF
--- a/fleet-mgmt-pipeline-version/content.json
+++ b/fleet-mgmt-pipeline-version/content.json
@@ -58,7 +58,7 @@
       "id": "guide-section-54137",
       "title": "Revert a configuration pipeline version",
       "requirements": [
-        "on-page:/grafana-collector-app/fleet-management/remote-configuration"
+        "on-page:/a/grafana-collector-app/fleet-management/remote-configuration"
       ]
     }
   ]

--- a/fleet-mgmt-pipeline-version/content.json
+++ b/fleet-mgmt-pipeline-version/content.json
@@ -49,7 +49,7 @@
             },
             {
               "action": "highlight",
-              "reftarget": "div[data-testid='data-testid portal-container'] button:nth-match(7)",
+              "reftarget": "div[data-testid='data-testid portal-container'] button:contains('Restore')",
               "description": "Click the Restore button to restore the pipeline version."
             }
           ]

--- a/fleet-mgmt-pipeline-version/content.json
+++ b/fleet-mgmt-pipeline-version/content.json
@@ -19,9 +19,6 @@
           "action": "highlight",
           "reftarget": "svg[data-testid='icon-history']:nth-match(1)",
           "content": "Click the Pipeline history icon for the configuration pipeline you want to revert.",
-          "requirements": [
-            "exists-reftarget"
-          ],
           "doIt": false
         },
         {

--- a/fleet-mgmt-pipeline-version/content.json
+++ b/fleet-mgmt-pipeline-version/content.json
@@ -1,0 +1,65 @@
+{
+  "id": "fleet-mgmt-pipeline-version",
+  "title": "Switch pipeline versions",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "This guide teaches you how to revert to a previous version of a configuration pipeline.\n\nGrafana Fleet Management tracks changes to configuration pipelines and displays them in the **Pipelines history** feature on the **Remote configuration** tab. With this history, your team can collaborate more efficiently, ensure audit compliance, and troubleshoot issues caused by configuration changes.\n\nThe log tracks creation and deletion of pipelines, changes to configuration content, and modifications to matching attributes. You can review changes for a specific pipeline by searching the log for a pipeline name, ID, or matching attribute."
+    },
+    {
+      "type": "section",
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Find the configuration pipeline by searching the log for a pipeline name, ID, or matching attribute."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "svg[data-testid='icon-history']:nth-match(1)",
+          "content": "Click the Pipeline history icon for the configuration pipeline you want to revert.",
+          "requirements": [
+            "exists-reftarget"
+          ],
+          "doIt": false
+        },
+        {
+          "type": "interactive",
+          "action": "button",
+          "reftarget": "History details",
+          "content": "Click the History details button for the change you want to review.",
+          "doIt": false
+        },
+        {
+          "type": "guided",
+          "content": "Once you're sure this is the version you want, click Restore to review your selection and pick the matching attributes to apply.",
+          "steps": [
+            {
+              "action": "button",
+              "reftarget": "Restore",
+              "description": "Click the Restore button to review the configuration pipeline."
+            },
+            {
+              "action": "hover",
+              "reftarget": "div[id='pipeline-history-restore-attributes-fake-empty-checkspace']",
+              "description": "Review the configuration and select the matching attributes you want to apply.",
+              "lazyRender": true,
+              "skippable": true
+            },
+            {
+              "action": "highlight",
+              "reftarget": "div[data-testid='data-testid portal-container'] button:nth-match(7)",
+              "description": "Click the Restore button to restore the pipeline version."
+            }
+          ]
+        }
+      ],
+      "id": "guide-section-54137",
+      "title": "Revert a configuration pipeline version",
+      "requirements": [
+        "on-page:/grafana-collector-app/fleet-management/remote-configuration"
+      ]
+    }
+  ]
+}

--- a/index.json
+++ b/index.json
@@ -285,6 +285,22 @@
                     { "source": "play.grafana.org" }
                 ]
             }
+        },
+        {
+            "id": "fleet-mgmt-pipeline-version",
+            "title": "Switch pipeline versions",
+            "type": "docs-page",
+            "url": "https://interactive-learning.grafana.net/fleet-mgmt-pipeline-version/content.json",
+            "match": {
+                "or": [
+                    {
+                        "urlPrefix": "/grafana-collector-app/fleet-management/remote-configuration"
+                    },
+                    {
+                        "urlRegex": "/grafana-collector-app/fleet-management/fleet-inventory?collector_id=.*&collector_tab=configuration"
+                    }
+                ]
+            }
         }
     ]
 }

--- a/index.json
+++ b/index.json
@@ -291,14 +291,14 @@
             "title": "Switch pipeline versions",
             "type": "docs-page",
             "description": "Hands-on guide: Learn how to revert to a previous version of a Fleet Management configuration pipeline.",
-            "url": "https://interactive-learning.grafana.net/fleet-mgmt-pipeline-version/content.json",
+            "url": "https://interactive-learning.grafana.net/guides/fleet-mgmt-pipeline-version/content.json",
             "match": {
                 "or": [
                     {
-                        "urlPrefix": "/grafana-collector-app/fleet-management/remote-configuration"
+                        "urlPrefix": "/a/grafana-collector-app/fleet-management/remote-configuration"
                     },
                     {
-                        "urlRegex": "/grafana-collector-app/fleet-management/fleet-inventory?collector_id=.*&collector_tab=configuration"
+                        "urlRegex": "/a/grafana-collector-app/fleet-management/fleet-inventory\\?collector_id=.*&collector_tab=configuration"
                     }
                 ]
             }

--- a/index.json
+++ b/index.json
@@ -290,6 +290,7 @@
             "id": "fleet-mgmt-pipeline-version",
             "title": "Switch pipeline versions",
             "type": "docs-page",
+            "description": "Hands-on guide: Learn how to revert to a previous version of a Fleet Management configuration pipeline.",
             "url": "https://interactive-learning.grafana.net/fleet-mgmt-pipeline-version/content.json",
             "match": {
                 "or": [


### PR DESCRIPTION
## New interactive guide: Switch pipeline versions

### Description

This guide teaches you how to revert to a previous version of a Fleet Management configuration pipeline, including steps and interactive elements.

### Checklist
- [x] Guide JSON is valid and renders correctly in the block editor
- [x] All selectors have been tested in the target Grafana version
- [x] Guide has appropriate requirements for each step

### Index registration
To make this guide discoverable by the recommender, add an entry to `index.json`:

```json
{
  "id": "fleet-mgmt-pipeline-version",
  "title": "Switch pipeline versions",
  "type": "docs-page",
  "url": "https://interactive-learning.grafana.net/fleet-mgmt-pipeline-version/content.json",
 "match": {
        "or": [
          {
            "urlPrefix": "/grafana-collector-app/fleet-management/remote-configuration"
          },
          {
            "urlRegex": "/grafana-collector-app/fleet-management/fleet-inventory?collector_id=.*&collector_tab=configuration"
          }
        ]
      }
}
```

<!-- Adjust urlPrefix based on where this guide should appear -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk content-only change that adds a new interactive guide and registers it in `index.json`; main risk is incorrect selectors/URL match rules affecting guide discoverability or runtime highlighting.
> 
> **Overview**
> Adds a new Fleet Management interactive guide (`fleet-mgmt-pipeline-version/content.json`) that walks users through viewing pipeline history and restoring a previous configuration pipeline version.
> 
> Registers the guide in `index.json` so it’s recommended on Fleet Management Remote Configuration and Fleet Inventory configuration URLs via `urlPrefix`/`urlRegex` matching.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0c6cf573617a15ddc4a7c6da6f90edbabbdac91e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->