### PR TITLE
Add interactive guide content for kafka-monitoring learning path

### DIFF
--- a/kafka-monitoring-lj/advantages-grafana-alloy/content.json
+++ b/kafka-monitoring-lj/advantages-grafana-alloy/content.json
@@ -1,0 +1,23 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "kafka-monitoring-advantages-grafana-alloy",
+  "title": "Advantages of Grafana Alloy for Kafka",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "Grafana Alloy simplifies Kafka monitoring by providing native support for JMX metrics collection without complex exporter configurations. Traditional Kafka monitoring often requires deploying and managing separate Prometheus JMX exporters on each broker, adding operational complexity and potential points of failure. Alloy eliminates this overhead with built-in JMX scraping capabilities."
+    },
+    {
+      "type": "markdown",
+      "content": "Alloy's vendor-neutral architecture based on OpenTelemetry enables seamless integration with Kafka clusters while automatically scaling based on metrics volume. This reduces operational overhead compared to managing multiple monitoring agents, and its efficient metrics processing helps optimize data transfer costs to Grafana Cloud."
+    },
+    {
+      "type": "markdown",
+      "content": "Grafana Alloy offers the following advantages for Kafka monitoring:\n\n- Native JMX scraping eliminates the need for separate Prometheus JMX exporters.\n- Single binary deployment simplifies installation and management across Kafka brokers.\n- Automatic scaling adjusts resource usage based on metrics volume.\n- Built-in metrics processing and filtering reduces data transfer costs.\n- Support for multiple data pipelines including Prometheus, OpenTelemetry, and Loki.\n- Configuration hot-reloading applies changes without service restarts.\n- Comprehensive service discovery automatically detects new Kafka brokers."
+    },
+    {
+      "type": "markdown",
+      "content": "In the next milestone, you install Grafana Alloy on the machine where you'll collect Kafka metrics."
+    }
+  ]
+}

