### PR TITLE
convert multistep to guided

### DIFF
--- a/grafana-13-tour-play/content.json
+++ b/grafana-13-tour-play/content.json
@@ -451,40 +451,40 @@
           "scrollContainer": "div[data-testid='data-testid DashboardEditPaneSplitter primary body'] div[data-testid='data-testid DashboardEditPaneSplitter body container']"
         },
         {
-          "type": "multistep",
-          "content": "This will **automatically** execute the steps to see how copy-paste styles work in action!",
+          "type": "guided",
+          "content": "Follow along to see how copy-paste styles work in action!",
           "steps": [
             {
               "action": "highlight",
               "reftarget": "div[data-testid='data-testid header-container'] button[data-testid='data-testid Panel menu Gauge with sparkline and gradient']",
-              "tooltip": "Open the panel menu to access style options.",
               "lazyRender": true,
-              "scrollContainer": "div[data-testid='data-testid DashboardEditPaneSplitter primary body'] div[data-testid='data-testid DashboardEditPaneSplitter body container']"
+              "scrollContainer": "div[data-testid='data-testid DashboardEditPaneSplitter primary body'] div[data-testid='data-testid DashboardEditPaneSplitter body container']",
+              "description": "Open the panel menu to access style options."
             },
             {
               "action": "hover",
               "reftarget": "div[data-testid='data-testid portal-container'] div[data-testid='data-testid Panel menu item Styles']",
-              "tooltip": "Hover to reveal the style actions."
+              "description": "Hover to reveal the style actions."
             },
             {
               "action": "highlight",
               "reftarget": "div[data-testid='data-testid portal-container'] div:text('Copy styles')",
-              "tooltip": "Copy the visual styling from this panel."
+              "description": "Copy the visual styling from this panel."
             },
             {
               "action": "highlight",
               "reftarget": "div[data-testid='data-testid header-container'] button[data-testid='data-testid Panel menu Gauge with sparkline and center glow']",
-              "tooltip": "Open the menu on the target panel."
+              "description": "Open the menu on the target panel."
             },
             {
               "action": "hover",
               "reftarget": "div[data-testid='data-testid portal-container'] div[data-testid='data-testid Panel menu item Styles']",
-              "tooltip": "Hover to reveal the style actions."
+              "description": "Hover to reveal the style actions."
             },
             {
               "action": "highlight",
               "reftarget": "div[data-testid='data-testid portal-container'] div:text('Paste styles')",
-              "tooltip": "Apply the copied styles to this panel."
+              "description": "Apply the copied styles to this panel."
             }
           ]
         },


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk content-only change in `content.json` that alters how the copy-paste styles tour step is presented/executed, with no code or data-handling impact.
> 
> **Overview**
> Updates the **Copy-paste styles** section in `grafana-13-tour-play/content.json` by converting the walkthrough block from `multistep` (auto-executed) to `guided` (follow-along), including renaming per-step `tooltip` fields to `description` and adjusting step copy accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b9be6561cd4b23e9cd5ebe8ab602832b0fbe88a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->