### PR TITLE
fix flaky selectors

### DIFF
--- a/grafana-13-tour-play/content.json
+++ b/grafana-13-tour-play/content.json
@@ -128,7 +128,7 @@
             },
             {
               "action": "formfill",
-              "reftarget": "div[data-testid='input-wrapper'] input:nth-match(8)",
+              "reftarget": "div[data-testid='input-wrapper'] input[placeholder=\"Field config thresholds\"]:nth-match(1)",
               "targetvalue": "Conversion rate (percentage)",
               "description": "For the **Threshold set**, provide **Conversion rate (percentage)** as the input",
               "validateInput": true
@@ -209,7 +209,7 @@
             },
             {
               "action": "formfill",
-              "reftarget": "div[data-testid='input-wrapper'] input:nth-match(9)",
+              "reftarget": "div[data-testid='input-wrapper'] input[placeholder=\"Field config thresholds\"]:nth-match(2)",
               "targetvalue": "Service health (SLA percentage)"
             },
             {
@@ -296,7 +296,7 @@
             },
             {
               "action": "formfill",
-              "reftarget": "div[data-testid='input-wrapper'] input:nth-match(10)",
+              "reftarget": "div[data-testid='input-wrapper'] input[placeholder=\"Field config thresholds\"]:nth-match(3)",
               "targetvalue": "Service health (SLA percentage)"
             },
             {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: only changes guided-tour `reftarget` CSS selectors in `content.json`, with no runtime code or data-handling impact; primary risk is selectors still not matching in some UI variants.
> 
> **Overview**
> Stabilizes the Grafana 13 Play guided tour for the Graphviz panel by replacing brittle `nth-match(N)` input selectors with placeholder-scoped selectors for the **Field config thresholds** inputs.
> 
> This updates three `formfill` steps (edge stroke color, node stroke color, node fill color) to target the correct threshold set fields more reliably.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40a3562c59ca7d25faab5e5f64ba76c6061974b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->