### PR TITLE
Add SAML + Okta interactive guide (UI-only)

### DIFF
--- a/index.json
+++ b/index.json
@@ -369,6 +369,18 @@
                     { "source": "play.grafana.org" }
                 ]
             }
+        },
+        {
+            "title": "Configure SAML authentication with Okta",
+            "type": "interactive",
+            "description": "UI walkthrough for SAML with Okta: Grafana SAML wizard, copy ACS and metadata URLs into Okta, paste IdP metadata, map assertions, Save and enable—for Grafana Enterprise and Grafana Cloud.",
+            "url": "https://github.com/grafana/interactive-tutorials/tree/main/saml-auth-okta",
+            "match": {
+                "or": [
+                    { "urlPrefix": "/admin/authentication" },
+                    { "urlPrefix": "/admin" }
+                ]
+            }
         }
     ]
 }

--- a/saml-auth-okta/content.json
+++ b/saml-auth-okta/content.json
@@ -1,0 +1,239 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "saml-auth-okta",
+  "title": "Configure SAML authentication with Okta",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "This tutorial follows the **Grafana SAML UI** ([Configure SAML authentication using the Grafana user interface](https://grafana.com/docs/grafana/latest/setup-grafana/configure-access/configure-authentication/saml/saml-ui/)) and [Configure SAML with Okta](https://grafana.com/docs/grafana/latest/setup-grafana/configure-access/configure-authentication/saml/configure-saml-with-okta/). SAML is available in **Grafana Enterprise** (10.0+) and on **select Grafana Cloud plans**. Grafana is the SAML **Service Provider**; Okta is the **Identity Provider**."
+    },
+    {
+      "type": "markdown",
+      "content": "> **Note:** You need permission to read and update SAML settings in the UI (the **Authentication configuration writer** role / `fixed:authentication.config:writer`). This guide only covers **UI** steps—no `grafana.ini` or API. UI changes override SAML settings from the configuration file or environment variables."
+    },
+    {
+      "type": "markdown",
+      "content": "> **Environment:** Use a stack where you can change authentication settings. Read-only sandboxes (for example Grafana Play) are not suitable."
+    },
+    {
+      "type": "section",
+      "id": "prerequisites",
+      "title": "Prerequisites",
+      "blocks": [
+        {
+          "type": "markdown",
+          "content": "You will confirm you can administer SAML in Grafana and Okta before changing either system."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "In Okta, ensure you can open the **Admin Console** and create a SAML app integration. See Okta’s [Add app integration](https://help.okta.com/en/prod/Content/Topics/Apps/apps-overview-add-apps.htm) if needed."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "In Grafana, confirm you have access to **Administration** \u003e **Authentication and authorization** (or equivalent) for SAML. See [Roles and permissions](https://grafana.com/docs/grafana/latest/administration/roles-and-permissions/) if you are unsure."
+        },
+        {
+          "type": "markdown",
+          "content": "You now know which permissions you need on both sides."
+        }
+      ]
+    },
+    {
+      "type": "section",
+      "id": "open-saml-ui",
+      "title": "Open the SAML configuration in Grafana",
+      "blocks": [
+        {
+          "type": "markdown",
+          "content": "You will open the SAML provider configuration so you can run the wizard and copy Service Provider URLs for Okta."
+        },
+        {
+          "type": "interactive",
+          "action": "navigate",
+          "reftarget": "/admin/authentication/saml",
+          "verify": "on-page:/admin/authentication/saml",
+          "content": "Go to **Administration** \u003e **Authentication and authorization**, choose **SAML**, or open the SAML configuration page directly.\n\n---\nIf your menu differs slightly, use the same destination: the SAML authentication settings for your stack.",
+          "requirements": ["is-logged-in"],
+          "skippable": true,
+          "tooltip": "Requires access to SAML settings in the UI; skip if your role does not include authentication configuration."
+        },
+        {
+          "type": "markdown",
+          "content": "If you skipped the previous step, open **Administration** \u003e **Authentication and authorization** \u003e **SAML** from the menu.\n\nYou are ready to use the SAML wizard (General settings through Test and enable)."
+        }
+      ]
+    },
+    {
+      "type": "section",
+      "id": "grafana-wizard-start",
+      "title": "SAML UI wizard: General and Sign requests",
+      "blocks": [
+        {
+          "type": "markdown",
+          "content": "You will complete **General settings** and **Sign requests** before connecting Okta."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "In **General settings**, set options such as **Allow signup**, **Auto login**, **Single logout**, and **Identity provider initiated login** as needed. See the field table in the [SAML UI documentation](https://grafana.com/docs/grafana/latest/setup-grafana/configure-access/configure-authentication/saml/saml-ui/#1-general-settings-section). Select **Next: Sign requests**."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "In **Sign requests**, choose whether outgoing requests are signed. If they are, provide or generate a certificate and private key (for example **Generate key and certificate** in the UI). Complete this section yourself—do not share private keys. Select **Next: Connect Grafana with Identity Provider**."
+        },
+        {
+          "type": "markdown",
+          "content": "You have reached the step where Grafana exposes URLs and fields for the Identity Provider."
+        }
+      ]
+    },
+    {
+      "type": "section",
+      "id": "connect-idp-urls",
+      "title": "Copy Grafana URLs for Okta",
+      "blocks": [
+        {
+          "type": "markdown",
+          "content": "You will copy the **Metadata URL** and **Assertion Consumer Service (ACS) URL** from Grafana and use them in Okta."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "In **Connect Grafana with Identity Provider**, find **Configure IdP using Grafana Metadata**. Copy the **Metadata URL**—you will give this to Okta so it can read Service Provider metadata."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Copy the **Assertion Consumer Service URL** (ACS). In Okta this is usually the **Single sign on URL** / Reply URL."
+        },
+        {
+          "type": "markdown",
+          "content": "You have the SP URLs Okta needs. Keep this page available while you configure Okta."
+        }
+      ]
+    },
+    {
+      "type": "section",
+      "id": "okta-create-app",
+      "title": "Create and configure the SAML app in Okta",
+      "blocks": [
+        {
+          "type": "markdown",
+          "content": "You will create a SAML 2.0 app in Okta and paste the URLs from Grafana."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Sign in to the [Okta portal](https://login.okta.com/), open **Admin Console** (switch to **Classic UI** from Developer Console if needed), then open **Applications**."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Choose **Create App Integration**, select **SAML 2.0**, then **Create**."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "On **General Settings**, name the app (for example Grafana) and add a logo if you want."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "On **Configure SAML**, set **Single sign on URL** to the **ACS URL** you copied from Grafana (`/saml/acs`)."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Set **Audience URI (SP Entity ID)** to your Grafana metadata URL (typically the `/saml/metadata` URL shown in Grafana or derived from your instance). It must match the Service Provider **entity ID** Grafana expects."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Adjust **Name ID format** and **Application username** if you use SAML Single Logout; otherwise defaults are often enough. See [Configure SAML with Okta](https://grafana.com/docs/grafana/latest/setup-grafana/configure-access/configure-authentication/saml/configure-saml-with-okta/) for details."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Under **ATTRIBUTE STATEMENTS (REQUIRED)**, add attributes whose **names** match what you will enter in Grafana **User mapping** (for example **Login**, **Email**, **DisplayName** with Okta expressions such as `user.login`, `user.email`, and a display name). Names must align with the Grafana **Assertion attributes mappings** fields."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Optionally under **GROUP ATTRIBUTE STATEMENTS**, add a group attribute (for example **Group**) if you use group or team sync in Grafana."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Finish the Okta wizard (**Next**, then **Finish**). Note your Okta **Identity Provider metadata** URL or file—you will paste metadata into Grafana next."
+        },
+        {
+          "type": "markdown",
+          "content": "Okta is configured to trust Grafana’s ACS and audience and to send the attributes Grafana will map."
+        }
+      ]
+    },
+    {
+      "type": "section",
+      "id": "finish-grafana-wizard",
+      "title": "Finish SAML in Grafana: IdP metadata and User mapping",
+      "blocks": [
+        {
+          "type": "markdown",
+          "content": "You will paste Okta metadata into Grafana, map assertions, then test and enable."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Still under **Connect Grafana with Identity Provider**, paste **IdP metadata** into Grafana (URL, file path, or Base64—whichever the UI offers). This tells Grafana how to connect to Okta."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Select **Next: User mapping**. In **Assertion attributes mappings**, enter the attribute names that match Okta (for example Login, Email, DisplayName). See the [Okta attribute table](https://grafana.com/docs/grafana/latest/setup-grafana/configure-access/configure-authentication/saml/configure-saml-with-okta/) in the official guide."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "If you use groups or role sync, complete **Groups attribute**, **Role mapping**, **Org mapping**, or **Allowed organizations** as needed. See [SAML UI](https://grafana.com/docs/grafana/latest/setup-grafana/configure-access/configure-authentication/saml/saml-ui/#4-user-mapping-section) and related topics (team sync, role sync, org mapping)."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Select **Next: Test and enable**, then **Save and enable**. Fix any validation errors the UI shows, then use **Save and apply** if the UI prompts you after edits."
+        },
+        {
+          "type": "markdown",
+          "content": "SAML is enabled from Grafana’s perspective and aligned with Okta’s metadata and attributes."
+        }
+      ]
+    },
+    {
+      "type": "section",
+      "id": "optional-scim",
+      "title": "Optional: SCIM and Okta",
+      "blocks": [
+        {
+          "type": "markdown",
+          "content": "You will decide whether you need an extra assertion for SCIM-provisioned users."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "If you use **SCIM** with Okta, align the SAML assertion with the provisioned user (for example an external ID claim). Follow the **SCIM** subsection in [Configure SAML with Okta](https://grafana.com/docs/grafana/latest/setup-grafana/configure-access/configure-authentication/saml/configure-saml-with-okta/).",
+          "skippable": true
+        },
+        {
+          "type": "markdown",
+          "content": "You know when to add SCIM-specific mapping beyond basic Login, Email, and display name."
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "---\n\n**Reference:** [SAML UI](https://grafana.com/docs/grafana/latest/setup-grafana/configure-access/configure-authentication/saml/saml-ui/) · [Configure SAML with Okta](https://grafana.com/docs/grafana/latest/setup-grafana/configure-access/configure-authentication/saml/configure-saml-with-okta/) · [SAML authentication in Grafana](https://grafana.com/docs/grafana/latest/setup-grafana/configure-access/configure-authentication/saml/) · [Okta guide source](https://github.com/grafana/grafana/blob/main/docs/sources/setup-grafana/configure-access/configure-authentication/saml/configure-saml-with-okta/_index.md)"
+    }
+  ]
+}

--- a/saml-auth-okta/manifest.json
+++ b/saml-auth-okta/manifest.json
@@ -1,0 +1,29 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "saml-auth-okta",
+  "type": "guide",
+  "description": "UI walkthrough for SAML SSO with Okta: Grafana SAML wizard (Administration > Authentication), copy SP URLs for Okta, IdP metadata and user mapping, then Save and enable—aligned with official Grafana docs for Grafana Enterprise and Grafana Cloud.",
+  "category": "general",
+  "author": {
+    "name": "Grafana Documentation",
+    "team": "interactive-learning"
+  },
+  "language": "en",
+  "startingLocation": "/admin/authentication/saml",
+  "targeting": {
+    "match": {
+      "or": [
+        { "urlPrefix": "/admin/authentication" },
+        { "urlPrefix": "/admin" }
+      ]
+    }
+  },
+  "testEnvironment": {
+    "tier": "cloud",
+    "minVersion": "10.0.0"
+  },
+  "depends": [],
+  "recommends": [],
+  "suggests": [],
+  "provides": []
+}


### PR DESCRIPTION
- New package saml-auth-okta with content.json aligned to Grafana SAML UI and Configure SAML with Okta docs (/admin/authentication/saml flow).
- manifest.json with targeting for admin authentication routes.
- index.json recommender entry for the new guide.

Made-with: Cursor