### PR TITLE
Add guides for cloud migration assistant

### DIFF
--- a/cloud-migration-assistant-lj/cloud/content.json
+++ b/cloud-migration-assistant-lj/cloud/content.json
@@ -25,7 +25,9 @@
           "action": "highlight",
           "reftarget": "a[data-testid='data-testid Nav menu item'][href='/admin/migrate-to-cloud']",
           "content": "Open the navigation menu on the left side of the screen and select **Administration** > **General** > **Migrate to Grafana Cloud**.",
-          "requirements": ["navmenu-open"],
+          "requirements": [
+            "navmenu-open"
+          ],
           "doIt": false
         },
         {
@@ -33,7 +35,9 @@
           "action": "button",
           "reftarget": "Generate a migration token",
           "content": "Click the **Generate a migration token** button.",
-          "requirements": ["on-page:/admin/migrate-to-cloud"],
+          "requirements": [
+            "on-page:/admin/migrate-to-cloud"
+          ],
           "doIt": false
         },
         {
@@ -76,7 +80,9 @@
           "action": "highlight",
           "reftarget": "a[data-testid='data-testid Nav menu item'][href='/dashboards']",
           "content": "Navigate to **Home** > **Dashboards** to view your migrated dashboards. Verify that your folder structure is preserved and dashboards appear in their original locations.",
-          "requirements": ["navmenu-open"],
+          "requirements": [
+            "navmenu-open"
+          ],
           "doIt": false
         },
         {
@@ -89,7 +95,9 @@
           "action": "highlight",
           "reftarget": "a[data-testid='data-testid Nav menu item'][href='/connections']",
           "content": "Navigate to **Connections** > **Data sources** to verify your data sources were migrated with their credentials.",
-          "requirements": ["navmenu-open"],
+          "requirements": [
+            "navmenu-open"
+          ],
           "doIt": false
         },
         {
@@ -97,7 +105,9 @@
           "action": "highlight",
           "reftarget": "a[data-testid='data-testid Nav menu item'][href='/alerts-and-incidents']",
           "content": "If you migrated alerting resources, navigate to **Alerts & IRM** > **Alerting** > **Alert rules** to verify alert rules are present. By default, alert rules are migrated in a 'paused' state to prevent duplicate notifications from both your source and cloud instances.",
-          "requirements": ["navmenu-open"],
+          "requirements": [
+            "navmenu-open"
+          ],
           "doIt": false
         },
         {
@@ -117,85 +127,75 @@
     },
     {
       "type": "section",
-      "title": "Option 1: Manually unpause alert rules",
+      "title": "Option 1: Manually resume alert rules",
       "blocks": [
         {
           "type": "interactive",
           "action": "highlight",
           "reftarget": "a[data-testid='data-testid Nav menu item'][href='/alerts-and-incidents']",
           "content": "In your Grafana Cloud instance, navigate to **Alerts & IRM** > **Alerting** > **Alert rules**.",
-          "requirements": ["navmenu-open"],
+          "requirements": [
+            "navmenu-open"
+          ],
+          "doIt": false
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[role='radiogroup']",
+          "content": "Ensure you are in the **Grouped** view. This is the default view and shows alert rules organized by folder.",
+          "requirements": [
+            "on-page:/alerting/list"
+          ],
           "doIt": false
         },
         {
           "type": "interactive",
           "action": "noop",
-          "content": "Review the list of alert rules (all should be in paused state)."
+          "content": "Before resuming alert rules here, disable or silence the corresponding alerts in your self-managed instance to avoid receiving duplicate notifications."
         },
         {
           "type": "interactive",
           "action": "noop",
-          "content": "Select the alert rules you want to activate by checking the boxes next to them."
+          "content": "Locate the folder containing your migrated alert rules."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[role='treeitem']:first-child [aria-label='Folder actions']",
+          "content": "Click the **Actions** button next to the folder name and select **Resume all rule evaluation**. This resumes all alert rules within that folder. To resume a specific rule instead, click the **More** button next to the rule name and select **Resume rule evaluation**.",
+          "requirements": [
+            "on-page:/alerting/list"
+          ],
+          "doIt": false
         },
         {
           "type": "interactive",
           "action": "noop",
-          "content": "Click the **Unpause** button at the top of the list."
+          "content": "Repeat for each folder or specific rule containing paused alert rules. There is no single button to resume all rules at once — you must resume them per folder or per rule."
         },
         {
           "type": "interactive",
           "action": "noop",
-          "content": "Verify that the selected alert rules change to an active state."
+          "content": "Verify that alert rules show a **Normal** state."
         },
         {
           "type": "interactive",
           "action": "noop",
-          "content": "Monitor alert notifications to ensure they fire correctly and reach the right contact points."
+          "content": "Monitor alert notifications to confirm they fire correctly and reach the right contact points."
         }
       ]
-    },
-    {
-      "type": "markdown",
-      "content": "Before activating alert rules in Grafana Cloud, disable or silence alerts in your self-managed instance to avoid receiving duplicate notifications."
     },
     {
       "type": "section",
       "title": "Option 2: Re-migrate alert rules in an active state",
       "blocks": [
         {
-          "type": "markdown",
-          "content": "If you prefer to migrate alert rules in their original state from your self-managed instance, you can configure this setting and re-run the migration."
-        },
-        {
           "type": "interactive",
           "action": "noop",
-          "content": "On your self-managed Grafana instance, locate your Grafana configuration file (`grafana.ini` or `custom.ini`) and add or modify the following setting:\n\n```ini\n[cloud_migration]\nalert_rules_state = unchanged\n```"
-        },
-        {
-          "type": "interactive",
-          "action": "noop",
-          "content": "Save the configuration file and restart your Grafana instance."
-        },
-        {
-          "type": "interactive",
-          "action": "noop",
-          "content": "Return to the Migration Assistant at **Home** > **Administration** > **General** > **Migrate to Grafana Cloud** on your self-managed instance."
-        },
-        {
-          "type": "interactive",
-          "action": "noop",
-          "content": "Build a new snapshot by clicking **Build snapshot**, then click **Upload snapshot** to re-run the migration."
-        },
-        {
-          "type": "interactive",
-          "action": "noop",
-          "content": "In Grafana Cloud, navigate to **Alerts & IRM** > **Alerting** > **Alert rules** and verify that alert rules are now in their original state (active or paused) from your self-managed instance."
+          "content": "If you prefer to migrate alert rules in their original state, you can configure a setting on your self-managed instance and re-upload the snapshot. Switch to the **self-managed guide** and follow the optional **Re-migrate alert rules in an active state** section to complete this from your source instance."
         }
       ]
-    },
-    {
-      "type": "markdown",
-      "content": "When you re-upload a snapshot, resources with matching UIDs are updated rather than duplicated. This means your alert rules will be updated to reflect their new state without creating duplicate rules."
     },
     {
       "type": "markdown",

--- a/cloud-migration-assistant-lj/cloud/content.json
+++ b/cloud-migration-assistant-lj/cloud/content.json
@@ -30,8 +30,8 @@
         },
         {
           "type": "interactive",
-          "action": "highlight",
-          "reftarget": "button:contains('Generate a migration token')",
+          "action": "button",
+          "reftarget": "Generate a migration token",
           "content": "Click the **Generate a migration token** button.",
           "requirements": ["on-page:/admin/migrate-to-cloud"],
           "doIt": false

--- a/cloud-migration-assistant-lj/cloud/content.json
+++ b/cloud-migration-assistant-lj/cloud/content.json
@@ -103,8 +103,8 @@
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "a[data-testid='data-testid Nav menu item'][href='/alerts-and-incidents']",
-          "content": "If you migrated alerting resources, navigate to **Alerts & IRM** > **Alerting** > **Alert rules** to verify alert rules are present. By default, alert rules are migrated in a 'paused' state to prevent duplicate notifications from both your source and cloud instances.",
+          "reftarget": "a[data-testid='data-testid Nav menu item'][href='/alerting/list']",
+          "content": "If you migrated alerting resources, navigate to **Alerts & IRM** > **Alerting** > **Alert rules** to verify alert rules are present. By default, alert rules are migrated in a 'paused' state to prevent duplicate notifications from both your self-managed and cloud instances.",
           "requirements": [
             "navmenu-open"
           ],
@@ -132,7 +132,7 @@
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "a[data-testid='data-testid Nav menu item'][href='/alerts-and-incidents']",
+          "reftarget": "a[data-testid='data-testid Nav menu item'][href='/alerting/list']",
           "content": "In your Grafana Cloud instance, navigate to **Alerts & IRM** > **Alerting** > **Alert rules**.",
           "requirements": [
             "navmenu-open"
@@ -142,7 +142,7 @@
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "[role='radiogroup']",
+          "reftarget": "[role='radiogroup']:has(input[id^='option-grouped'])",
           "content": "Ensure you are in the **Grouped** view. This is the default view and shows alert rules organized by folder.",
           "requirements": [
             "on-page:/alerting/list"

--- a/cloud-migration-assistant-lj/cloud/content.json
+++ b/cloud-migration-assistant-lj/cloud/content.json
@@ -1,0 +1,205 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "cloud-migration-assistant-cloud",
+  "title": "Migrate to Grafana Cloud — Cloud steps",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "This guide walks you through the steps performed in your **Grafana Cloud** instance during a migration. You should complete these steps alongside the self-managed steps guide, which covers actions performed on your source Grafana instance."
+    },
+    {
+      "type": "markdown",
+      "content": "## Generate a migration token\n\nThe migration token authenticates your self-managed instance with your Grafana Cloud stack, establishing a secure connection for resource transfer. This token enables encrypted communication between the two instances and ensures that only authorized migrations can occur."
+    },
+    {
+      "type": "section",
+      "title": "Generate migration token",
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Sign in to your Grafana Cloud instance, for example `mystack.grafana.net`."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "a[data-testid='data-testid Nav menu item'][href='/admin/migrate-to-cloud']",
+          "content": "Open the navigation menu on the left side of the screen and select **Administration** > **General** > **Migrate to Grafana Cloud**.",
+          "requirements": ["navmenu-open"],
+          "doIt": false
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "button:contains('Generate a migration token')",
+          "content": "Click the **Generate a migration token** button.",
+          "requirements": ["on-page:/admin/migrate-to-cloud"],
+          "doIt": false
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Copy the migration token to your clipboard. Store this token securely — you need it to connect your self-managed instance to Grafana Cloud."
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "The token is displayed and ready to copy. Return to the self-managed steps guide to connect your source instance using this token."
+    },
+    {
+      "type": "section",
+      "title": "Connect and upload from self-managed",
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Complete the **Connect instances**, **Build snapshot**, and **Upload snapshot** steps in the self-managed guide on your source Grafana instance."
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "## Verify migrated resources\n\nVerification ensures your migrated resources work correctly in Grafana Cloud and that all configurations were preserved during migration. This step helps identify any issues before you switch users to the cloud environment."
+    },
+    {
+      "type": "section",
+      "title": "Verify migration",
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Sign in to your Grafana Cloud instance."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "a[data-testid='data-testid Nav menu item'][href='/dashboards']",
+          "content": "Navigate to **Home** > **Dashboards** to view your migrated dashboards. Verify that your folder structure is preserved and dashboards appear in their original locations.",
+          "requirements": ["navmenu-open"],
+          "doIt": false
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Open a migrated dashboard and verify:\n\n- Visualizations render correctly\n- Data source connections work\n- Queries return expected data"
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "a[data-testid='data-testid Nav menu item'][href='/connections']",
+          "content": "Navigate to **Connections** > **Data sources** to verify your data sources were migrated with their credentials.",
+          "requirements": ["navmenu-open"],
+          "doIt": false
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "a[data-testid='data-testid Nav menu item'][href='/alerts-and-incidents']",
+          "content": "If you migrated alerting resources, navigate to **Alerts & IRM** > **Alerting** > **Alert rules** to verify alert rules are present. By default, alert rules are migrated in a 'paused' state to prevent duplicate notifications from both your source and cloud instances.",
+          "requirements": ["navmenu-open"],
+          "doIt": false
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Check the UIDs of migrated resources match the originals, allowing you to correlate resources between instances."
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "Your resources appear in Grafana Cloud with preserved folder structures, working data source connections, and correct configurations."
+    },
+    {
+      "type": "markdown",
+      "content": "## Activate alert rules\n\nAlert rules are migrated in a paused state by default to prevent duplicate notifications from both your self-managed and cloud instances. Once you've verified your alerting configuration works correctly in Grafana Cloud, you can activate your alert rules."
+    },
+    {
+      "type": "section",
+      "title": "Option 1: Manually unpause alert rules",
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "a[data-testid='data-testid Nav menu item'][href='/alerts-and-incidents']",
+          "content": "In your Grafana Cloud instance, navigate to **Alerts & IRM** > **Alerting** > **Alert rules**.",
+          "requirements": ["navmenu-open"],
+          "doIt": false
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Review the list of alert rules (all should be in paused state)."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Select the alert rules you want to activate by checking the boxes next to them."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Click the **Unpause** button at the top of the list."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Verify that the selected alert rules change to an active state."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Monitor alert notifications to ensure they fire correctly and reach the right contact points."
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "Before activating alert rules in Grafana Cloud, disable or silence alerts in your self-managed instance to avoid receiving duplicate notifications."
+    },
+    {
+      "type": "section",
+      "title": "Option 2: Re-migrate alert rules in an active state",
+      "blocks": [
+        {
+          "type": "markdown",
+          "content": "If you prefer to migrate alert rules in their original state from your self-managed instance, you can configure this setting and re-run the migration."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "On your self-managed Grafana instance, locate your Grafana configuration file (`grafana.ini` or `custom.ini`) and add or modify the following setting:\n\n```ini\n[cloud_migration]\nalert_rules_state = unchanged\n```"
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Save the configuration file and restart your Grafana instance."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Return to the Migration Assistant at **Home** > **Administration** > **General** > **Migrate to Grafana Cloud** on your self-managed instance."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Build a new snapshot by clicking **Build snapshot**, then click **Upload snapshot** to re-run the migration."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "In Grafana Cloud, navigate to **Alerts & IRM** > **Alerting** > **Alert rules** and verify that alert rules are now in their original state (active or paused) from your self-managed instance."
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "When you re-upload a snapshot, resources with matching UIDs are updated rather than duplicated. This means your alert rules will be updated to reflect their new state without creating duplicate rules."
+    },
+    {
+      "type": "markdown",
+      "content": "## Destination reached!\n\nCongratulations on completing this journey! You have:\n\n- Understood the value of automated migration to Grafana Cloud\n- Verified the prerequisites for a successful migration\n- Generated a secure migration token on your Grafana Cloud instance\n- Connected your self-managed instance to Grafana Cloud\n- Built a snapshot of your Grafana resources\n- Uploaded resources to Grafana Cloud with real-time progress tracking\n- Verified your migrated resources in Grafana Cloud\n- Activated alert rules in Grafana Cloud or re-migrated them in an active state\n- Gained confidence in managing cloud migrations efficiently"
+    }
+  ]
+}

--- a/cloud-migration-assistant-lj/cloud/content.json
+++ b/cloud-migration-assistant-lj/cloud/content.json
@@ -5,7 +5,7 @@
   "blocks": [
     {
       "type": "markdown",
-      "content": "This guide walks you through the steps performed in your **Grafana Cloud** instance during a migration. You should complete these steps alongside the self-managed steps guide, which covers actions performed on your source Grafana instance."
+      "content": "This guide walks you through the steps performed in your **Grafana Cloud** instance during a migration. You should complete these steps alongside the self-managed steps guide, which covers actions performed on your self-managed Grafana instance."
     },
     {
       "type": "markdown",
@@ -49,7 +49,7 @@
     },
     {
       "type": "markdown",
-      "content": "The token is displayed and ready to copy. Return to the self-managed steps guide to connect your source instance using this token."
+      "content": "The token is displayed and ready to copy. Return to the self-managed steps guide to connect your self-managed instance using this token."
     },
     {
       "type": "section",
@@ -58,7 +58,7 @@
         {
           "type": "interactive",
           "action": "noop",
-          "content": "Complete the **Connect instances**, **Build snapshot**, and **Upload snapshot** steps in the self-managed guide on your source Grafana instance."
+          "content": "Complete the **Connect instances**, **Build snapshot**, and **Upload snapshot** steps in the self-managed guide on your self-managed Grafana instance."
         }
       ]
     },
@@ -193,7 +193,7 @@
         {
           "type": "interactive",
           "action": "noop",
-          "content": "If you prefer to migrate alert rules in their original state, you can configure a setting on your self-managed instance and re-upload the snapshot. Switch to the **self-managed guide** and follow the optional **Re-migrate alert rules in an active state** section to complete this from your source instance."
+          "content": "If you prefer to migrate alert rules in their original state, you can configure a setting on your self-managed instance and re-upload the snapshot. Switch to the **self-managed guide** and follow the optional **Re-migrate alert rules in an active state** section to complete this from your self-managed instance."
         }
       ]
     },

