### PR TITLE
update k6 gcon interactive guide as per k6 team feedback

### DIFF
--- a/k6-extensions-grafana-cloud/content.json
+++ b/k6-extensions-grafana-cloud/content.json
@@ -52,9 +52,9 @@
         },
         {
           "type": "code-block",
+          "code": "import { sleep } from 'k6'\nimport faker from 'k6/x/faker'\n\n// See https://grafana.com/docs/k6/latest/using-k6/k6-options/reference/\nexport const options = {\n  vus: 1,\n  iterations: 1,\n  cloud: {\n    distribution: {\n      'amazon:us:ashburn': { loadZone: 'amazon:us:ashburn', percent: 100 },\n    },\n  },\n}\n\nexport default function main() {\n  console.log(faker.person.firstName())\n  sleep(1)\n}",
           "reftarget": "div[data-testid='data-testid Code editor container']",
           "language": "javascript",
-          "code": "import { sleep } from 'k6'\nimport http from 'k6/http'\nimport faker from 'k6/x/faker'\n\n// See https://grafana.com/docs/k6/latest/using-k6/k6-options/reference/\nexport const options = {\n  vus: 1,\n  iterations: 1,\n  thresholds: {\n    http_req_failed: ['rate<0.02'], // http errors should be less than 2%\n    http_req_duration: ['p(95)<2000'], // 95% requests should be below 2s\n  },\n  cloud: {\n    distribution: {\n      'amazon:us:ashburn': { loadZone: 'amazon:us:ashburn', percent: 100 },\n    },\n  },\n}\n\nexport default function main() {\n  console.log(faker.person.firstName())\n  sleep(1)\n}",
           "content": "Add this script: it imports **k6/x/faker** and logs a random first name when the test runs.",
           "requirements": [
             "on-page:/a/k6-app"

--- a/k6-extensions-grafana-cloud/content.json
+++ b/k6-extensions-grafana-cloud/content.json
@@ -4,7 +4,7 @@
   "blocks": [
     {
       "type": "markdown",
-      "content": "**What you'll learn:** How to run a Grafana Cloud k6 test that imports a supported extension (using `k6/x/faker` as an example), execute it, and confirm the extension output, without building a custom k6 binary."
+      "content": "**What you'll learn:** How to run a Grafana Cloud k6 test that imports a supported extension (using `k6/x/faker` as an example), execute it, and confirm the extension output."
     },
     {
       "type": "section",
@@ -17,64 +17,70 @@
         },
         {
           "type": "markdown",
-          "content": "k6 extensions extend core k6 behavior. In k6 open source you can build a custom binary; in Grafana Cloud k6 you can import a supported subset in your scripts, without any custom build required."
+          "content": "k6 extensions extend core k6 behavior. To use an extension, you need to import it in your test script."
         },
         {
           "type": "interactive",
           "action": "navigate",
-          "reftarget": "/a/k6-app/projects/6999415",
-          "verify": "on-page:/a/k6-app",
-          "content": "**k6 test with extensions** — Go to the k6 projects page, then follow the steps below."
+          "reftarget": "/a/k6-app/projects/",
+          "content": "**k6 test with extensions** — Go to the k6 projects page, then follow the steps below.",
+          "verify": "on-page:/a/k6-app"
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid=\"project-listing-layout-table\"] a:nth-match(1)",
+          "content": "Click **Default project**"
         },
         {
           "type": "interactive",
           "action": "button",
           "reftarget": "Create new test",
+          "content": "Click **Create new test** to create a sample k6 test with extensions.",
           "requirements": [
             "on-page:/a/k6-app"
-          ],
-          "content": "Click **Create new test** to create a sample k6 test with extensions."
+          ]
         },
         {
           "type": "interactive",
           "action": "button",
           "reftarget": "Start Scripting",
+          "content": "Click **Start Scripting**.",
           "requirements": [
             "on-page:/a/k6-app"
-          ],
-          "content": "Click **Start Scripting**."
+          ]
         },
         {
           "type": "code-block",
-          "code": "import { sleep } from 'k6'\nimport http from 'k6/http'\nimport faker from 'k6/x/faker'\n\n// See https://grafana.com/docs/k6/latest/using-k6/k6-options/reference/\nexport const options = {\n  vus: 1,\n  iterations: 1,\n  thresholds: {\n    http_req_failed: ['rate<0.02'], // http errors should be less than 2%\n    http_req_duration: ['p(95)<2000'], // 95% requests should be below 2s\n  },\n  cloud: {\n    distribution: {\n      'amazon:us:ashburn': { loadZone: 'amazon:us:ashburn', percent: 100 },\n    },\n  },\n}\n\nexport default function main() {\n  console.log(faker.person.firstName())\n  let response = http.get('https://quickpizza.grafana.com')\n  sleep(1)\n}",
           "reftarget": "div[data-testid='data-testid Code editor container']",
           "language": "javascript",
+          "code": "import { sleep } from 'k6'\nimport http from 'k6/http'\nimport faker from 'k6/x/faker'\n\n// See https://grafana.com/docs/k6/latest/using-k6/k6-options/reference/\nexport const options = {\n  vus: 1,\n  iterations: 1,\n  thresholds: {\n    http_req_failed: ['rate<0.02'], // http errors should be less than 2%\n    http_req_duration: ['p(95)<2000'], // 95% requests should be below 2s\n  },\n  cloud: {\n    distribution: {\n      'amazon:us:ashburn': { loadZone: 'amazon:us:ashburn', percent: 100 },\n    },\n  },\n}\n\nexport default function main() {\n  console.log(faker.person.firstName())\n  sleep(1)\n}",
+          "content": "Add this script: it imports **k6/x/faker** and logs a random first name when the test runs.",
           "requirements": [
             "on-page:/a/k6-app"
-          ],
-          "content": "Add this script: it imports **k6/x/faker** and logs a random first name when the test runs."
+          ]
         },
         {
           "type": "interactive",
           "action": "button",
           "reftarget": "Create And Run",
+          "content": "Click **Create and Run** and wait for the test to finish.",
           "requirements": [
             "on-page:/a/k6-app"
-          ],
-          "content": "Click **Create and Run** and wait for the test to finish."
+          ]
         },
         {
           "type": "interactive",
           "action": "highlight",
           "reftarget": "div[data-onboarding='breakdown'] a[data-testid='data-testid Tab LOGS']",
+          "content": "Open the **Logs** tab to confirm the extension ran.",
           "requirements": [
             "on-page:/a/k6-app"
-          ],
-          "content": "Open the **Logs** tab to confirm the extension ran."
+          ]
         },
         {
           "type": "markdown",
-          "content": "You learned how to import **k6/x/faker**, run the test in Grafana Cloud k6, and verify extension output on **Logs** (you should see a random first name). For the full list of supported extensions, see [Use k6 extensions](https://grafana.com/docs/grafana-cloud/testing/k6/author-run/use-k6-extensions/#import-an-extension-in-your-test-script)."
+          "content": "You learned how to import **k6/x/faker**, run the test in Grafana Cloud k6, and verify extension output on **Logs** (you should see a random first name). For the full list of supported extensions, see [Explore extensions](https://grafana.com/docs/k6/latest/extensions/explore/#explore-extensions)."
         }
       ]
     }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only changes to an interactive onboarding guide; main risk is minor breakage if UI selectors or button labels drift.
> 
> **Overview**
> Updates the `k6-extensions-grafana-cloud` interactive guide to better match current Grafana Cloud k6 UI and simplify the learning flow.
> 
> The walkthrough now navigates to the generic projects listing, explicitly highlights selecting the default project, and streamlines the example script to only import `k6/x/faker` (removing the HTTP request/thresholds). It also updates the supported-extensions link to the newer *Explore extensions* page and trims wording that referenced building custom binaries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 842f9a0126d42ee6b5a2439ad873f2426b196f8f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->