--- a/kafka-monitoring-lj/advantages-grafana-alloy/content.json
+++ b/kafka-monitoring-lj/advantages-grafana-alloy/content.json
@@ -5,7 +5,7 @@
   "blocks": [
     {
       "type": "markdown",
-      "content": "Grafana Alloy simplifies Kafka monitoring by providing native support for JMX metrics collection without complex exporter configurations. Traditional Kafka monitoring often requires deploying and managing separate Prometheus JMX exporters on each broker, adding operational complexity and potential points of failure. Alloy eliminates this overhead with built-in JMX scraping capabilities."
+      "content": "Grafana Alloy simplifies Kafka monitoring by connecting directly to the JMX remote access you just enabled on your Kafka brokers. Traditional Kafka monitoring often requires deploying and managing a separate Prometheus JMX exporter process on each broker — in addition to enabling JMX remote access — adding operational complexity and potential points of failure. Alloy eliminates this extra component by scraping JMX metrics directly, with no additional exporter process required."
     },
     {
       "type": "markdown",

--- a/kafka-monitoring-lj/configure-alloy-kafka-metrics/content.json
+++ b/kafka-monitoring-lj/configure-alloy-kafka-metrics/content.json
@@ -9,6 +9,7 @@
     },
     {
       "type": "section",
+      "autoCollapse": false,
       "blocks": [
         {
           "type": "interactive",
@@ -48,11 +49,11 @@
     },
     {
       "type": "markdown",
-      "content": "---\n\n### More to explore (optional)\n\nAt this point in your journey, you can explore the following paths:\n\n- [Configure Grafana Alloy](/docs/alloy/latest/configure/)\n- [Prometheus JMX receiver component reference](/docs/alloy/latest/reference/components/prometheus/prometheus.exporter.jmx/)"
+      "content": "---\n\n### More to explore (optional)\n\nAt this point in your journey, you can explore the following paths:\n\n- [Configure Grafana Alloy](https://grafana.com/docs/alloy/latest/configure/)\n- [Prometheus JMX receiver component reference](https://grafana.com/docs/alloy/latest/reference/components/prometheus/prometheus.exporter.jmx/)"
     },
     {
       "type": "markdown",
-      "content": "---\n\n### Troubleshooting\n\nExplore the following troubleshooting topics if you need help:\n\n- [Alloy service fails to restart or shows configuration errors](/docs/grafana-cloud/monitor-infrastructure/integrations/troubleshoot/install-troubleshoot-linux-alloy/#alloy-service-fails-to-start)\n- [Configuration file syntax errors](/docs/alloy/latest/configure/)\n- [Cannot connect to Kafka JMX endpoints](/docs/grafana-cloud/monitor-infrastructure/integrations/troubleshoot/)"
+      "content": "---\n\n### Troubleshooting\n\nExplore the following troubleshooting topics if you need help:\n\n- [Alloy service fails to restart or shows configuration errors](https://grafana.com/docs/grafana-cloud/monitor-infrastructure/integrations/troubleshoot/install-troubleshoot-linux-alloy/#alloy-service-fails-to-start)\n- [Configuration file syntax errors](https://grafana.com/docs/alloy/latest/configure/)\n- [Cannot connect to Kafka JMX endpoints](https://grafana.com/docs/grafana-cloud/monitor-infrastructure/integrations/troubleshoot/)"
     }
   ]
 }

--- a/kafka-monitoring-lj/configure-alloy-kafka-metrics/content.json
+++ b/kafka-monitoring-lj/configure-alloy-kafka-metrics/content.json
@@ -21,7 +21,9 @@
         },
         {
           "type": "interactive",
-          "action": "noop",
+          "action": "formfill",
+          "reftarget": "[data-testid='search-input-input']",
+          "targetvalue": "Kafka",
           "content": "In the search box, type **Kafka** to find the integration."
         },
         {

--- a/kafka-monitoring-lj/configure-alloy-kafka-metrics/content.json
+++ b/kafka-monitoring-lj/configure-alloy-kafka-metrics/content.json
@@ -49,7 +49,7 @@
     },
     {
       "type": "markdown",
-      "content": "---\n\n### More to explore (optional)\n\nAt this point in your journey, you can explore the following paths:\n\n- [Configure Grafana Alloy](https://grafana.com/docs/alloy/latest/configure/)\n- [Prometheus JMX receiver component reference](https://grafana.com/docs/alloy/latest/reference/components/prometheus/prometheus.exporter.jmx/)"
+      "content": "---\n\n### More to explore (optional)\n\nAt this point in your journey, you can explore the following paths:\n\n- [Configure Grafana Alloy](https://grafana.com/docs/alloy/latest/configure/)\n- [Prometheus Kafka receiver component reference](https://grafana.com/docs/alloy/latest/reference/components/prometheus/prometheus.exporter.kafka/)"
     },
     {
       "type": "markdown",

--- a/kafka-monitoring-lj/configure-alloy-kafka-metrics/content.json
+++ b/kafka-monitoring-lj/configure-alloy-kafka-metrics/content.json
@@ -11,31 +11,9 @@
       "type": "section",
       "blocks": [
         {
-          "type": "multistep",
-          "content": "Navigate to **Connections > Add new connection**.",
-          "requirements": ["navmenu-open"],
-          "steps": [
-            { "action": "highlight", "reftarget": "a[data-testid='data-testid Nav menu item'][href='/connections']" },
-            { "action": "highlight", "reftarget": "a[data-testid='data-testid Nav menu item'][href='/connections/add-new-connection']" }
-          ]
-        },
-        {
-          "type": "interactive",
-          "action": "formfill",
-          "reftarget": "[data-testid='search-input-input']",
-          "targetvalue": "Kafka",
-          "content": "In the search box, type **Kafka** to find the integration."
-        },
-        {
-          "type": "interactive",
-          "action": "highlight",
-          "reftarget": "a[href='/connections/add-new-connection/kafka']",
-          "content": "Select the **Kafka** integration tile."
-        },
-        {
           "type": "interactive",
           "action": "noop",
-          "content": "In the **Set up Grafana Alloy to use the Kafka integration** section, copy the provided Alloy configuration snippet for Kafka."
+          "content": "On the Kafka integration page, scroll to the **Set up Grafana Alloy to use the Kafka integration** section and copy the provided Alloy configuration snippet for Kafka."
         },
         {
           "type": "interactive",
@@ -66,7 +44,7 @@
     },
     {
       "type": "markdown",
-      "content": "In the next milestone, you verify that Kafka metrics are flowing to Grafana Cloud."
+      "content": "In the next milestone, you install the pre-built Kafka dashboards and alerts."
     },
     {
       "type": "markdown",

--- a/kafka-monitoring-lj/configure-alloy-kafka-metrics/content.json
+++ b/kafka-monitoring-lj/configure-alloy-kafka-metrics/content.json
@@ -1,0 +1,78 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "kafka-monitoring-configure-alloy-kafka-metrics",
+  "title": "Configure Alloy for Kafka metrics",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "Grafana Alloy collects Kafka metrics by scraping JMX metrics from your Kafka brokers. This requires adding a Kafka integration configuration block to the Alloy config file, which tells Alloy where to find your brokers, how often to collect metrics, and where to send the collected data.\n\nThe key configuration parameters include broker endpoints with their JMX ports, scrape intervals that determine how frequently metrics are collected, and Grafana Cloud remote write settings that enable metrics forwarding. The configuration provided through Grafana Cloud comes pre-populated with your stack-specific connection details."
+    },
+    {
+      "type": "section",
+      "blocks": [
+        {
+          "type": "multistep",
+          "content": "Navigate to **Connections > Add new connection**.",
+          "requirements": ["navmenu-open"],
+          "steps": [
+            { "action": "highlight", "reftarget": "a[data-testid='data-testid Nav menu item'][href='/connections']" },
+            { "action": "highlight", "reftarget": "a[data-testid='data-testid Nav menu item'][href='/connections/add-new-connection']" }
+          ]
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "In the search box, type **Kafka** to find the integration."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "a[href='/connections/add-new-connection/kafka']",
+          "content": "Select the **Kafka** integration tile."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "In the **Set up Grafana Alloy to use the Kafka integration** section, copy the provided Alloy configuration snippet for Kafka."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "**On the machine where Alloy is installed**, open the Alloy configuration file:\n\n- **Linux:** `/etc/alloy/config.alloy`\n- **macOS (Homebrew):** `/opt/homebrew/etc/alloy/config.alloy`\n- **Windows:** `C:\\Program Files\\GrafanaLabs\\Alloy\\config.alloy`\n- **Docker:** Depends on your volume mount configuration\n\nFor more information, refer to [Grafana Alloy configuration file locations](/docs/alloy/latest/configure/)."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Paste the Kafka configuration snippet into the config file, then update the targets list with your Kafka broker addresses and JMX ports. For example:\n\n```\ntargets = [{__address__ = \"kafka-broker-1:9999\"}, {__address__ = \"kafka-broker-2:9999\"}]\n```"
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Review the `forward_to` parameter to ensure it points to your Grafana Cloud remote write endpoint. Optionally, adjust the `scrape_interval` (default is typically 60s). Save the configuration file."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Restart the Alloy service to apply the new configuration:\n\n- **Linux:** `sudo systemctl restart alloy`\n- **macOS:** `brew services restart alloy`\n- **Windows:** Restart the Alloy service from Services Manager"
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Check the Alloy logs to confirm the service restarted successfully and is connecting to your Kafka brokers."
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "In the next milestone, you verify that Kafka metrics are flowing to Grafana Cloud."
+    },
+    {
+      "type": "markdown",
+      "content": "---\n\n### More to explore (optional)\n\nAt this point in your journey, you can explore the following paths:\n\n- [Configure Grafana Alloy](/docs/alloy/latest/configure/)\n- [Prometheus JMX receiver component reference](/docs/alloy/latest/reference/components/prometheus/prometheus.exporter.jmx/)"
+    },
+    {
+      "type": "markdown",
+      "content": "---\n\n### Troubleshooting\n\nExplore the following troubleshooting topics if you need help:\n\n- [Alloy service fails to restart or shows configuration errors](/docs/grafana-cloud/monitor-infrastructure/integrations/troubleshoot/install-troubleshoot-linux-alloy/#alloy-service-fails-to-start)\n- [Configuration file syntax errors](/docs/alloy/latest/configure/)\n- [Cannot connect to Kafka JMX endpoints](/docs/grafana-cloud/monitor-infrastructure/integrations/troubleshoot/)"
+    }
+  ]
+}

--- a/kafka-monitoring-lj/configure-jmx-exporter/content.json
+++ b/kafka-monitoring-lj/configure-jmx-exporter/content.json
@@ -21,7 +21,7 @@
     },
     {
       "type": "markdown",
-      "content": "In the next milestone, you configure Grafana Alloy to collect metrics from your Kafka brokers."
+      "content": "In the next milestone, you learn about the advantages of using Grafana Alloy for Kafka metrics collection."
     },
     {
       "type": "markdown",

--- a/kafka-monitoring-lj/configure-jmx-exporter/content.json
+++ b/kafka-monitoring-lj/configure-jmx-exporter/content.json
@@ -5,7 +5,7 @@
   "blocks": [
     {
       "type": "markdown",
-      "content": "Kafka exposes operational metrics through Java Management Extensions (JMX), which requires enabling JMX remote access on your Kafka brokers. JMX provides comprehensive visibility into broker performance, topic statistics, partition health, and other critical operational data that Grafana Alloy can collect and send to Grafana Cloud."
+      "content": "Kafka exposes operational metrics through Java Management Extensions (JMX), which requires enabling JMX remote access on your Kafka brokers. JMX provides comprehensive visibility into broker performance, topic statistics, partition health, and other critical operational data that your monitoring tool can collect and forward to Grafana Cloud."
     },
     {
       "type": "markdown",

--- a/kafka-monitoring-lj/configure-jmx-exporter/content.json
+++ b/kafka-monitoring-lj/configure-jmx-exporter/content.json
@@ -25,11 +25,11 @@
     },
     {
       "type": "markdown",
-      "content": "---\n\n### More to explore (optional)\n\nAt this point in your journey, you can explore the following paths:\n\n- [Kafka JMX Metrics Reference](/docs/grafana-cloud/monitor-infrastructure/integrations/integration-reference/integration-kafka/)"
+      "content": "---\n\n### More to explore (optional)\n\nAt this point in your journey, you can explore the following paths:\n\n- [Kafka JMX Metrics Reference](https://grafana.com/docs/grafana-cloud/monitor-infrastructure/integrations/integration-reference/integration-kafka/)"
     },
     {
       "type": "markdown",
-      "content": "---\n\n### Troubleshooting\n\nExplore the following troubleshooting topics if you need help:\n\n- [Kafka integration troubleshooting](/docs/grafana-cloud/monitor-infrastructure/integrations/troubleshoot/)\n- [Cannot connect to JMX port or metrics not appearing](/docs/grafana-cloud/monitor-infrastructure/integrations/integration-reference/integration-kafka/#troubleshooting)"
+      "content": "---\n\n### Troubleshooting\n\nExplore the following troubleshooting topics if you need help:\n\n- [Kafka integration troubleshooting](https://grafana.com/docs/grafana-cloud/monitor-infrastructure/integrations/troubleshoot/)\n- [Cannot connect to JMX port or metrics not appearing](https://grafana.com/docs/grafana-cloud/monitor-infrastructure/integrations/integration-reference/integration-kafka/#troubleshooting)"
     }
   ]
 }

--- a/kafka-monitoring-lj/configure-jmx-exporter/content.json
+++ b/kafka-monitoring-lj/configure-jmx-exporter/content.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "kafka-monitoring-configure-jmx-exporter",
+  "title": "Configure Kafka JMX exporter",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "Kafka exposes operational metrics through Java Management Extensions (JMX), which requires enabling JMX remote access on your Kafka brokers. JMX provides comprehensive visibility into broker performance, topic statistics, partition health, and other critical operational data that Grafana Alloy can collect and send to Grafana Cloud."
+    },
+    {
+      "type": "markdown",
+      "content": "To configure JMX settings, you'll set the JMX port and authentication options based on your security requirements. The configuration typically involves setting environment variables that the Kafka broker reads during startup to enable JMX remote access."
+    },
+    {
+      "type": "markdown",
+      "content": "**On your Kafka broker server**, complete the following steps:\n\n1. Locate the Kafka configuration directory (typically `/opt/kafka/config` or `/etc/kafka`).\n1. Edit the `server.properties` file or create a `kafka-run-class.sh` override.\n1. Add or update the following JMX environment variables in your Kafka startup script or systemd service file:\n\n   ```bash\n   export JMX_PORT=9999\n   export KAFKA_JMX_OPTS=\"-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.port=9999\"\n   ```\n\n1. If running multiple brokers, ensure each broker uses a unique JMX port or IP binding.\n1. Restart the Kafka broker service to apply the JMX configuration changes.\n1. Verify the JMX port is accessible: `telnet localhost 9999`."
+    },
+    {
+      "type": "markdown",
+      "content": "The JMX port responds to connection attempts and you can access JMX metrics from the Kafka broker. Repeat these steps for all brokers in your cluster."
+    },
+    {
+      "type": "markdown",
+      "content": "In the next milestone, you configure Grafana Alloy to collect metrics from your Kafka brokers."
+    },
+    {
+      "type": "markdown",
+      "content": "---\n\n### More to explore (optional)\n\nAt this point in your journey, you can explore the following paths:\n\n- [Kafka JMX Metrics Reference](/docs/grafana-cloud/monitor-infrastructure/integrations/integration-reference/integration-kafka/)"
+    },
+    {
+      "type": "markdown",
+      "content": "---\n\n### Troubleshooting\n\nExplore the following troubleshooting topics if you need help:\n\n- [Kafka integration troubleshooting](/docs/grafana-cloud/monitor-infrastructure/integrations/troubleshoot/)\n- [Cannot connect to JMX port or metrics not appearing](/docs/grafana-cloud/monitor-infrastructure/integrations/integration-reference/integration-kafka/#troubleshooting)"
+    }
+  ]
+}