--- a/cloud-migration-assistant-lj/oss/content.json
+++ b/cloud-migration-assistant-lj/oss/content.json
@@ -228,7 +228,17 @@
           "type": "interactive",
           "action": "highlight",
           "reftarget": "[data-testid='migrate-to-cloud-summary-reconfigure-snapshot-button']",
-          "content": "Click **Reconfigure snapshot** to rebuild the snapshot with the updated alert rule state.",
+          "content": "Click **Reconfigure snapshot** to return to the resource selection screen.",
+          "requirements": [
+            "on-page:/admin/migrate-to-cloud"
+          ],
+          "doIt": false
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='migrate-to-cloud-configure-snapshot-build-snapshot-button']",
+          "content": "Select your resources and click **Build snapshot** to create a new snapshot with the updated alert rule state.",
           "requirements": [
             "on-page:/admin/migrate-to-cloud"
           ],

--- a/cloud-migration-assistant-lj/oss/content.json
+++ b/cloud-migration-assistant-lj/oss/content.json
@@ -21,7 +21,7 @@
     },
     {
       "type": "markdown",
-      "content": "Before starting your migration, verify the following prerequisites:\n\n1. Ensure you have Grafana server administrator access on the source instance\n2. Confirm you have Admin role access on your Grafana Cloud stack\n3. Verify your source instance has internet access\n4. If using a highly-available setup, scale down to one replica\n5. Add required IPs and URLs to your network allowlist (if applicable)"
+      "content": "Before starting your migration, verify the following prerequisites:\n\n1. Ensure you have Grafana server administrator access on the self-managed instance\n2. Confirm you have Admin role access on your Grafana Cloud stack\n3. Verify your self-managed instance has internet access\n4. If using a highly-available setup, scale down to one replica\n5. Add required IPs and URLs to your network allowlist (if applicable)"
     },
     {
       "type": "section",
@@ -30,7 +30,7 @@
         {
           "type": "interactive",
           "action": "noop",
-          "content": "Complete the next step in your **Grafana Cloud stack** to generate a migration token. Open the Cloud guide in Pathfinder when you're in your Cloud environment."
+          "content": "Complete this step in your **Grafana Cloud stack** to generate a migration token. Open the Cloud guide in your interactive learning when you're in your Cloud environment."
         }
       ]
     },
