### PR TITLE
Add interactivity for categorize-collector-fleet learning path

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -27,6 +27,7 @@
 /adaptive-metrics-recommendations/                        @brendamuir
 /alerting-101/                                            @tomglenn
 /billing-usage-lj/                                        @jtvdez
+/categorize-collector-fleet-lj/                            @tiffany76
 /connect-prometheus-metrics/                              @tacole02
 /detect-outages-synthetic-monitoring-lj/                  @heitortsergent
 /drilldown-logs-lj/                                       @jstickler

--- a/categorize-collector-fleet-lj/add-environment-attribute/content.json
+++ b/categorize-collector-fleet-lj/add-environment-attribute/content.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "categorize-collector-fleet-add-environment-attribute",
+  "title": "Create and assign the environment attribute",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "In this milestone, you create the `env` attribute that identifies the deployment environment. This attribute enables environment-specific configuration management and prevents accidental changes to production systems by allowing you to target configuration updates to specific environments."
+    },
+    {
+      "type": "markdown",
+      "content": "Repeat Milestone 3 to select collectors that are deployed in the same environment."
+    },
+    {
+      "type": "markdown",
+      "content": "Click **Edit remote attributes**, then in the dialog:\n\n1. Click **Add remote attributes** to expand the section.\n2. In the **Key** field, type `env` and press Enter.\n3. In the **Value** field, type a deployment environment, for example, `prod`, and press Enter.\n4. Click **Apply changes**."
+    },
+    {
+      "type": "markdown",
+      "content": "Repeat this milestone until all collectors have been categorized by environment."
+    },
+    {
+      "type": "markdown",
+      "content": "After you apply the final changes, return to the **Inventory** tab to view all the new remote attributes that categorize your fleet: `team`, `service.name`, and `env`. These attributes provide a comprehensive categorization profile that tells you who owns the collector, which service it monitors, and where it runs."
+    },
+    {
+      "type": "markdown",
+      "content": "In the next milestone, you celebrate completing this journey and review what you've accomplished."
+    },
+    {
+      "type": "markdown",
+      "content": "---\n\n### More to explore (optional)\n\nAt this point in your journey, you can explore the following paths:\n\n- [Streamline your workflows](/docs/grafana-cloud/send-data/fleet-management/streamline-workflows/)"
+    }
+  ]
+}

--- a/categorize-collector-fleet-lj/add-environment-attribute/manifest.json
+++ b/categorize-collector-fleet-lj/add-environment-attribute/manifest.json
@@ -1,0 +1,12 @@
+{
+  "id": "categorize-collector-fleet-add-environment-attribute",
+  "type": "guide",
+  "description": "Learn how to create the env attribute that identifies the deployment environment for targeted configuration management.",
+  "category": "query-and-visualize",
+  "author": { "team": "Grafana Documentation", "name": "tiffany76" },
+  "testEnvironment": { "tier": "cloud" },
+  "depends": ["categorize-collector-fleet-add-service-attribute"],
+  "recommends": ["categorize-collector-fleet-end-journey"],
+  "suggests": [],
+  "provides": []
+}

--- a/categorize-collector-fleet-lj/add-service-attribute/content.json
+++ b/categorize-collector-fleet-lj/add-service-attribute/content.json
@@ -1,0 +1,31 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "categorize-collector-fleet-add-service-attribute",
+  "title": "Create and assign the service.name attribute",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "In this milestone, you create the `service.name` attribute that identifies which service a collector monitors. This attribute enables service-based configuration and troubleshooting workflows, allowing you to manage telemetry collection for specific services across your infrastructure."
+    },
+    {
+      "type": "markdown",
+      "content": "Repeat Milestone 3 to select collectors that monitor a specific service."
+    },
+    {
+      "type": "markdown",
+      "content": "Click **Edit remote attributes**, then in the dialog:\n\n1. Click **Add remote attributes** to expand the section.\n2. In the **Key** field, type `service.name` and press Enter.\n3. In the **Value** field, type a service name, for example, `payment-api`, and press Enter.\n4. Click **Apply changes**."
+    },
+    {
+      "type": "markdown",
+      "content": "Repeat this milestone until all your collectors are categorized by service."
+    },
+    {
+      "type": "markdown",
+      "content": "After you apply the final changes, return to the **Inventory** tab to see the `service.name` attribute with assigned values in the attributes list of the selected collectors."
+    },
+    {
+      "type": "markdown",
+      "content": "In the next milestone, you learn how to add the `env` attribute to specify where collectors are running."
+    }
+  ]
+}