--- a/kafka-monitoring-lj/end-journey/content.json
+++ b/kafka-monitoring-lj/end-journey/content.json
@@ -21,7 +21,7 @@
     },
     {
       "type": "markdown",
-      "content": "---\n\n### Related paths\n\nConsider taking the following paths after you complete this journey.\n\n- [Explore metrics using Metrics Drilldown](/docs/learning-paths/drilldown-metrics/)\n- [Create infrastructure alerts](/docs/learning-paths/infrastructure-alerting/)\n- [Explore logs using Logs Drilldown](/docs/learning-paths/drilldown-logs/)"
+      "content": "---\n\n### Related paths\n\nConsider taking the following paths after you complete this journey.\n\n- [Explore metrics using Metrics Drilldown](https://grafana.com/docs/learning-paths/drilldown-metrics/)\n- [Create infrastructure alerts](https://grafana.com/docs/learning-paths/infrastructure-alerting/)\n- [Explore logs using Logs Drilldown](https://grafana.com/docs/learning-paths/drilldown-logs/)"
     }
   ]
 }

--- a/kafka-monitoring-lj/end-journey/content.json
+++ b/kafka-monitoring-lj/end-journey/content.json
@@ -1,0 +1,27 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "kafka-monitoring-end-journey",
+  "title": "Destination reached!",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "Congratulations on completing this journey! Job well done!"
+    },
+    {
+      "type": "markdown",
+      "content": "You've successfully implemented comprehensive Kafka monitoring with Grafana Cloud and gained valuable event streaming observability skills."
+    },
+    {
+      "type": "markdown",
+      "content": "Here's what you accomplished on this journey:\n\n- Understood the value of comprehensive Kafka monitoring for maintaining reliable message streaming.\n- Learned about Grafana Alloy's advantages for collecting Kafka metrics efficiently.\n- Installed Grafana Alloy on a monitoring server with access to your Kafka cluster.\n- Configured JMX metrics exposure on your Kafka brokers.\n- Set up Alloy to scrape and forward Kafka metrics to Grafana Cloud.\n- Verified successful metrics collection through Grafana Explore.\n- Installed pre-built dashboards for cluster overview, broker performance, and topic analysis.\n- Explored key Kafka performance indicators and learned to interpret cluster health metrics."
+    },
+    {
+      "type": "markdown",
+      "content": "Now that you have Kafka monitoring set up, consider these related paths to expand your observability capabilities and protect your event streaming infrastructure."
+    },
+    {
+      "type": "markdown",
+      "content": "---\n\n### Related paths\n\nConsider taking the following paths after you complete this journey.\n\n- [Explore metrics using Metrics Drilldown](/docs/learning-paths/drilldown-metrics/)\n- [Create infrastructure alerts](/docs/learning-paths/infrastructure-alerting/)\n- [Explore logs using Logs Drilldown](/docs/learning-paths/drilldown-logs/)"
+    }
+  ]
+}

--- a/kafka-monitoring-lj/explore-kafka-metrics/content.json
+++ b/kafka-monitoring-lj/explore-kafka-metrics/content.json
@@ -13,6 +13,7 @@
     },
     {
       "type": "section",
+      "autoCollapse": false,
       "blocks": [
         {
           "type": "interactive",

--- a/kafka-monitoring-lj/explore-kafka-metrics/content.json
+++ b/kafka-monitoring-lj/explore-kafka-metrics/content.json
@@ -1,0 +1,80 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "kafka-monitoring-explore-kafka-metrics",
+  "title": "Explore Kafka metrics",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "Understanding how to interpret the key Kafka performance metrics displayed in your dashboards is essential for maintaining a healthy cluster. Important metrics include message throughput, byte rates, consumer lag, under-replicated partitions, and request latencies."
+    },
+    {
+      "type": "markdown",
+      "content": "Normal operating ranges vary by workload, but certain metrics have clear indicators of problems. Under-replicated partitions should typically be **0** in a healthy cluster, the active controller count should always be **1**, and consumer lag should remain low relative to your message ingestion rate."
+    },
+    {
+      "type": "section",
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "a[data-testid='data-testid Nav menu item'][href='/dashboards']",
+          "requirements": ["navmenu-open"],
+          "content": "Navigate to **Dashboards** from the main menu."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Find and open the **Kafka** dashboards folder, then open the **Kafka Overview** dashboard."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Review the **Messages In Rate** panel to see the volume of messages being produced to your topics."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Check the **Bytes In/Out Rate** panels to monitor data throughput across your cluster."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Examine the **Under Replicated Partitions** panel — this should typically be **0** in a healthy cluster."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Review the **Request Latency** panels to identify slow produce or fetch requests."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Check the **Active Controller Count** panel — this should always be **1** in a healthy cluster."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Navigate to the **Kafka Broker Metrics** dashboard to view individual broker performance, including CPU usage, network throughput, and request queue size."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Explore the **Kafka Topic Metrics** dashboard to analyze per-topic message rates and retention."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Use the time range selector to analyze historical trends and identify patterns."
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "You can now interpret the Kafka metrics displayed across your dashboards and identify which panels indicate healthy operation versus potential issues."
+    },
+    {
+      "type": "markdown",
+      "content": "In the next milestone, you celebrate completing this learning journey!"
+    }
+  ]
+}