@@ -98,11 +98,7 @@
         {
           "type": "interactive",
           "action": "noop",
-          "content": "Select the checkbox next to each resource type you want to migrate: **Dashboards**, **Folders**, **Data sources**, **App Plugins**, **Panel Plugins**, **Library Panels**, and **Grafana Alerting resources**."
-        },
-        {
-          "type": "markdown",
-          "content": "When you select a resource that depends on other resources, those dependencies are automatically included. For example, selecting **Dashboards** automatically includes required **Data sources**, **Plugins**, **Library elements**, and **Folders**."
+          "content": "Select the checkbox next to each resource type you want to migrate: **Dashboards**, **Folders**, **Data sources**, **App Plugins**, **Panel Plugins**, **Library Panels**, and **Grafana Alerting resources**. When you select a resource that depends on other resources, those dependencies are automatically included."
         },
         {
           "type": "interactive",
@@ -196,13 +192,13 @@
         {
           "type": "interactive",
           "action": "noop",
-          "content": "Complete the remaining steps in your **Grafana Cloud stack** to verify migrated resources and activate alert rules. Open the Cloud guide in Pathfinder when you're in your Cloud environment."
+          "content": "Complete the remaining steps in your **Grafana Cloud stack** to verify migrated resources and activate alert rules. Open the Cloud guide in your interactive learning when you're in your Cloud environment."
         }
       ]
     },
     {
       "type": "markdown",
-      "content": "## Optional: Re-migrate alert rules in an active state\n\nBy default, alert rules are migrated in a paused state. If you prefer to re-migrate them in their original state from your self-managed instance, you can change a configuration setting and re-upload the snapshot. When you re-upload, resources with matching UIDs are updated rather than duplicated."
+      "content": "## Optional: Re-migrate alert rules in an active state\n\nAfter completing the initial migration and verifying your resources in Grafana Cloud, you may want to re-migrate alert rules in their original active state instead of manually resuming them. To do this, change a configuration setting on your self-managed instance and re-upload the snapshot. When you re-upload, resources with matching UIDs are updated rather than duplicated."
     },
     {
       "type": "section",

--- a/cloud-migration-assistant-lj/oss/content.json
+++ b/cloud-migration-assistant-lj/oss/content.json
@@ -1,0 +1,183 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "cloud-migration-assistant-oss",
+  "title": "Migrate to Grafana Cloud — Self-managed steps",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "Migrating from a self-hosted Grafana instance to Grafana Cloud traditionally requires extensive API knowledge, custom scripts, and manual configuration of each resource. This process can take hours or days, depending on the complexity of your environment, and is prone to errors that can disrupt monitoring and alerting workflows."
+    },
+    {
+      "type": "markdown",
+      "content": "The Grafana Cloud Migration Assistant eliminates these challenges by automating the entire migration process. With a simple UI-guided workflow, you can securely migrate dashboards, data sources, folders, plugins, library panels, and alerting resources to Grafana Cloud in minutes, with real-time progress tracking and automatic validation."
+    },
+    {
+      "type": "markdown",
+      "content": "The Grafana Cloud Migration Assistant provides the following advantages over manual migration:\n\n- Eliminate the need for API knowledge or scripting\n- Migrate all resources in minutes instead of hours or days\n- Securely transfer credentials and sensitive data with encryption\n- Preserve resource UIDs and folder hierarchies automatically\n- Track migration progress in real-time with detailed status updates\n- Reduce errors through automated validation and verification"
+    },
+    {
+      "type": "markdown",
+      "content": "## Understand migration prerequisites\n\nSuccessful migrations require proper preparation of both your self-hosted Grafana instance and your Grafana Cloud environment. Taking time to verify these prerequisites prevents migration issues and ensures a smooth transition."
+    },
+    {
+      "type": "markdown",
+      "content": "Before starting your migration, verify the following prerequisites:\n\n1. Confirm your source Grafana instance is running version 11.2 or later (v12.0+ for GA)\n2. Verify the `onPremToCloudMigrations` feature toggle is enabled (enabled by default in v11.5+)\n3. Ensure you have Grafana server administrator access on the source instance\n4. Confirm you have Admin role access on your Grafana Cloud stack\n5. Verify your source instance has internet access\n6. If using a highly-available setup, scale down to one replica\n7. Add required IPs and URLs to your network allowlist (if applicable)"
+    },
+    {
+      "type": "section",
+      "title": "Generate a migration token",
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Complete the next step in your **Grafana Cloud stack** to generate a migration token. Open the Cloud guide in Pathfinder when you're in your Cloud environment."
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "## Connect your self-managed instance to Grafana Cloud\n\nConnecting your self-managed instance to Grafana Cloud establishes a secure link between the two environments, enabling resource migration. The migration token authenticates this connection and verifies that both instances can communicate. This connection is read-only from the self-managed instance and won't modify your existing resources."
+    },
+    {
+      "type": "section",
+      "title": "Connect instances",
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Sign in to your self-managed Grafana instance as a server administrator."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "a[data-testid='data-testid Nav menu item'][href='/admin/migrate-to-cloud']",
+          "content": "Navigate to **Home** > **Administration** > **General** > **Migrate to Grafana Cloud**.",
+          "requirements": ["navmenu-open"],
+          "doIt": false
+        },
+        {
+          "type": "markdown",
+          "content": "Next, you'll click the **Migrate this instance to Cloud** button. A modal will appear where you need to:\n\n1. Paste your migration token into the **Migration token** field\n2. Click **Connect to this Stack**"
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='migrate-to-cloud-connect-session-modal-button']",
+          "content": "Click the **Migrate this instance to Cloud** button, then paste your token and click **Connect to this Stack** in the modal that appears.",
+          "requirements": ["on-page:/admin/migrate-to-cloud"],
+          "doIt": false
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "The connection is established and you see the migration assistant interface with options to build a snapshot."
+    },
+    {
+      "type": "markdown",
+      "content": "## Build a migration snapshot\n\nA snapshot captures the current state of your selected resources and stores them locally on your instance, ready for upload to Grafana Cloud. The snapshot includes all resource metadata, configurations, and dependencies. When you select a resource that requires other resources, the Migration Assistant automatically includes those dependencies in the snapshot."
+    },
+    {
+      "type": "section",
+      "title": "Build snapshot",
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Review the available resources for migration displayed in the migration assistant interface."
+        },
+        {
+          "type": "markdown",
+          "content": "In Grafana v12.0 and later, you can select specific resources. In versions 11.2-11.6, all supported resources are included automatically."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "If using Grafana v12.0 or later, select the checkbox next to each resource type you want to migrate: **Dashboards**, **Folders**, **Data sources**, **App Plugins**, **Panel Plugins**, **Library Panels**, and **Grafana Alerting resources**."
+        },
+        {
+          "type": "markdown",
+          "content": "When you select a resource that depends on other resources, those dependencies are automatically included. For example, selecting **Dashboards** automatically includes required **Data sources**, **Plugins**, **Library elements**, and **Folders**."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='migrate-to-cloud-configure-snapshot-build-snapshot-button']",
+          "content": "Click **Build snapshot**.",
+          "requirements": ["on-page:/admin/migrate-to-cloud"],
+          "doIt": false
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Wait for the snapshot creation to complete. The interface displays progress as resources are captured."
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "The snapshot is created and a list of resources appears with Type and Status columns showing 'Not yet uploaded' for each resource."
+    },
+    {
+      "type": "markdown",
+      "content": "## Upload resources to Grafana Cloud\n\nUploading the snapshot securely transfers your resources to Grafana Cloud, where you can track progress in real-time and review any errors that need manual resolution. Resource UIDs are preserved during upload, allowing you to correlate local and cloud resources, and enabling you to re-run migrations to update resources if needed."
+    },
+    {
+      "type": "section",
+      "title": "Upload snapshot",
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Review the snapshot summary showing the total number of resources ready for upload."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='migrate-to-cloud-summary-upload-snapshot-button']",
+          "content": "Click **Upload snapshot**.",
+          "requirements": ["on-page:/admin/migrate-to-cloud"],
+          "doIt": false
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Monitor the real-time progress tracking as resources are migrated. The Status column updates to show resources being uploaded, successfully uploaded resources ('Uploaded to cloud'), and any resources with errors."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "tr:has(th)",
+          "content": "Use the column headers to organize the view. Click **Name** to sort alphabetically, **Type** to group by resource type, or **Status** to group by upload status.",
+          "requirements": ["on-page:/admin/migrate-to-cloud"],
+          "doIt": false
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Review the updated snapshot information showing total resources, successful migrations, and any errors."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "For any resources with errors, expand the error details to understand what requires manual resolution."
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "The upload completes and you see resources marked as 'Uploaded to cloud' with the snapshot summary showing the number of successfully migrated resources."
+    },
+    {
+      "type": "section",
+      "title": "Verify and activate in Cloud",
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Complete the remaining steps in your **Grafana Cloud stack** to verify migrated resources and activate alert rules. Open the Cloud guide in Pathfinder when you're in your Cloud environment."
+        }
+      ]
+    }
+  ]
+}