--- a/categorize-collector-fleet-lj/add-service-attribute/manifest.json
+++ b/categorize-collector-fleet-lj/add-service-attribute/manifest.json
@@ -1,0 +1,12 @@
+{
+  "id": "categorize-collector-fleet-add-service-attribute",
+  "type": "guide",
+  "description": "Learn how to create the service.name attribute that identifies which service the collector monitors.",
+  "category": "query-and-visualize",
+  "author": { "team": "Grafana Documentation", "name": "tiffany76" },
+  "testEnvironment": { "tier": "cloud" },
+  "depends": ["categorize-collector-fleet-add-team-attribute"],
+  "recommends": ["categorize-collector-fleet-add-environment-attribute"],
+  "suggests": [],
+  "provides": []
+}

--- a/categorize-collector-fleet-lj/add-team-attribute/content.json
+++ b/categorize-collector-fleet-lj/add-team-attribute/content.json
@@ -1,0 +1,31 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "categorize-collector-fleet-add-team-attribute",
+  "title": "Create and assign the team attribute",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "In this milestone, you create the `team` attribute that identifies collector ownership. This attribute enables team-based filtering and configuration management in Fleet Management, ensuring clear operational accountability for each collector in your fleet."
+    },
+    {
+      "type": "markdown",
+      "content": "Click **Edit remote attributes**, then in the dialog:\n\n1. Click **Add remote attributes** to expand the section.\n2. In the **Key** field, type `team` and press Enter.\n3. In the **Value** field, type a team name, for example, `payments-platform`, and press Enter.\n4. Click **Apply changes**."
+    },
+    {
+      "type": "markdown",
+      "content": "Repeat Milestones 3 and 4 until all your collectors are categorized by team."
+    },
+    {
+      "type": "markdown",
+      "content": "After you apply the final changes, return to the **Inventory** tab to see the `team` attribute with assigned values in the attributes list of the selected collectors."
+    },
+    {
+      "type": "markdown",
+      "content": "In the next milestone, you learn how to add the `service.name` attribute to identify which service a collector monitors."
+    },
+    {
+      "type": "markdown",
+      "content": "---\n\n### More to explore (optional)\n\nAt this point in your journey, you can explore the following paths:\n\n- [Manage your Fleet](/docs/grafana-cloud/send-data/fleet-management/manage-fleet/)"
+    }
+  ]
+}

--- a/categorize-collector-fleet-lj/add-team-attribute/manifest.json
+++ b/categorize-collector-fleet-lj/add-team-attribute/manifest.json
@@ -1,0 +1,12 @@
+{
+  "id": "categorize-collector-fleet-add-team-attribute",
+  "type": "guide",
+  "description": "Learn how to create the team attribute that identifies collector ownership for operational accountability.",
+  "category": "query-and-visualize",
+  "author": { "team": "Grafana Documentation", "name": "tiffany76" },
+  "testEnvironment": { "tier": "cloud" },
+  "depends": ["categorize-collector-fleet-select-collector"],
+  "recommends": ["categorize-collector-fleet-add-service-attribute"],
+  "suggests": [],
+  "provides": []
+}

--- a/categorize-collector-fleet-lj/business-value/content.json
+++ b/categorize-collector-fleet-lj/business-value/content.json
@@ -1,0 +1,19 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "categorize-collector-fleet-business-value",
+  "title": "The value of fleet categorization",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "When you manage large collector fleets without proper organization, you can face operational challenges and configuration management complexity. Custom attributes solve this problem by providing a systematic way to categorize collectors and enable remote configuration through Fleet Management."
+    },
+    {
+      "type": "markdown",
+      "content": "Categorize your fleet with attributes to gain the following advantages:\n\n- Remotely configure collectors with reusable configuration based on meaningful characteristics\n- Quickly identify collector ownership when issues arise\n- Filter collectors by attribute to monitor health and identify issues\n- Segment collectors by environment to target configuration changes to production, staging, or development\n- Enable efficient troubleshooting through organized fleet visibility"
+    },
+    {
+      "type": "markdown",
+      "content": "In the next milestone, you learn how to navigate to Fleet Management to begin categorizing your collectors."
+    }
+  ]
+}

--- a/categorize-collector-fleet-lj/business-value/manifest.json
+++ b/categorize-collector-fleet-lj/business-value/manifest.json
@@ -1,0 +1,12 @@
+{
+  "id": "categorize-collector-fleet-business-value",
+  "type": "guide",
+  "description": "Understand how attributes enable remote configuration management and operational organization of your collector fleet.",
+  "category": "query-and-visualize",
+  "author": { "team": "Grafana Documentation", "name": "tiffany76" },
+  "testEnvironment": { "tier": "cloud" },
+  "depends": [],
+  "recommends": ["categorize-collector-fleet-navigate-to-fleet"],
+  "suggests": [],
+  "provides": []
+}