--- a/kafka-monitoring-lj/install-dashboards/content.json
+++ b/kafka-monitoring-lj/install-dashboards/content.json
@@ -13,6 +13,7 @@
     },
     {
       "type": "section",
+      "autoCollapse": false,
       "blocks": [
         {
           "type": "interactive",
@@ -33,11 +34,12 @@
         },
         {
           "type": "multistep",
-          "content": "Navigate to **Alerts & IRM > Alerting > Manage alert rules**.",
+          "content": "Navigate to **Alerts & IRM > Alerting > Alert rules**.",
           "requirements": ["navmenu-open"],
           "steps": [
             { "action": "highlight", "reftarget": "a[data-testid='data-testid Nav menu item'][href='/alerts-and-incidents']" },
-            { "action": "navigate", "reftarget": "/alerting/list" }
+            { "action": "highlight", "reftarget": "a[data-testid='data-testid Nav menu item'][href='/alerting']" },
+            { "action": "highlight", "reftarget": "a[data-testid='data-testid Nav menu item'][href='/alerting/list']" }
           ]
         }
       ]
@@ -52,7 +54,7 @@
     },
     {
       "type": "markdown",
-      "content": "---\n\n### Troubleshooting\n\nExplore the following troubleshooting topics if you need help:\n\n- [Dashboards and alerts don't appear](/docs/grafana/latest/dashboards/troubleshoot-dashboards/)"
+      "content": "---\n\n### Troubleshooting\n\nExplore the following troubleshooting topics if you need help:\n\n- [Dashboards and alerts don't appear](https://grafana.com/docs/grafana/latest/dashboards/troubleshoot-dashboards/)"
     }
   ]
 }

--- a/kafka-monitoring-lj/install-dashboards/content.json
+++ b/kafka-monitoring-lj/install-dashboards/content.json
@@ -15,28 +15,6 @@
       "type": "section",
       "blocks": [
         {
-          "type": "multistep",
-          "content": "Navigate to **Connections > Add new connection**.",
-          "requirements": ["navmenu-open"],
-          "steps": [
-            { "action": "highlight", "reftarget": "a[data-testid='data-testid Nav menu item'][href='/connections']" },
-            { "action": "highlight", "reftarget": "a[data-testid='data-testid Nav menu item'][href='/connections/add-new-connection']" }
-          ]
-        },
-        {
-          "type": "interactive",
-          "action": "formfill",
-          "reftarget": "[data-testid='search-input-input']",
-          "targetvalue": "Kafka",
-          "content": "In the search box, type **Kafka** to find the integration."
-        },
-        {
-          "type": "interactive",
-          "action": "highlight",
-          "reftarget": "a[href='/connections/add-new-connection/kafka']",
-          "content": "Select the **Kafka** integration tile."
-        },
-        {
           "type": "interactive",
           "action": "highlight",
           "reftarget": "[data-testid='install-button']",
@@ -70,7 +48,7 @@
     },
     {
       "type": "markdown",
-      "content": "In the next milestone, you learn about the pre-built dashboards included with the Kafka integration."
+      "content": "In the next milestone, you verify that Kafka metrics are flowing to Grafana Cloud."
     },
     {
       "type": "markdown",

--- a/kafka-monitoring-lj/install-dashboards/content.json
+++ b/kafka-monitoring-lj/install-dashboards/content.json
@@ -1,0 +1,80 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "kafka-monitoring-install-dashboards",
+  "title": "Install Kafka dashboards and alerts",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "The Grafana Cloud Kafka integration comes with pre-built dashboards and alerts that you can use immediately. In this milestone, you install those dashboards and alerts, then navigate to confirm they are available."
+    },
+    {
+      "type": "markdown",
+      "content": "> **Did you know?** You aren't limited to using the pre-built dashboards and alerts. You can create your own custom dashboards and alerts to meet your specific monitoring needs."
+    },
+    {
+      "type": "section",
+      "blocks": [
+        {
+          "type": "multistep",
+          "content": "Navigate to **Connections > Add new connection**.",
+          "requirements": ["navmenu-open"],
+          "steps": [
+            { "action": "highlight", "reftarget": "a[data-testid='data-testid Nav menu item'][href='/connections']" },
+            { "action": "highlight", "reftarget": "a[data-testid='data-testid Nav menu item'][href='/connections/add-new-connection']" }
+          ]
+        },
+        {
+          "type": "interactive",
+          "action": "formfill",
+          "reftarget": "[data-testid='search-input-input']",
+          "targetvalue": "Kafka",
+          "content": "In the search box, type **Kafka** to find the integration."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "a[href='/connections/add-new-connection/kafka']",
+          "content": "Select the **Kafka** integration tile."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='install-button']",
+          "content": "Scroll down to the **Install dashboards and alerts** section and click **Install**. You should see the message: **Dashboards and alerts have been installed.**"
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='view-dashboards-button']",
+          "content": "Click **View Dashboards** to open the Kafka dashboards folder. A folder containing the Kafka dashboards appears."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "To see the installed alerts, click the **Home** button in the top left corner of the screen. The left-side menu appears."
+        },
+        {
+          "type": "multistep",
+          "content": "Navigate to **Alerts & IRM > Alerting > Manage alert rules**.",
+          "requirements": ["navmenu-open"],
+          "steps": [
+            { "action": "highlight", "reftarget": "a[data-testid='data-testid Nav menu item'][href='/alerts-and-incidents']" },
+            { "action": "navigate", "reftarget": "/alerting/list" }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "The Alert rules page shows all active alerts. Kafka integration alerts begin with **integrations-kafka**."
+    },
+    {
+      "type": "markdown",
+      "content": "In the next milestone, you learn about the pre-built dashboards included with the Kafka integration."
+    },
+    {
+      "type": "markdown",
+      "content": "---\n\n### Troubleshooting\n\nExplore the following troubleshooting topics if you need help:\n\n- [Dashboards and alerts don't appear](/docs/grafana/latest/dashboards/troubleshoot-dashboards/)"
+    }
+  ]
+}

--- a/kafka-monitoring-lj/install-dashboards/content.json
+++ b/kafka-monitoring-lj/install-dashboards/content.json
@@ -18,7 +18,7 @@
           "type": "interactive",
           "action": "highlight",
           "reftarget": "[data-testid='install-button']",
