### PR TITLE
Add Semantic Layer Data Model Configuration guide

### DIFF
--- a/semantic-layer-data-model-config/content.json
+++ b/semantic-layer-data-model-config/content.json
@@ -1,0 +1,85 @@
+{
+  "id": "semantic-layer-data-model-config",
+  "title": "Semantic Layer: Data Model Configuration",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "You'll explore the Cube data source's Data Model tab to see how tables, joins, and dimensions are defined in YAML."
+    },
+    {
+      "type": "section",
+      "id": "data-model-exploration",
+      "title": "Explore the Data Model",
+      "autoCollapse": false,
+      "blocks": [
+        {
+          "type": "markdown",
+          "content": "You'll navigate to the Cube data source and explore its schema tables and YAML configuration files."
+        },
+        {
+          "type": "interactive",
+          "action": "navigate",
+          "reftarget": "/connections/datasources/edit/grafana-cube-datasource",
+          "content": "Navigate to the **Cube** data source configuration.",
+          "verify": "on-page:/connections/datasources/edit/grafana-cube-datasource"
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='data-testid Tab Data Model']",
+          "content": "Click **Data Model** to view the schema and configuration files.",
+          "tooltip": "The Data Model tab shows the database schema and YAML files that define the Semantic Layer.",
+          "requirements": [
+            "on-page:/connections/datasources/edit/grafana-cube-datasource"
+          ]
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "button:has-text('grafana_play_cube')",
+          "content": "This is the **grafana_play_cube** schema containing the tables used by the Semantic Layer dashboards.",
+          "tooltip": "Each schema groups the database tables available for building cubes and views.",
+          "requirements": [
+            "on-page:/connections/datasources/edit/grafana-cube-datasource"
+          ],
+          "doIt": false
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "button:has-text('Files')",
+          "content": "Click **Files** to see the YAML configuration that defines each cube.",
+          "tooltip": "Cube YAML files define SQL tables, joins, dimensions, and measures for the Semantic Layer.",
+          "requirements": [
+            "on-page:/connections/datasources/edit/grafana-cube-datasource"
+          ]
+        },
+        {
+          "type": "interactive",
+          "action": "button",
+          "reftarget": "cubes/orders.yml",
+          "content": "Click **cubes/orders.yml** to preview the orders cube definition.",
+          "tooltip": "Each YAML file defines one cube with its table, relationships, and queryable fields.",
+          "requirements": [
+            "on-page:/connections/datasources/edit/grafana-cube-datasource"
+          ]
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "div[data-testid='data-testid Code editor container']",
+          "content": "This YAML defines the `orders` cube -- its SQL table, joins to `customers` and `payments`, and dimensions like `id`, `status`, and `order_date`.",
+          "tooltip": "These YAML definitions generate the SQL you saw in the dashboard query editors.",
+          "requirements": [
+            "on-page:/connections/datasources/edit/grafana-cube-datasource"
+          ],
+          "doIt": false
+        },
+        {
+          "type": "markdown",
+          "content": "You've seen how the Cube data source's Data Model tab exposes the schema tables and YAML configuration powering the Semantic Layer."
+        }
+      ]
+    }
+  ]
+}

--- a/semantic-layer-data-model-config/manifest.json
+++ b/semantic-layer-data-model-config/manifest.json
@@ -1,0 +1,17 @@
+{
+  "id": "semantic-layer-data-model-config",
+  "type": "guide",
+  "description": "Explore the Cube data source's Data Model tab to see how schema tables, joins, and dimensions are defined in YAML.",
+  "category": "general",
+  "author": {
+    "team": "interactive-learning",
+    "name": "Jayclifford345"
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": [],
+  "recommends": [],
+  "suggests": [],
+  "provides": []
+}

--- a/semantic-layer-tutorial/content.json
+++ b/semantic-layer-tutorial/content.json
@@ -345,6 +345,12 @@
           "content": "You've seen how the Semantic Layer dynamically injects both `LEFT JOIN`s and `WHERE` clauses when you filter, and removes them when the filter is cleared -- eliminating `column not found` errors entirely."
         }
       ]
+    },
+    {
+      "type": "interactive",
+      "action": "navigate",
+      "reftarget": "https://fbde35.grafana.net/connections/datasources/edit/grafana-cube-datasource?doc=semantic-layer-data-model-config",
+      "content": "Next, explore the **Data Model** configuration behind the Cube data source to see how cubes, joins, and dimensions are defined in YAML."
     }
   ]
 }

--- a/semantic-layer-tutorial/content.json
+++ b/semantic-layer-tutorial/content.json
@@ -349,7 +349,7 @@
     {
       "type": "interactive",
       "action": "navigate",
-      "reftarget": "https://fbde35.grafana.net/connections/datasources/edit/grafana-cube-datasource?doc=semantic-layer-data-model-config",
+      "reftarget": "https://fbde35.grafana.net/connections/datasources/edit/grafana-cube-datasource?doc=https://interactive-learning.grafana.net/guides/semantic-layer-data-model-config/content.json",
       "content": "Next, explore the **Data Model** configuration behind the Cube data source to see how cubes, joins, and dimensions are defined in YAML."
     }
   ]


### PR DESCRIPTION
## Summary
- Adds new `semantic-layer-data-model-config` guide that walks through the Cube data source's Data Model tab, showing schema tables and YAML configuration files (cubes, joins, dimensions)
- Adds a navigate step at the end of `semantic-layer-tutorial` linking to the new guide on fbde35 via `doc=` parameter
- New guide manifest has empty dependency arrays so it won't match any existing recommendations

## Test plan
- [ ] Load guide on fbde35 instance via `?doc=semantic-layer-data-model-config` on the Cube datasource page
- [ ] Verify each step targets the correct UI element (Data Model tab, schema toggle, Files button, orders.yml, code editor)
- [ ] Verify tooltips appear and are under 250 characters
- [ ] Verify the linking step at the end of `semantic-layer-tutorial` opens the new guide

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a new interactive-learning guide and a link from an existing tutorial; risk is limited to guide navigation/selector stability and does not affect product logic.
> 
> **Overview**
> Adds a new `semantic-layer-data-model-config` interactive guide that walks users through the Cube data source’s **Data Model** tab, including viewing schema tables and opening `cubes/orders.yml` in the built-in YAML editor.
> 
> Updates `semantic-layer-tutorial` to end with a navigation step that deep-links to the new guide via the `doc=` query parameter on the Cube data source page.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3412368b22ddf3afb940267c6387affe30359397. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->