--- a/categorize-collector-fleet-lj/content.json
+++ b/categorize-collector-fleet-lj/content.json
@@ -1,0 +1,18 @@
+{
+  "id": "categorize-collector-fleet-lj",
+  "title": "Categorize a collector fleet in Fleet Management",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "Welcome to the Grafana Fleet Management learning journey that shows you how to organize and categorize your collector fleet using custom attributes for remote configuration.\nFleet Management lets you manage collectors at scale, and custom remote attributes provide the foundation for organizing and remotely configuring your fleet based on operational context.\n\nRemote attributes are key-value pairs that you assign to collectors in the Fleet Management application to categorize them by meaningful characteristics, such as team ownership, service context, and deployment environment.\nThese attributes enable remote configuration management, allowing you to target configuration changes to specific groups of collectors without manual intervention on each system."
+    },
+    {
+      "type": "markdown",
+      "content": "## Here's what to expect\n\nWhen you complete this journey, you'll be able to:\n\n- Explain the value of fleet categorization for remote configuration\n- Create and assign the `team` attribute to identify collector ownership\n- Create and assign the `service.name` attribute to identify which service the collector monitors\n- Create and assign the `env` attribute to identify the deployment environment"
+    },
+    {
+      "type": "markdown",
+      "content": "## Before you begin\n\nBefore you categorize a collector fleet, ensure that you have:\n\n- More than one collector registered in Fleet Management.\n  If you don't yet have collectors registered, refer to [Register collectors in Fleet Management](https://grafana.com/docs/grafana-cloud/send-data/fleet-management/set-up/onboard-collectors/).\n- **Admin** or RBAC permissions in Grafana Cloud to create attributes and modify collector configurations.\n  Refer to [Role-based access control for Fleet Management](https://grafana.com/docs/grafana-cloud/send-data/fleet-management/set-up/role-based-access-control/) for more information.\n- Familiarity with your organizational structure, including team names, service names, and environment classifications."
+    }
+  ]
+}

--- a/categorize-collector-fleet-lj/end-journey/content.json
+++ b/categorize-collector-fleet-lj/end-journey/content.json
@@ -1,0 +1,19 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "categorize-collector-fleet-end-journey",
+  "title": "Destination reached!",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "Congratulations on completing this journey! Job well done!"
+    },
+    {
+      "type": "markdown",
+      "content": "We hope you've enjoyed traveling with us as you:\n\n- Created and assigned the `team` attribute to identify collector ownership\n- Created and assigned the `service.name` attribute to identify which service the collector monitors\n- Created and assigned the `env` attribute to identify the deployment environment\n- Organized your fleet with attributes that enable remote configuration management"
+    },
+    {
+      "type": "markdown",
+      "content": "---\n\n### Related paths\n\nConsider taking the following paths after you complete this journey.\n\n- [Monitor a Linux server in Grafana Cloud](/docs/learning-paths/linux-server-integration/)\n- [Send logs to Grafana Cloud using Alloy](/docs/learning-paths/send-logs-alloy-loki/)"
+    }
+  ]
+}

--- a/categorize-collector-fleet-lj/end-journey/manifest.json
+++ b/categorize-collector-fleet-lj/end-journey/manifest.json
@@ -1,0 +1,12 @@
+{
+  "id": "categorize-collector-fleet-end-journey",
+  "type": "guide",
+  "description": "Celebrate completing the journey and review what you've accomplished in categorizing your collector fleet.",
+  "category": "query-and-visualize",
+  "author": { "team": "Grafana Documentation", "name": "tiffany76" },
+  "testEnvironment": { "tier": "cloud" },
+  "depends": ["categorize-collector-fleet-add-environment-attribute"],
+  "recommends": [],
+  "suggests": ["linux-server-integration-lj", "send-logs-alloy-loki-lj"],
+  "provides": []
+}

--- a/categorize-collector-fleet-lj/manifest.json
+++ b/categorize-collector-fleet-lj/manifest.json
@@ -1,0 +1,34 @@
+{
+  "id": "categorize-collector-fleet-lj",
+  "type": "path",
+  "description": "Step-by-step guide: Categorize a collector fleet in Fleet Management.",
+  "category": "query-and-visualize",
+  "author": { "team": "Grafana Documentation", "name": "tiffany76" },
+  "startingLocation": "/a/grafana-collector-app/fleet-management",
+  "targeting": {
+    "match": {
+      "and": [
+        {
+          "urlPrefix": "/a/grafana-collector-app/fleet-management"
+        },
+        {
+          "targetPlatform": "cloud"
+        }
+      ]
+    }
+  },
+  "testEnvironment": { "tier": "cloud" },
+  "milestones": [
+    "categorize-collector-fleet-business-value",
+    "categorize-collector-fleet-navigate-to-fleet",
+    "categorize-collector-fleet-select-collector",
+    "categorize-collector-fleet-add-team-attribute",
+    "categorize-collector-fleet-add-service-attribute",
+    "categorize-collector-fleet-add-environment-attribute",
+    "categorize-collector-fleet-end-journey"
+  ],
+  "depends": [],
+  "recommends": [],
+  "suggests": ["linux-server-integration-lj", "send-logs-alloy-loki-lj"],
+  "provides": []
+}