-          "content": "Scroll down to the **Install dashboards and alerts** section and click **Install**. You should see the message: **Dashboards and alerts have been installed.**"
+          "content": "On the Kafka integration page, scroll down to the **Install dashboards and alerts** section and click **Install**. You should see the message: **Dashboards and alerts have been installed.**"
         },
         {
           "type": "interactive",

--- a/kafka-monitoring-lj/install-grafana-alloy/content.json
+++ b/kafka-monitoring-lj/install-grafana-alloy/content.json
@@ -1,0 +1,83 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "kafka-monitoring-install-grafana-alloy",
+  "title": "Install Grafana Alloy",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "The Grafana Alloy installation process varies by operating system, and you can access the installation commands directly from Grafana Cloud. These commands are pre-configured with your stack-specific connection details, making the setup process straightforward."
+    },
+    {
+      "type": "markdown",
+      "content": "Alloy should be installed on a machine with network access to your Kafka brokers' JMX ports (typically port 9999 or as configured). This can be on one of the Kafka broker machines themselves, or on a dedicated monitoring host with network connectivity to all brokers in your cluster."
+    },
+    {
+      "type": "section",
+      "blocks": [
+        {
+          "type": "multistep",
+          "content": "Navigate to **Connections > Add new connection**.",
+          "requirements": ["navmenu-open"],
+          "steps": [
+            { "action": "highlight", "reftarget": "a[data-testid='data-testid Nav menu item'][href='/connections']" },
+            { "action": "highlight", "reftarget": "a[data-testid='data-testid Nav menu item'][href='/connections/add-new-connection']" }
+          ]
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "In the search box, type **Kafka** to find the Kafka integration."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "a[href='/connections/add-new-connection/kafka']",
+          "content": "Select the **Kafka** integration tile."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Under **Select platform**, choose your operating system and architecture."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='agent-config-button']",
+          "content": "Click **Run Grafana Alloy**. This opens a dialog to generate your Alloy installation command, which may include creating an API token."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Complete the dialog steps, then copy the generated installation command."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "**On the machine where Alloy is installed**, open the Alloy configuration file:\n\n- **Linux:** `/etc/alloy/config.alloy`\n- **macOS (Homebrew):** `/opt/homebrew/etc/alloy/config.alloy`\n- **Windows:** `C:\\Program Files\\GrafanaLabs\\Alloy\\config.alloy`\n- **Docker:** Depends on your volume mount configuration\n\nFor more information, refer to [Grafana Alloy configuration file locations](/docs/alloy/latest/configure/)."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "On the machine where you want to collect Kafka metrics, open a terminal with administrator or root privileges, paste and run the installation command, then wait for the installation to complete."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "The installation completes successfully and displays a confirmation message. The Alloy service starts automatically and runs in the background."
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "In the next milestone, you configure the JMX exporter to expose Kafka broker metrics."
+    },
+    {
+      "type": "markdown",
+      "content": "---\n\n### More to explore (optional)\n\nAt this point in your journey, you can explore the following paths:\n\n- [What is Grafana Alloy?](/oss/alloy-opentelemetry-collector)\n- [Grafana Alloy configuration syntax and examples](/docs/alloy/latest/reference/config-blocks/)"
+    },
+    {
+      "type": "markdown",
+      "content": "---\n\n### Troubleshooting\n\nExplore the following troubleshooting topics if you need help:\n\n- [Common errors when executing Alloy installation script](/docs/grafana-cloud/monitor-infrastructure/integrations/troubleshoot/install-troubleshoot-linux-alloy/#common-errors-when-executing-alloy-installation-script)\n- [Alloy is installed, but data doesn't appear in Grafana Cloud](/docs/grafana-cloud/monitor-infrastructure/integrations/troubleshoot/install-troubleshoot-linux-alloy/#alloy-is-installed-but-data-doesnt-appear-in-grafana-cloud)"
+    }
+  ]
+}

--- a/kafka-monitoring-lj/install-grafana-alloy/content.json
+++ b/kafka-monitoring-lj/install-grafana-alloy/content.json
@@ -25,7 +25,9 @@
         },
         {
           "type": "interactive",
-          "action": "noop",
+          "action": "formfill",
+          "reftarget": "[data-testid='search-input-input']",
+          "targetvalue": "Kafka",
           "content": "In the search box, type **Kafka** to find the Kafka integration."
         },
         {
@@ -49,11 +51,6 @@
           "type": "interactive",
           "action": "noop",
           "content": "Complete the dialog steps, then copy the generated installation command."
-        },
-        {
-          "type": "interactive",
-          "action": "noop",
-          "content": "**On the machine where Alloy is installed**, open the Alloy configuration file:\n\n- **Linux:** `/etc/alloy/config.alloy`\n- **macOS (Homebrew):** `/opt/homebrew/etc/alloy/config.alloy`\n- **Windows:** `C:\\Program Files\\GrafanaLabs\\Alloy\\config.alloy`\n- **Docker:** Depends on your volume mount configuration\n\nFor more information, refer to [Grafana Alloy configuration file locations](/docs/alloy/latest/configure/)."
         },
         {
           "type": "interactive",

--- a/kafka-monitoring-lj/install-grafana-alloy/content.json
+++ b/kafka-monitoring-lj/install-grafana-alloy/content.json
@@ -28,7 +28,7 @@
           "action": "formfill",
           "reftarget": "[data-testid='search-input-input']",
           "targetvalue": "Kafka",
-          "content": "In the search box, type **Kafka** to find the Kafka integration."
+          "content": "In the search box, type **Kafka** and press **Enter**. You should see the Kafka integration tile."
         },
         {
           "type": "interactive",

--- a/kafka-monitoring-lj/install-grafana-alloy/content.json
+++ b/kafka-monitoring-lj/install-grafana-alloy/content.json
@@ -13,6 +13,7 @@
     },
     {
       "type": "section",
+      "autoCollapse": false,
       "blocks": [
         {
           "type": "multistep",
@@ -69,11 +70,11 @@
     },
     {
       "type": "markdown",
-      "content": "---\n\n### More to explore (optional)\n\nAt this point in your journey, you can explore the following paths:\n\n- [What is Grafana Alloy?](/oss/alloy-opentelemetry-collector)\n- [Grafana Alloy configuration syntax and examples](/docs/alloy/latest/reference/config-blocks/)"
+      "content": "---\n\n### More to explore (optional)\n\nAt this point in your journey, you can explore the following paths:\n\n- [What is Grafana Alloy?](https://grafana.com/oss/alloy-opentelemetry-collector)\n- [Grafana Alloy configuration syntax and examples](https://grafana.com/docs/alloy/latest/reference/config-blocks/)"
     },
     {
       "type": "markdown",
-      "content": "---\n\n### Troubleshooting\n\nExplore the following troubleshooting topics if you need help:\n\n- [Common errors when executing Alloy installation script](/docs/grafana-cloud/monitor-infrastructure/integrations/troubleshoot/install-troubleshoot-linux-alloy/#common-errors-when-executing-alloy-installation-script)\n- [Alloy is installed, but data doesn't appear in Grafana Cloud](/docs/grafana-cloud/monitor-infrastructure/integrations/troubleshoot/install-troubleshoot-linux-alloy/#alloy-is-installed-but-data-doesnt-appear-in-grafana-cloud)"
+      "content": "---\n\n### Troubleshooting\n\nExplore the following troubleshooting topics if you need help:\n\n- [Common errors when executing Alloy installation script](https://grafana.com/docs/grafana-cloud/monitor-infrastructure/integrations/troubleshoot/install-troubleshoot-linux-alloy/#common-errors-when-executing-alloy-installation-script)\n- [Alloy is installed, but data doesn't appear in Grafana Cloud](https://grafana.com/docs/grafana-cloud/monitor-infrastructure/integrations/troubleshoot/install-troubleshoot-linux-alloy/#alloy-is-installed-but-data-doesnt-appear-in-grafana-cloud)"
     }
   ]
 }

--- a/kafka-monitoring-lj/install-grafana-alloy/content.json
+++ b/kafka-monitoring-lj/install-grafana-alloy/content.json
@@ -57,16 +57,15 @@
           "action": "noop",
           "content": "On the machine where you want to collect Kafka metrics, open a terminal with administrator or root privileges, paste and run the installation command, then wait for the installation to complete."
         },
