### PR TITLE
update selectors in graphviz guide

### DIFF
--- a/grafana-13-tour-play/content.json
+++ b/grafana-13-tour-play/content.json
@@ -128,7 +128,7 @@
             },
             {
               "action": "formfill",
-              "reftarget": "div[data-testid='input-wrapper'] input:nth-match(6)",
+              "reftarget": "div[data-testid='input-wrapper'] input:nth-match(8)",
               "targetvalue": "Conversion rate (percentage)",
               "description": "For the **Threshold set**, provide **Conversion rate (percentage)** as the input",
               "validateInput": true
@@ -209,7 +209,7 @@
             },
             {
               "action": "formfill",
-              "reftarget": "div[data-testid='input-wrapper'] input:nth-match(7)",
+              "reftarget": "div[data-testid='input-wrapper'] input:nth-match(9)",
               "targetvalue": "Service health (SLA percentage)"
             },
             {
@@ -296,7 +296,7 @@
             },
             {
               "action": "formfill",
-              "reftarget": "div[data-testid='input-wrapper'] input:nth-match(8)",
+              "reftarget": "div[data-testid='input-wrapper'] input:nth-match(10)",
               "targetvalue": "Service health (SLA percentage)"
             },
             {

--- a/grafana-13-tour-play/content.json
+++ b/grafana-13-tour-play/content.json
@@ -452,7 +452,7 @@
         },
         {
           "type": "multistep",
-          "content": "Follow along to see how copy-paste styles work in action!",
+          "content": "This will **automatically** execute the steps to see how copy-paste styles work in action!",
           "steps": [
             {
               "action": "highlight",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Content-only updates to guided tour selectors/text; low risk aside from potentially breaking the tour if selectors are still inaccurate.
> 
> **Overview**
> Updates the Grafana 13 Play tour JSON to keep the Graphviz walkthrough working after UI input ordering changes by adjusting several `nth-match()` selectors used in `formfill` steps.
> 
> Also tweaks the copy-paste styles tour step intro text to clarify that the multistep flow runs **automatically**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b846c9e0ca94f906942ec4319c5976edaf30f525. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->