--- a/categorize-collector-fleet-lj/navigate-to-fleet/content.json
+++ b/categorize-collector-fleet-lj/navigate-to-fleet/content.json
@@ -1,0 +1,45 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "categorize-collector-fleet-navigate-to-fleet",
+  "title": "Navigate to Fleet Management",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "In this milestone, you navigate to Fleet Management within Grafana Cloud to access your collector fleet. Fleet Management provides a centralized interface for viewing collector status, health metrics, and configuration details across your entire deployment."
+    },
+    {
+      "type": "section",
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Sign in to your Grafana Cloud instance."
+        },
+        {
+          "type": "multistep",
+          "content": "Navigate to **Connections** > **Collector** > **Fleet Management**.",
+          "requirements": ["navmenu-open"],
+          "steps": [
+            { "action": "highlight", "reftarget": "a[data-testid='data-testid Nav menu item'][href='/connections']" },
+            { "action": "highlight", "reftarget": "a[data-testid='data-testid Nav menu item'][href='/a/grafana-collector-app']" },
+            { "action": "highlight", "reftarget": "a[data-testid='data-testid Nav menu item'][href='/a/grafana-collector-app/fleet-management']" }
+          ]
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='tab-fleet-inventory']",
+          "content": "On the **Inventory** tab, view the collector fleet overview showing all registered collectors."
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "The Fleet Management page displays a list of collectors showing their current health status and basic metadata."
+    },
+    {
+      "type": "markdown",
+      "content": "In the next milestone, you learn how to select collectors to configure with remote attributes."
+    }
+  ]
+}

--- a/categorize-collector-fleet-lj/navigate-to-fleet/manifest.json
+++ b/categorize-collector-fleet-lj/navigate-to-fleet/manifest.json
@@ -1,0 +1,12 @@
+{
+  "id": "categorize-collector-fleet-navigate-to-fleet",
+  "type": "guide",
+  "description": "Learn how to access Fleet Management in Grafana Cloud to view and manage your collector fleet.",
+  "category": "query-and-visualize",
+  "author": { "team": "Grafana Documentation", "name": "tiffany76" },
+  "testEnvironment": { "tier": "cloud" },
+  "depends": ["categorize-collector-fleet-business-value"],
+  "recommends": ["categorize-collector-fleet-select-collector"],
+  "suggests": [],
+  "provides": []
+}

--- a/categorize-collector-fleet-lj/select-collector/content.json
+++ b/categorize-collector-fleet-lj/select-collector/content.json
@@ -1,0 +1,30 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "categorize-collector-fleet-select-collector",
+  "title": "Select collectors",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "In this milestone, you select from your fleet the collectors owned by a single team to begin the categorization process. You can apply attributes to multiple collectors at once using the bulk edit tool."
+    },
+    {
+      "type": "section",
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "In your Fleet Management **Inventory**, identify the collectors you want to categorize."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Select the checkboxes next to each collector ID."
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "In the next milestone, you open the bulk edit tool and create the `team` ownership attribute for these collectors."
+    }
+  ]
+}

--- a/categorize-collector-fleet-lj/select-collector/manifest.json
+++ b/categorize-collector-fleet-lj/select-collector/manifest.json
@@ -1,0 +1,12 @@
+{
+  "id": "categorize-collector-fleet-select-collector",
+  "type": "guide",
+  "description": "Learn how to select a specific set of collectors from your fleet to begin the categorization process.",
+  "category": "query-and-visualize",
+  "author": { "team": "Grafana Documentation", "name": "tiffany76" },
+  "testEnvironment": { "tier": "cloud" },
+  "depends": ["categorize-collector-fleet-navigate-to-fleet"],
+  "recommends": ["categorize-collector-fleet-add-team-attribute"],
+  "suggests": [],
+  "provides": []
+}


### PR DESCRIPTION
Scaffolds content.json files for all 7 milestones of the categorize-collector-fleet learning path and adds CODEOWNERS entry.

Made-with: Cursor

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily adds new learning-journey JSON content and a CODEOWNERS entry; no runtime code paths or security-sensitive logic changes.
> 
> **Overview**
> Adds a new `categorize-collector-fleet-lj` learning journey, including a `path` manifest plus 7 milestone guides with interactive/markdown steps for categorizing collectors via remote attributes (`team`, `service.name`, `env`) in Fleet Management.
> 
> Updates `.github/CODEOWNERS` to assign ownership of the new learning-journey directory to `@tiffany76`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 672437319c6b5bf2820b9e3f683c14d25bf245d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->