-        {
-          "type": "interactive",
-          "action": "noop",
-          "content": "The installation completes successfully and displays a confirmation message. The Alloy service starts automatically and runs in the background."
-        }
       ]
     },
     {
       "type": "markdown",
-      "content": "In the next milestone, you configure the JMX exporter to expose Kafka broker metrics."
+      "content": "The installation completes successfully and displays a confirmation message. The Alloy service starts automatically and runs in the background."
+    },
+    {
+      "type": "markdown",
+      "content": "In the next milestone, you configure Grafana Alloy to collect metrics from your Kafka brokers."
     },
     {
       "type": "markdown",

--- a/kafka-monitoring-lj/install-grafana-alloy/content.json
+++ b/kafka-monitoring-lj/install-grafana-alloy/content.json
@@ -56,7 +56,7 @@
           "type": "interactive",
           "action": "noop",
           "content": "On the machine where you want to collect Kafka metrics, open a terminal with administrator or root privileges, paste and run the installation command, then wait for the installation to complete."
-        },
+        }
       ]
     },
     {

--- a/kafka-monitoring-lj/understand-alerts/content.json
+++ b/kafka-monitoring-lj/understand-alerts/content.json
@@ -5,7 +5,7 @@
   "blocks": [
     {
       "type": "markdown",
-      "content": "The Kafka integration provides a variety of pre-built alerts that you can use right away to begin troubleshooting issues. In this milestone, you'll become familiar with these pre-built alerts and learn how to use them to address various problems."
+      "content": "The Kafka integration provides a variety of pre-built alerts that you can use right away to begin troubleshooting issues. In this milestone, you'll become familiar with these pre-built alerts and learn how to use them to address various problems.\n\nThe following alerts are included with the Kafka integration:"
     },
     {
       "type": "markdown",

--- a/kafka-monitoring-lj/understand-alerts/content.json
+++ b/kafka-monitoring-lj/understand-alerts/content.json
@@ -1,0 +1,67 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "kafka-monitoring-understand-alerts",
+  "title": "About Kafka integration pre-built alerts",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "The Kafka integration provides a variety of pre-built alerts that you can use right away to begin troubleshooting issues. In this milestone, you'll become familiar with these pre-built alerts and learn how to use them to address various problems."
+    },
+    {
+      "type": "markdown",
+      "content": "> **Did you know?** If your Kafka cluster is functioning properly, you won't receive any alerts. No news is good news!"
+    },
+    {
+      "type": "markdown",
+      "content": "**KafkaOfflinePartitionCount**\n\n**Description:** Kafka has offline partitions.\n\n**What this means:** One or more partitions are offline, meaning they have no active leader and cannot be read from or written to. This indicates a critical issue affecting data availability.\n\n**What to do:** Check broker health and logs to identify why partitions went offline. Verify that the cluster has sufficient healthy brokers and that replication is functioning properly."
+    },
+    {
+      "type": "markdown",
+      "content": "**KafkaUnderReplicatedPartitions**\n\n**Description:** Kafka has under-replicated partitions.\n\n**What this means:** Some partitions don't have the configured number of in-sync replicas, meaning data durability is at risk. If the leader broker fails, data loss could occur.\n\n**What to do:** Investigate broker performance and network connectivity. Check if any brokers are down or experiencing high load that prevents replication from keeping up."
+    },
+    {
+      "type": "markdown",
+      "content": "**KafkaActiveController**\n\n**Description:** No active Kafka controller detected or multiple controllers detected.\n\n**What this means:** The cluster either has no active controller (preventing partition leadership changes) or has split-brain with multiple controllers, both of which are critical issues.\n\n**What to do:** Check ZooKeeper connectivity and health. Examine broker logs for controller election issues. Ensure network connectivity between brokers and ZooKeeper is stable."
+    },
+    {
+      "type": "markdown",
+      "content": "**KafkaUncleanLeaderElection**\n\n**Description:** Unclean leader elections are occurring.\n\n**What this means:** Kafka is electing partition leaders from brokers that were not in-sync, which can result in message loss. This indicates the cluster is prioritizing availability over data consistency.\n\n**What to do:** Investigate why in-sync replicas are unavailable. Review broker health and replication lag. Consider adjusting replication factors or `min.insync.replicas` settings."
+    },
+    {
+      "type": "markdown",
+      "content": "**KafkaISRExpandRate**\n\n**Description:** In-Sync Replica (ISR) expansion rate is high.\n\n**What this means:** Replicas are frequently joining the ISR set, which may indicate intermittent broker or network issues causing replicas to fall behind and then catch up.\n\n**What to do:** Monitor broker performance and network stability. Check for broker restarts or network partitions. Review replication lag metrics to identify problematic brokers."
+    },
+    {
+      "type": "markdown",
+      "content": "**KafkaISRShrinkRate**\n\n**Description:** In-Sync Replica (ISR) shrink rate is high.\n\n**What this means:** Replicas are frequently being removed from the ISR set because they're falling behind the leader, indicating replication performance issues.\n\n**What to do:** Investigate broker resource utilization (CPU, disk I/O, network). Check for slow disks or network issues. Review replication lag and broker logs for errors."
+    },
+    {
+      "type": "markdown",
+      "content": "**KafkaBrokerCount**\n\n**Description:** Kafka broker count has changed.\n\n**What this means:** The number of active brokers in the cluster has decreased, which may indicate broker failures or planned maintenance.\n\n**What to do:** Verify if the broker loss was intentional. If unplanned, investigate why brokers went offline and restore them to maintain cluster capacity and fault tolerance."
+    },
+    {
+      "type": "markdown",
+      "content": "**KafkaZookeeperSyncConnect**\n\n**Description:** ZooKeeper sync connection issues detected.\n\n**What this means:** Kafka brokers are experiencing problems maintaining connections to ZooKeeper, which can affect cluster metadata operations and coordination.\n\n**What to do:** Check ZooKeeper cluster health and network connectivity between Kafka brokers and ZooKeeper nodes. Review ZooKeeper logs for errors."
+    },
+    {
+      "type": "markdown",
+      "content": "**KafkaLagIsTooHigh**\n\n**Description:** Consumer lag is too high.\n\n**What this means:** Consumer groups are falling significantly behind in processing messages, indicating consumers can't keep up with the message production rate.\n\n**What to do:** Scale up consumer instances, optimize consumer processing logic, or investigate performance bottlenecks in consumer applications."
+    },
+    {
+      "type": "markdown",
+      "content": "**KafkaLagKeepsIncreasing**\n\n**Description:** Consumer lag keeps increasing.\n\n**What this means:** Consumer lag is continuously growing over time, indicating a persistent problem where consumers cannot keep pace with producers.\n\n**What to do:** Urgently investigate consumer performance issues. Consider increasing consumer parallelism, optimizing consumer code, or adjusting partition assignments."
+    },
+    {
+      "type": "markdown",
+      "content": "**JvmMemoryFillingUp**\n\n**Description:** JVM memory filling up for Kafka broker.\n\n**What this means:** Kafka broker JVM heap memory usage is high and trending upward, which may indicate a memory leak or insufficient heap size configuration.\n\n**What to do:** Monitor for garbage collection issues. Consider increasing JVM heap size if appropriate, or investigate potential memory leaks in custom components or configurations."
+    },
+    {
+      "type": "markdown",
+      "content": "**JvmThreadsDeadlocked**\n\n**Description:** JVM threads are deadlocked in Kafka broker.\n\n**What this means:** The Kafka broker JVM has detected threads that are stuck in a deadlock, which can cause the broker to become unresponsive.\n\n**What to do:** Collect thread dumps and analyze for deadlock situations. This typically requires restarting the affected broker and may indicate a bug that needs investigation."
+    },
+    {
+      "type": "markdown",
+      "content": "In the next milestone, you explore the Kafka metrics displayed in your dashboards."
+    }
+  ]
+}