--- a/cloud-migration-assistant-lj/oss/content.json
+++ b/cloud-migration-assistant-lj/oss/content.json
@@ -83,8 +83,11 @@
       "blocks": [
         {
           "type": "interactive",
-          "action": "noop",
-          "content": "Review the available resources for migration displayed in the migration assistant interface."
+          "action": "highlight",
+          "reftarget": "div:has(> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-'])",
+          "content": "Review the available resources for migration displayed in the migration assistant interface.",
+          "requirements": ["on-page:/admin/migrate-to-cloud"],
+          "doIt": false
         },
         {
           "type": "markdown",
@@ -128,8 +131,11 @@
       "blocks": [
         {
           "type": "interactive",
-          "action": "noop",
-          "content": "Review the snapshot summary showing the total number of resources ready for upload."
+          "action": "highlight",
+          "reftarget": "div:has(> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button'])",
+          "content": "Review the snapshot summary showing the total number of resources ready for upload.",
+          "requirements": ["on-page:/admin/migrate-to-cloud"],
+          "doIt": false
         },
         {
           "type": "interactive",
@@ -154,8 +160,11 @@
         },
         {
           "type": "interactive",
-          "action": "noop",
-          "content": "Review the updated snapshot information showing total resources, successful migrations, and any errors."
+          "action": "highlight",
+          "reftarget": "div:has(> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button'])",
+          "content": "Review the updated snapshot information showing total resources, successful migrations, and any errors.",
+          "requirements": ["on-page:/admin/migrate-to-cloud"],
+          "doIt": false
         },
         {
           "type": "interactive",

--- a/cloud-migration-assistant-lj/oss/content.json
+++ b/cloud-migration-assistant-lj/oss/content.json
@@ -21,7 +21,7 @@
     },
     {
       "type": "markdown",
-      "content": "Before starting your migration, verify the following prerequisites:\n\n1. Confirm your source Grafana instance is running version 11.2 or later (v12.0+ for GA)\n2. Verify the `onPremToCloudMigrations` feature toggle is enabled (enabled by default in v11.5+)\n3. Ensure you have Grafana server administrator access on the source instance\n4. Confirm you have Admin role access on your Grafana Cloud stack\n5. Verify your source instance has internet access\n6. If using a highly-available setup, scale down to one replica\n7. Add required IPs and URLs to your network allowlist (if applicable)"
+      "content": "Before starting your migration, verify the following prerequisites:\n\n1. Ensure you have Grafana server administrator access on the source instance\n2. Confirm you have Admin role access on your Grafana Cloud stack\n3. Verify your source instance has internet access\n4. If using a highly-available setup, scale down to one replica\n5. Add required IPs and URLs to your network allowlist (if applicable)"
     },
     {
       "type": "section",
@@ -52,7 +52,9 @@
           "action": "highlight",
           "reftarget": "a[data-testid='data-testid Nav menu item'][href='/admin/migrate-to-cloud']",
           "content": "Navigate to **Home** > **Administration** > **General** > **Migrate to Grafana Cloud**.",
-          "requirements": ["navmenu-open"],
+          "requirements": [
+            "navmenu-open"
+          ],
           "doIt": false
         },
         {
@@ -64,7 +66,9 @@
           "action": "highlight",
           "reftarget": "[data-testid='migrate-to-cloud-connect-session-modal-button']",
           "content": "Click the **Migrate this instance to Cloud** button, then paste your token and click **Connect to this Stack** in the modal that appears.",
-          "requirements": ["on-page:/admin/migrate-to-cloud"],
+          "requirements": [
+            "on-page:/admin/migrate-to-cloud"
+          ],
           "doIt": false
         }
       ]
@@ -86,17 +90,15 @@
           "action": "highlight",
           "reftarget": "div:has(> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-'])",
           "content": "Review the available resources for migration displayed in the migration assistant interface.",
-          "requirements": ["on-page:/admin/migrate-to-cloud"],
+          "requirements": [
+            "on-page:/admin/migrate-to-cloud"
+          ],
           "doIt": false
-        },
-        {
-          "type": "markdown",
-          "content": "In Grafana v12.0 and later, you can select specific resources. In versions 11.2-11.6, all supported resources are included automatically."
         },
         {
           "type": "interactive",
           "action": "noop",
-          "content": "If using Grafana v12.0 or later, select the checkbox next to each resource type you want to migrate: **Dashboards**, **Folders**, **Data sources**, **App Plugins**, **Panel Plugins**, **Library Panels**, and **Grafana Alerting resources**."
+          "content": "Select the checkbox next to each resource type you want to migrate: **Dashboards**, **Folders**, **Data sources**, **App Plugins**, **Panel Plugins**, **Library Panels**, and **Grafana Alerting resources**."
         },
         {
           "type": "markdown",
@@ -107,7 +109,9 @@
           "action": "highlight",
           "reftarget": "[data-testid='migrate-to-cloud-configure-snapshot-build-snapshot-button']",
           "content": "Click **Build snapshot**.",
-          "requirements": ["on-page:/admin/migrate-to-cloud"],
+          "requirements": [
+            "on-page:/admin/migrate-to-cloud"
+          ],
           "doIt": false
         },
         {
@@ -134,7 +138,9 @@
           "action": "highlight",
           "reftarget": "div:has(> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button'])",
           "content": "Review the snapshot summary showing the total number of resources ready for upload.",
-          "requirements": ["on-page:/admin/migrate-to-cloud"],
+          "requirements": [
+            "on-page:/admin/migrate-to-cloud"
+          ],
           "doIt": false
         },
         {
@@ -142,7 +148,9 @@
           "action": "highlight",
           "reftarget": "[data-testid='migrate-to-cloud-summary-upload-snapshot-button']",
           "content": "Click **Upload snapshot**.",
-          "requirements": ["on-page:/admin/migrate-to-cloud"],
+          "requirements": [
+            "on-page:/admin/migrate-to-cloud"
+          ],
           "doIt": false
         },
         {
@@ -155,7 +163,9 @@
           "action": "highlight",
           "reftarget": "tr:has(th)",
           "content": "Use the column headers to organize the view. Click **Name** to sort alphabetically, **Type** to group by resource type, or **Status** to group by upload status.",
-          "requirements": ["on-page:/admin/migrate-to-cloud"],
+          "requirements": [
+            "on-page:/admin/migrate-to-cloud"
+          ],
           "doIt": false
         },
         {
@@ -163,7 +173,9 @@
           "action": "highlight",
           "reftarget": "div:has(> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button'])",
           "content": "Review the updated snapshot information showing total resources, successful migrations, and any errors.",
-          "requirements": ["on-page:/admin/migrate-to-cloud"],
+          "requirements": [
+            "on-page:/admin/migrate-to-cloud"
+          ],
           "doIt": false
         },
         {
@@ -185,6 +197,61 @@
           "type": "interactive",
           "action": "noop",
           "content": "Complete the remaining steps in your **Grafana Cloud stack** to verify migrated resources and activate alert rules. Open the Cloud guide in Pathfinder when you're in your Cloud environment."
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "## Optional: Re-migrate alert rules in an active state\n\nBy default, alert rules are migrated in a paused state. If you prefer to re-migrate them in their original state from your self-managed instance, you can change a configuration setting and re-upload the snapshot. When you re-upload, resources with matching UIDs are updated rather than duplicated."
+    },
+    {
+      "type": "section",
+      "title": "Re-migrate alert rules in an active state",
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Locate your Grafana configuration file (`grafana.ini` or `custom.ini`) and add or modify the following setting:\n\n```ini\n[cloud_migration]\nalert_rules_state = unchanged\n```"
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Save the configuration file and restart your Grafana instance."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "a[data-testid='data-testid Nav menu item'][href='/admin/migrate-to-cloud']",
+          "content": "Navigate back to **Administration** > **General** > **Migrate to Grafana Cloud**.",
+          "requirements": [
+            "navmenu-open"
+          ],
+          "doIt": false
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='migrate-to-cloud-summary-reconfigure-snapshot-button']",
+          "content": "Click **Reconfigure snapshot** to rebuild the snapshot with the updated alert rule state.",
+          "requirements": [
+            "on-page:/admin/migrate-to-cloud"
+          ],
+          "doIt": false
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='migrate-to-cloud-summary-upload-snapshot-button']",
+          "content": "Click **Upload snapshot** to re-upload your resources. Alert rules will be updated to reflect their original state without creating duplicates.",
+          "requirements": [
+            "on-page:/admin/migrate-to-cloud"
+          ],
+          "doIt": false
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "In your Grafana Cloud instance, navigate to **Alerts & IRM** > **Alerting** > **Alert rules** and verify that alert rules now reflect their original state from your self-managed instance."
         }
       ]
     }


