### PR TITLE
update CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -69,7 +69,7 @@
 /dynamic-dashboards-tour/                                 @Jayclifford345
 /git-sync-guide/                                          @Jayclifford345
 /grafana-13-tour-learn/                                   @Jayclifford345
-/grafana-13-tour-play/                                    @Jayclifford345
+/grafana-13-tour-play/                                    @Jayclifford345 @mdcruz
 /kiosk/                                                   @Jayclifford345
 /rca-demo/                                                @simonprickett
 /slo-quickstart/                                          @grafana/slo-squad
@@ -85,6 +85,7 @@
 /visualization-logs/                                      @jstickler
 /visualization-metrics-lj/                                @knylander-grafana
 /visualization-traces-lj/                                 @knylander-grafana
-/welcome-to-play/                                         @Jayclifford345
+/welcome-to-play/                                         @Jayclifford345 @mdcruz
 /windows-integration/                                     @chri2547
 /haproxy-load-balancer-lj/                                @tacole02
+/sm-scripted-check-tutorial                               @mdcruz @legander

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -88,4 +88,4 @@
 /welcome-to-play/                                         @Jayclifford345 @mdcruz
 /windows-integration/                                     @chri2547
 /haproxy-load-balancer-lj/                                @tacole02
-/sm-scripted-check-tutorial                               @mdcruz @legander
+/sm-scripted-check-tutorial/                              @mdcruz @legander


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Updates only `.github/CODEOWNERS`, affecting review/approval routing but not runtime behavior. Low risk aside from potentially changing who is auto-requested/required for guide changes.
> 
> **Overview**
> Updates `.github/CODEOWNERS` to expand ownership for `/grafana-13-tour-play/` and `/welcome-to-play/` by adding `@mdcruz`, and adds a new ownership rule for `/sm-scripted-check-tutorial/` (`@mdcruz` and `@legander`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e62597e8884e021eec8a4a3a4b46e89a2e05e577. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->