--- a/kafka-monitoring-lj/understand-dashboards/content.json
+++ b/kafka-monitoring-lj/understand-dashboards/content.json
@@ -1,0 +1,50 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "kafka-monitoring-understand-dashboards",
+  "title": "About Kafka integration pre-built dashboards",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "The Kafka integration provides a variety of pre-built dashboards that you can use right away to begin troubleshooting issues. In this milestone, you'll become familiar with these pre-built dashboards and learn how to use them to address various problems."
+    },
+    {
+      "type": "markdown",
+      "content": "> **Did you know?** If you don't see any metrics, try switching the data source using the drop-down at the top of the dashboard."
+    },
+    {
+      "type": "markdown",
+      "content": "**Kafka overview dashboard**\n\nThis dashboard offers a comprehensive overview of your Kafka cluster, including:\n\n- Active Kafka controllers\n- Broker count\n- Partition health (unclean leader elections, preferred replica imbalances, partition distribution)\n- Cluster throughput (bytes in and messages in)\n- Current role (distribution of partition leadership across brokers)\n- Broker throughput (network throughput and message rates per broker)\n- Replication status (online, offline, under-replicated, and under min ISR partitions)\n- Process overview (uptime, start times, load average)\n- JVM overview (CPU and memory usage for broker JVM processes)\n\nUse this dashboard to gain a high-level understanding of cluster operational status, quickly identify broker health issues, and monitor cluster-wide throughput trends."
+    },
+    {
+      "type": "image",
+      "src": "https://grafana.com/media/integrations/kafka/screenshots/kafka_overview_1.1.0.png",
+      "alt": "Kafka Overview dashboard displaying cluster health and performance metrics"
+    },
+    {
+      "type": "markdown",
+      "content": "**Kafka topics dashboard**\n\nThis dashboard shows detailed information about Kafka topics, including:\n\n- Topic overview (namespace, partition, start/end offset, messages per second, log size)\n- Messages per second (ingestion rate per topic over time)\n- Topic bytes in/out (data transfer rates)\n- Consumer group overview (groups, associated topics, consume rate, and lag)\n- Consumer group metrics (consume rate and lag over time per group)\n\nUse this dashboard to monitor topic-level performance, identify unusual message rates, track consumer lag, and analyze topic growth."
+    },
+    {
+      "type": "image",
+      "src": "https://grafana.com/media/integrations/kafka/screenshots/kafka_topics_1.1.0.png",
+      "alt": "Kafka Topics dashboard displaying per-topic message rates and consumer lag"
+    },
+    {
+      "type": "markdown",
+      "content": "**Kafka Connect overview dashboard**\n\nThis dashboard displays information about Kafka Connect, including:\n\n- General task status (total, running, paused, failed, unassigned, destroyed)\n- Connector status (repartition of connectors and tasks per status)\n- Status over time (time-series graphs of connector and task status)\n- System metrics (CPU usage and JVM memory for Connect workers)\n- Connect Worker table (cluster, instance, startup time, version, connector/task details)\n\nUse this dashboard to monitor Kafka Connect health, track task execution status, identify failed connectors, and monitor resource usage."
+    },
+    {
+      "type": "image",
+      "src": "https://grafana.com/media/integrations/kafka/screenshots/Kafka_Connect_Overview.png",
+      "alt": "Kafka Connect Overview dashboard displaying connector and task status"
+    },
+    {
+      "type": "markdown",
+      "content": "In the next milestone, you learn about the pre-built alerts included with the Kafka integration."
+    },
+    {
+      "type": "markdown",
+      "content": "---\n\n### More to explore (optional)\n\nAt this point in your journey, you can explore the following paths:\n\n- [Create custom dashboards and panels](/docs/grafana/latest/dashboards/)"
+    }
+  ]
+}

--- a/kafka-monitoring-lj/understand-dashboards/content.json
+++ b/kafka-monitoring-lj/understand-dashboards/content.json
@@ -5,7 +5,7 @@
   "blocks": [
     {
       "type": "markdown",
-      "content": "The Kafka integration provides a variety of pre-built dashboards that you can use right away to begin troubleshooting issues. In this milestone, you'll become familiar with these pre-built dashboards and learn how to use them to address various problems."
+      "content": "The Kafka integration provides a variety of pre-built dashboards that you can use right away to begin troubleshooting issues. In this milestone, you'll become familiar with these pre-built dashboards and learn how to use them to address various problems.\n\nThe following dashboards are included with the Kafka integration:"
     },
     {
       "type": "markdown",

--- a/kafka-monitoring-lj/understand-dashboards/content.json
+++ b/kafka-monitoring-lj/understand-dashboards/content.json
@@ -44,7 +44,7 @@
     },
     {
       "type": "markdown",
-      "content": "---\n\n### More to explore (optional)\n\nAt this point in your journey, you can explore the following paths:\n\n- [Create custom dashboards and panels](/docs/grafana/latest/dashboards/)"
+      "content": "---\n\n### More to explore (optional)\n\nAt this point in your journey, you can explore the following paths:\n\n- [Create custom dashboards and panels](https://grafana.com/docs/grafana/latest/dashboards/)"
     }
   ]
 }

--- a/kafka-monitoring-lj/value-kafka-monitoring/content.json
+++ b/kafka-monitoring-lj/value-kafka-monitoring/content.json
@@ -1,0 +1,23 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "kafka-monitoring-value-kafka-monitoring",
+  "title": "The value of Kafka monitoring",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "Operating Apache Kafka clusters without proper observability can be challenging and risky. Without comprehensive monitoring, teams often struggle to detect broker failures, identify consumer lag issues, and troubleshoot performance bottlenecks before they impact critical data pipelines."
+    },
+    {
+      "type": "markdown",
+      "content": "Comprehensive Kafka monitoring with Grafana Cloud provides real-time visibility into message throughput, partition health, replication status, and consumer group performance. This enables teams to proactively maintain reliable data streaming pipelines, quickly diagnose issues, and optimize cluster performance based on actual usage patterns and trends."
+    },
+    {
+      "type": "markdown",
+      "content": "Kafka monitoring with Grafana Cloud provides the following advantages over manual log inspection and basic metrics:\n\n- Detect broker failures and performance degradation before they impact data pipelines.\n- Monitor consumer lag in real-time to ensure timely message processing.\n- Track partition distribution and replication health across your cluster.\n- Identify slow producers and consumers affecting throughput.\n- Analyze topic-level metrics to optimize resource allocation.\n- Correlate Kafka metrics with application performance and infrastructure health.\n- Access pre-built dashboards and alerts designed for Kafka best practices."
+    },
+    {
+      "type": "markdown",
+      "content": "In the next milestone, you learn about the advantages of using Grafana Alloy for Kafka metrics collection."
+    }
+  ]
+}

--- a/kafka-monitoring-lj/value-kafka-monitoring/content.json
+++ b/kafka-monitoring-lj/value-kafka-monitoring/content.json
@@ -17,7 +17,7 @@
     },
     {
       "type": "markdown",
-      "content": "In the next milestone, you learn about the advantages of using Grafana Alloy for Kafka metrics collection."
+      "content": "In the next milestone, you configure the JMX exporter on your Kafka brokers."
     }
   ]
 }