### PR DESCRIPTION
## Add interactive content for `cloud-migration-assistant` learning journey

### Summary

Adds two interactive Pathfinder guides for the Cloud Migration Assistant learning journey, split by environment: one for steps performed on the self-managed Grafana instance (OSS) and one for steps performed on Grafana Cloud.

### Changes

| Milestone | File | Blocks | Description |
|-----------|------|--------|-------------|
| OSS guide (business-value, prerequisites, connect, build, upload) | `cloud-migration-assistant-lj/oss/content.json` | 22 | Self-managed migration steps with highlights for nav, "Migrate this instance to Cloud" button, build snapshot, upload snapshot, and column headers |
| Cloud guide (generate-token, verify, activate, end-journey) | `cloud-migration-assistant-lj/cloud/content.json` | 28 | Cloud-side steps with highlights for nav, "Generate a migration token" button, dashboards, connections, and alerting verification |

### Interactive features

- Environment-aware selectors: OSS uses `data-testid` selectors verified on localhost:3000; Cloud uses Cloud-specific nav paths (`/alerts-and-incidents` vs `/alerting`) and `:contains()` for elements without `data-testid`
- Modal-safe UX: connection modal steps front-load instructions in markdown before the highlight, so users know what to do before the modal overlay blocks the sidebar
- Handoff steps: `noop` blocks at guide boundaries direct users between the OSS and Cloud guides

### Testing

- ✅ JSON validation passed
- ✅ OSS highlights verified: nav menu, "Migrate this instance to Cloud" button, build snapshot, upload snapshot, column headers
- 🟡 Cloud guide selectors discovered on personal cloud stack but not yet tested in Block Editor

### Related

- Learning journey source: `/docs/learning-journeys/cloud-migration-assistant/`