--- a/kafka-monitoring-lj/verify-kafka-metrics/content.json
+++ b/kafka-monitoring-lj/verify-kafka-metrics/content.json
@@ -1,0 +1,69 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "kafka-monitoring-verify-kafka-metrics",
+  "title": "Verify Kafka metrics collection",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "After configuring Grafana Alloy to collect Kafka metrics, you should confirm that the metrics are successfully being sent to Grafana Cloud. Using the Explore view, you can query for Kafka-specific metric names to verify the integration is working correctly.\n\nCommon Kafka metrics to check include message rates, byte rates, and request metrics. These metrics provide immediate confirmation that Alloy is successfully connecting to your Kafka brokers via JMX and forwarding the data to your Grafana Cloud stack."
+    },
+    {
+      "type": "section",
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "a[data-testid='data-testid Nav menu item'][href='/explore']",
+          "requirements": ["navmenu-open"],
+          "content": "Navigate to **Explore** from the main menu."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='data-testid Select a data source']",
+          "content": "In the data source dropdown, select your Prometheus data source (typically named **grafanacloud-[your-stack]-prom**).",
+          "doIt": false
+        },
+        {
+          "type": "interactive",
+          "action": "formfill",
+          "reftarget": "[data-testid='data-testid metric select']",
+          "targetvalue": "kafka_",
+          "content": "In the metrics browser, type **kafka_** to search for Kafka metrics, then select a metric such as **kafka_server_brokertopicmetrics_messagesin_total**."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='data-testid RefreshPicker run button']",
+          "content": "Click the **Run query** button to execute the query."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Verify that data points appear in the graph and table views. Check the labels to confirm they include your broker information (`instance`, `job`, `topic`)."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Try querying additional Kafka metrics to ensure comprehensive data collection."
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "Kafka metrics appear with recent timestamps and update as new data arrives from your brokers, typically within 1-2 minutes of the first scrape."
+    },
+    {
+      "type": "markdown",
+      "content": "In the next milestone, you install pre-built Kafka dashboards to visualize your metrics."
+    },
+    {
+      "type": "markdown",
+      "content": "---\n\n### More to explore (optional)\n\nAt this point in your journey, you can explore the following paths:\n\n- [Query and visualize data in Explore](/docs/grafana/latest/explore/)\n- [Prometheus query basics](/docs/grafana/latest/datasources/prometheus/query-editor/)"
+    },
+    {
+      "type": "markdown",
+      "content": "---\n\n### Troubleshooting\n\nExplore the following troubleshooting topics if you need help:\n\n- [No Kafka metrics appear in Grafana Cloud](/docs/grafana-cloud/monitor-infrastructure/integrations/troubleshoot/install-troubleshoot-linux-alloy/#no-data-appears-in-grafana-cloud)\n- [Check Alloy service status and logs](/docs/alloy/latest/troubleshoot/)\n- [Verify JMX connectivity from Alloy to Kafka brokers](/docs/grafana-cloud/monitor-infrastructure/integrations/troubleshoot/)"
+    }
+  ]
+}

--- a/kafka-monitoring-lj/verify-kafka-metrics/content.json
+++ b/kafka-monitoring-lj/verify-kafka-metrics/content.json
@@ -9,6 +9,7 @@
     },
     {
       "type": "section",
+      "autoCollapse": false,
       "blocks": [
         {
           "type": "interactive",
@@ -59,11 +60,11 @@
     },
     {
       "type": "markdown",
-      "content": "---\n\n### More to explore (optional)\n\nAt this point in your journey, you can explore the following paths:\n\n- [Query and visualize data in Explore](/docs/grafana/latest/explore/)\n- [Prometheus query basics](/docs/grafana/latest/datasources/prometheus/query-editor/)"
+      "content": "---\n\n### More to explore (optional)\n\nAt this point in your journey, you can explore the following paths:\n\n- [Query and visualize data in Explore](https://grafana.com/docs/grafana/latest/explore/)\n- [Prometheus query basics](https://grafana.com/docs/grafana/latest/datasources/prometheus/query-editor/)"
     },
     {
       "type": "markdown",
-      "content": "---\n\n### Troubleshooting\n\nExplore the following troubleshooting topics if you need help:\n\n- [No Kafka metrics appear in Grafana Cloud](/docs/grafana-cloud/monitor-infrastructure/integrations/troubleshoot/install-troubleshoot-linux-alloy/#no-data-appears-in-grafana-cloud)\n- [Check Alloy service status and logs](/docs/alloy/latest/troubleshoot/)\n- [Verify JMX connectivity from Alloy to Kafka brokers](/docs/grafana-cloud/monitor-infrastructure/integrations/troubleshoot/)"
+      "content": "---\n\n### Troubleshooting\n\nExplore the following troubleshooting topics if you need help:\n\n- [No Kafka metrics appear in Grafana Cloud](https://grafana.com/docs/grafana-cloud/monitor-infrastructure/integrations/troubleshoot/install-troubleshoot-linux-alloy/#no-data-appears-in-grafana-cloud)\n- [Check Alloy service status and logs](https://grafana.com/docs/alloy/latest/troubleshoot/)\n- [Verify JMX connectivity from Alloy to Kafka brokers](https://grafana.com/docs/grafana-cloud/monitor-infrastructure/integrations/troubleshoot/)"
     }
   ]
 }

--- a/kafka-monitoring-lj/verify-kafka-metrics/content.json
+++ b/kafka-monitoring-lj/verify-kafka-metrics/content.json
@@ -5,7 +5,7 @@
   "blocks": [
     {
       "type": "markdown",
-      "content": "After configuring Grafana Alloy to collect Kafka metrics, you should confirm that the metrics are successfully being sent to Grafana Cloud. Using the Explore view, you can query for Kafka-specific metric names to verify the integration is working correctly.\n\nCommon Kafka metrics to check include message rates, byte rates, and request metrics. These metrics provide immediate confirmation that Alloy is successfully connecting to your Kafka brokers via JMX and forwarding the data to your Grafana Cloud stack."
+      "content": "With Grafana Alloy configured and your Kafka dashboards installed, you should now confirm that metrics are successfully flowing to Grafana Cloud. Using the Explore view, you can query for Kafka-specific metric names to verify the integration is working correctly.\n\nCommon Kafka metrics to check include message rates, byte rates, and request metrics. These metrics provide immediate confirmation that Alloy is successfully connecting to your Kafka brokers via JMX and forwarding the data to your Grafana Cloud stack."
     },
     {
       "type": "section",

--- a/kafka-monitoring-lj/verify-kafka-metrics/content.json
+++ b/kafka-monitoring-lj/verify-kafka-metrics/content.json
@@ -55,7 +55,7 @@
     },
     {
       "type": "markdown",
-      "content": "In the next milestone, you install pre-built Kafka dashboards to visualize your metrics."
+      "content": "In the next milestone, you learn about the pre-built dashboards included with the Kafka integration."
     },
     {
       "type": "markdown",


### PR DESCRIPTION
Scaffolds all 11 milestones of the `kafka-monitoring` learning path with tested and validated Pathfinder `content.json` files.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds new Pathfinder `content.json` learning-journey content only, with no changes to runtime logic or data handling.
> 
> **Overview**
> Adds a new `kafka-monitoring-lj` learning-journey by scaffolding 11 milestone `content.json` files covering Kafka monitoring with Grafana Cloud.
> 
> The new content walks users through enabling Kafka JMX, explaining Grafana Alloy benefits, installing/configuring Alloy, installing dashboards/alerts, verifying metrics in Explore, and understanding dashboards/alerts, ending with a completion step and optional links/troubleshooting guidance.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 97aa667b63bb21d7b641e840271e72b5918a5d1f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->