### PR TITLE
Add interactive guides for establish-k6-baseline learning path

### DIFF
--- a/establish-k6-baseline-lj/add-checks/content.json
+++ b/establish-k6-baseline-lj/add-checks/content.json
@@ -1,0 +1,44 @@
+{
+  "id": "establish-k6-baseline-add-checks",
+  "title": "Add checks to your script",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "In this milestone, you use the `check` API so every response validates correctness, not just latency."
+    },
+    {
+      "type": "section",
+      "id": "add-response-checks",
+      "title": "Validate responses",
+      "blocks": [
+        {
+          "type": "markdown",
+          "content": "You'll wire checks that record pass rate without aborting the load test when a single response fails."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Open `baseline.js` and update the import statement to include `check`:\n\n```javascript\nimport http from 'k6/http';\nimport { check, sleep } from 'k6';\n```"
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "In the default function, assign the HTTP response to a variable and add checks after the request:\n\n```javascript\nexport default function () {\n  const res = http.get('https://quickpizza.grafana.com');\n\n  check(res, {\n    'status is 200': (r) => r.status === 200,\n    'response body is not empty': (r) => r.body.length > 0,\n  });\n\n  sleep(1);\n}\n```\n\nEach check has a descriptive name and a predicate returning true or false. Failed checks do not stop the test; k6 aggregates pass rate across the run."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Save the file. Your complete `baseline.js` should now look like this:\n\n```javascript\nimport http from 'k6/http';\nimport { check, sleep } from 'k6';\n\nexport const options = {\n  stages: [\n    { duration: '30s', target: 20 },\n    { duration: '1m', target: 20 },\n    { duration: '30s', target: 0 },\n  ],\n};\n\nexport default function () {\n  const res = http.get('https://quickpizza.grafana.com');\n\n  check(res, {\n    'status is 200': (r) => r.status === 200,\n    'response body is not empty': (r) => r.body.length > 0,\n  });\n\n  sleep(1);\n}\n```\n\nWhen you run the test, the summary includes check pass rate alongside HTTP metrics."
+        },
+        {
+          "type": "markdown",
+          "content": "You now measure both performance and functional correctness in the same script."
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "In the next milestone, you run the test and read the k6 summary output."
+    }
+  ]
+}

--- a/establish-k6-baseline-lj/add-checks/manifest.json
+++ b/establish-k6-baseline-lj/add-checks/manifest.json
@@ -1,0 +1,26 @@
+{
+  "id": "establish-k6-baseline-add-checks",
+  "type": "guide",
+  "description": "Hands-on guide: Import check from k6 and assert status and body on each response.",
+  "category": "take-action",
+  "author": {
+    "name": "bonnywelsford-source",
+    "team": "Grafana Documentation"
+  },
+  "startingLocation": "/testing-and-synthetics",
+  "targeting": {
+    "match": {
+      "and": [
+        { "targetPlatform": "cloud" },
+        { "urlPrefix": "/testing-and-synthetics" }
+      ]
+    }
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": ["establish-k6-baseline-design-load-profile"],
+  "recommends": ["establish-k6-baseline-run-and-read-results"],
+  "suggests": [],
+  "provides": []
+}

--- a/establish-k6-baseline-lj/add-thresholds/content.json
+++ b/establish-k6-baseline-lj/add-thresholds/content.json
@@ -1,0 +1,44 @@
+{
+  "id": "establish-k6-baseline-add-thresholds",
+  "title": "Add thresholds to your script",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "In this milestone, you add `thresholds` so k6 exits non-zero when latency, errors, or check pass rate violate your baseline."
+    },
+    {
+      "type": "section",
+      "id": "configure-thresholds",
+      "title": "Configure thresholds",
+      "blocks": [
+        {
+          "type": "markdown",
+          "content": "You'll attach quantitative gates that CI systems can trust using the process exit code."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Open `baseline.js` and add a `thresholds` map inside `options`:\n\n```javascript\nexport const options = {\n  stages: [\n    { duration: '30s', target: 20 },\n    { duration: '1m', target: 20 },\n    { duration: '30s', target: 0 },\n  ],\n  thresholds: {\n    http_req_duration: ['p(95)<500'],\n    http_req_failed: ['rate<0.01'],\n  },\n};\n```\n\n`p(95)<500` fails if more than 5% of observations exceed 500 ms. `rate<0.01` fails if more than 1% of requests error. Adjust the numbers to match the headroom plan from your baseline table."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Optionally guard correctness with a checks threshold:\n\n```javascript\nthresholds: {\n  http_req_duration: ['p(95)<500'],\n  http_req_failed: ['rate<0.01'],\n  checks: ['rate>0.99'],\n},\n```\n\n`checks: ['rate>0.99']` fails if overall check pass rate drops below 99%."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Save the file. A complete example:\n\n```javascript\nimport http from 'k6/http';\nimport { check, sleep } from 'k6';\n\nexport const options = {\n  stages: [\n    { duration: '30s', target: 20 },\n    { duration: '1m', target: 20 },\n    { duration: '30s', target: 0 },\n  ],\n  thresholds: {\n    http_req_duration: ['p(95)<500'],\n    http_req_failed: ['rate<0.01'],\n    checks: ['rate>0.99'],\n  },\n};\n\nexport default function () {\n  const res = http.get('https://quickpizza.grafana.com');\n\n  check(res, {\n    'status is 200': (r) => r.status === 200,\n    'response body is not empty': (r) => r.body.length > 0,\n  });\n\n  sleep(1);\n}\n```\n\nYou can stack multiple expressions per metric, for example `http_req_duration: ['p(95)<500', 'p(99)<1000']`."
+        },
+        {
+          "type": "markdown",
+          "content": "Your script now fails fast when the baseline regresses instead of only printing numbers."
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "In the next milestone, you prove thresholds pass under normal settings and fail when deliberately broken."
+    }
+  ]
+}

--- a/establish-k6-baseline-lj/add-thresholds/manifest.json
+++ b/establish-k6-baseline-lj/add-thresholds/manifest.json
@@ -1,0 +1,26 @@
+{
+  "id": "establish-k6-baseline-add-thresholds",
+  "type": "guide",
+  "description": "Hands-on guide: Add thresholds on http_req_duration, http_req_failed, and checks to enforce pass or fail behavior.",
+  "category": "take-action",
+  "author": {
+    "name": "bonnywelsford-source",
+    "team": "Grafana Documentation"
+  },
+  "startingLocation": "/testing-and-synthetics",
+  "targeting": {
+    "match": {
+      "and": [
+        { "targetPlatform": "cloud" },
+        { "urlPrefix": "/testing-and-synthetics" }
+      ]
+    }
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": ["establish-k6-baseline-identify-baseline-values"],
+  "recommends": ["establish-k6-baseline-validate-thresholds"],
+  "suggests": [],
+  "provides": []
+}

--- a/establish-k6-baseline-lj/content.json
+++ b/establish-k6-baseline-lj/content.json
@@ -1,0 +1,22 @@
+{
+  "id": "establish-k6-baseline-lj",
+  "title": "Establish a performance baseline with k6",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "A performance baseline is a set of known-good metric values, such as response time and error rate, that represent how your system behaves under a realistic load. Without a baseline, you have no benchmark to compare against when something changes.\n\nThis journey walks you through designing a load profile, adding checks, running a test, reading the summary, recording baseline numbers, encoding them as thresholds, validating pass or fail exit codes, and streaming results to Grafana Cloud k6 for historical comparison."
+    },
+    {
+      "type": "markdown",
+      "content": "## Here's what to expect\n\nWhen you complete this journey, you'll be able to:\n\n- Understand what p95 or p99 latency, throughput, and error rate mean as baseline metrics\n- Design a load profile with ramping virtual users that reflects realistic traffic\n- Add checks to validate response correctness alongside performance\n- Interpret k6 summary output including percentiles and averages\n- Define thresholds so your test passes or fails based on baseline criteria\n- Save and compare results in Grafana Cloud k6"
+    },
+    {
+      "type": "markdown",
+      "content": "## Before you begin\n\nEnsure that you have:\n\n- A Grafana Cloud account\n- k6 installed on your machine\n- Basic knowledge of JavaScript (k6 scripts use JavaScript)\n- A code editor and access to a terminal"
+    },
+    {
+      "type": "markdown",
+      "content": "## Troubleshooting\n\nIf you get stuck, we've got your back! Where appropriate, troubleshooting information is just a click away.\n\n## More to explore\n\nWe understand you might want to explore other capabilities not strictly on this path. We'll provide you opportunities where it makes sense."
+    }
+  ]
+}

--- a/establish-k6-baseline-lj/design-load-profile/content.json
+++ b/establish-k6-baseline-lj/design-load-profile/content.json
@@ -1,0 +1,54 @@
+{
+  "id": "establish-k6-baseline-design-load-profile",
+  "title": "Design your load profile",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "In this milestone, you create `baseline.js` with a ramping virtual user profile: ramp up, steady state, and ramp down."
+    },
+    {
+      "type": "section",
+      "id": "author-baseline-script",
+      "title": "Author the baseline script",
+      "blocks": [
+        {
+          "type": "markdown",
+          "content": "You'll build a minimal k6 script with `stages` so metrics stabilize during the middle stage."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "In your code editor, create a new file named `baseline.js` and add the following imports.\n\nIf you prefer a visual approach to script creation, you can use [k6 Studio](https://grafana.com/docs/k6-studio/). This path uses a code editor so you can see and modify the script directly as you add checks and thresholds in later milestones.\n\n```javascript\nimport http from 'k6/http';\nimport { sleep } from 'k6';\n```"
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Define your load profile using the `stages` option.\n\nThe following example ramps up to 20 virtual users over 30 seconds, holds steady for 1 minute, then ramps back down over 30 seconds:\n\n```javascript\nexport const options = {\n  stages: [\n    { duration: '30s', target: 20 },\n    { duration: '1m', target: 20 },\n    { duration: '30s', target: 0 },\n  ],\n};\n```\n\nThe `stages` shorthand uses the ramping virtual users executor. Adjust `target` to approximate production concurrency and lengthen the steady stage if metrics need more time to settle."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Add the default function that performs your request:\n\n```javascript\nexport default function () {\n  http.get('https://quickpizza.grafana.com');\n  sleep(1);\n}\n```"
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Replace the URL with the endpoint you want to baseline."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Save the file. Your complete `baseline.js` should look like this:\n\n```javascript\nimport http from 'k6/http';\nimport { sleep } from 'k6';\n\nexport const options = {\n  stages: [\n    { duration: '30s', target: 20 },\n    { duration: '1m', target: 20 },\n    { duration: '30s', target: 0 },\n  ],\n};\n\nexport default function () {\n  http.get('https://quickpizza.grafana.com');\n  sleep(1);\n}\n```\n\nThe steady-state stage (the middle stage) is where your baseline data comes from. Make it long enough, at least 1 minute, so the metrics stabilize and reflect consistent system behavior rather than warm-up effects."
+        },
+        {
+          "type": "markdown",
+          "content": "You now have a runnable script whose traffic shape matches ramp, hold, and ramp down."
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "In the next milestone, you add checks so you measure correctness as well as speed."
+    }
+  ]
+}

--- a/establish-k6-baseline-lj/design-load-profile/manifest.json
+++ b/establish-k6-baseline-lj/design-load-profile/manifest.json
@@ -1,0 +1,26 @@
+{
+  "id": "establish-k6-baseline-design-load-profile",
+  "type": "guide",
+  "description": "Hands-on guide: Create baseline.js with ramping stages and a default function that issues an HTTP request.",
+  "category": "take-action",
+  "author": {
+    "name": "bonnywelsford-source",
+    "team": "Grafana Documentation"
+  },
+  "startingLocation": "/testing-and-synthetics",
+  "targeting": {
+    "match": {
+      "and": [
+        { "targetPlatform": "cloud" },
+        { "urlPrefix": "/testing-and-synthetics" }
+      ]
+    }
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": ["establish-k6-baseline-understand-baselines"],
+  "recommends": ["establish-k6-baseline-add-checks"],
+  "suggests": [],
+  "provides": []
+}

--- a/establish-k6-baseline-lj/end-journey/content.json
+++ b/establish-k6-baseline-lj/end-journey/content.json
@@ -1,0 +1,18 @@
+{
+  "id": "establish-k6-baseline-end-journey",
+  "title": "Destination reached!",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "Congratulations on completing this learning path. You now have a repeatable way to capture baselines, enforce them with thresholds, and archive runs in Grafana Cloud k6."
+    },
+    {
+      "type": "markdown",
+      "content": "**What you accomplished**\n\n- Learned how p95 or p99 latency, throughput, and error rate combine into a baseline story\n- Authored `baseline.js` with ramping virtual users and steady-state measurement\n- Added checks for functional validation alongside performance metrics\n- Interpreted k6 summary output and translated numbers into thresholds\n- Validated pass and fail exit codes for automation\n- Streamed results to Grafana Cloud for historical comparison"
+    },
+    {
+      "type": "markdown",
+      "content": "**Where to go next**\n\n- Explore [Synthetic Monitoring](https://grafana.com/docs/grafana-cloud/testing/synthetic-monitoring/) for continuous production checks\n- Continue reliability practice with the [Create an availability SLO](https://grafana.com/docs/learning-paths/create-availability-slo/) path\n- Revisit [Run your first k6 performance test](https://grafana.com/docs/learning-paths/run-first-k6-test/) if teammates still need foundational setup"
+    }
+  ]
+}

--- a/establish-k6-baseline-lj/end-journey/manifest.json
+++ b/establish-k6-baseline-lj/end-journey/manifest.json
@@ -1,0 +1,26 @@
+{
+  "id": "establish-k6-baseline-end-journey",
+  "type": "guide",
+  "description": "Wrap-up: recap baseline skills and suggested follow-on Grafana learning paths.",
+  "category": "take-action",
+  "author": {
+    "name": "bonnywelsford-source",
+    "team": "Grafana Documentation"
+  },
+  "startingLocation": "/a/k6-app",
+  "targeting": {
+    "match": {
+      "and": [
+        { "targetPlatform": "cloud" },
+        { "urlPrefix": "/a/k6-app" }
+      ]
+    }
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": ["establish-k6-baseline-save-share-results"],
+  "recommends": [],
+  "suggests": ["detect-outages-synthetic-monitoring-lj", "create-availability-slo-lj"],
+  "provides": []
+}

--- a/establish-k6-baseline-lj/identify-baseline-values/content.json
+++ b/establish-k6-baseline-lj/identify-baseline-values/content.json
@@ -1,0 +1,49 @@
+{
+  "id": "establish-k6-baseline-identify-baseline-values",
+  "title": "Identify your baseline values",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "In this milestone, you translate the raw summary into benchmark numbers you will encode as thresholds next."
+    },
+    {
+      "type": "section",
+      "id": "record-benchmarks",
+      "title": "Record benchmark numbers",
+      "blocks": [
+        {
+          "type": "markdown",
+          "content": "You'll capture p95 latency, error rate, and throughput, then decide how much headroom to allow before a threshold fails."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Find **`http_req_duration`** and note **`p(95)`** as your latency baseline. Example:\n\n```text\nhttp_req_duration..: avg=180ms  min=95ms\n                     med=165ms  max=850ms\n                     p(90)=280ms  p(95)=350ms\n```\n\nHere the p95 latency baseline is **350 ms**.\n\np95 is a practical starting point: it reflects most users while muting rare spikes. You can tighten to p90 or add p99 later once the process feels stable."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Find **`http_req_failed`** and note the percentage as your error-rate baseline:\n\n```text\nhttp_req_failed................: 0.00%   0 out of 1200\n```\n\nZero is ideal; thresholds usually keep a small tolerance (for example below 1%) for transient failures."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Find **`iterations`** and note the per-second rate as throughput at your chosen load:\n\n```text\niterations.....................: 1200    10.00/s\n```\n\nHere throughput is about **10 iterations per second** at 20 virtual users."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Write the numbers down in a simple table before editing thresholds:\n\n| Metric | Baseline value | Example threshold |\n| --- | --- | --- |\n| p95 latency | your observed p95 | add headroom (see below) |\n| Error rate | your observed rate | `rate<0.01` (allow under 1%) |\n| Throughput | your observed RPS | monitor, optional to threshold |\n\nHeadroom means setting the latency threshold higher than the observed p95 so normal variance does not fail the test. A common approach is to multiply observed p95 by **1.2 to 1.5** (20% to 50% above). Example: p95 53 ms times 1.3 rounds to **`p(95)<70`**. Use smaller multipliers for very stable services and larger multipliers when variance is high."
+        },
+        {
+          "type": "markdown",
+          "content": "You now have explicit baseline figures and a headroom rule you can copy into `thresholds`."
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "In the next milestone, you encode those values as k6 thresholds."
+    }
+  ]
+}

--- a/establish-k6-baseline-lj/identify-baseline-values/manifest.json
+++ b/establish-k6-baseline-lj/identify-baseline-values/manifest.json
@@ -1,0 +1,26 @@
+{
+  "id": "establish-k6-baseline-identify-baseline-values",
+  "type": "guide",
+  "description": "Hands-on guide: Record p95 latency, error rate, and throughput from the summary and plan threshold headroom.",
+  "category": "take-action",
+  "author": {
+    "name": "bonnywelsford-source",
+    "team": "Grafana Documentation"
+  },
+  "startingLocation": "/testing-and-synthetics",
+  "targeting": {
+    "match": {
+      "and": [
+        { "targetPlatform": "cloud" },
+        { "urlPrefix": "/testing-and-synthetics" }
+      ]
+    }
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": ["establish-k6-baseline-run-and-read-results"],
+  "recommends": ["establish-k6-baseline-add-thresholds"],
+  "suggests": [],
+  "provides": []
+}

--- a/establish-k6-baseline-lj/manifest.json
+++ b/establish-k6-baseline-lj/manifest.json
@@ -1,0 +1,37 @@
+{
+  "id": "establish-k6-baseline-lj",
+  "type": "path",
+  "description": "Step-by-step guide: Design a k6 load profile, add checks and thresholds, interpret results, validate pass or fail behavior, and stream baselines to Grafana Cloud k6.",
+  "category": "take-action",
+  "author": {
+    "name": "bonnywelsford-source",
+    "team": "Grafana Documentation"
+  },
+  "startingLocation": "/a/k6-app",
+  "targeting": {
+    "match": {
+      "and": [
+        { "urlPrefix": "/a/k6-app" },
+        { "targetPlatform": "cloud" }
+      ]
+    }
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "milestones": [
+    "establish-k6-baseline-understand-baselines",
+    "establish-k6-baseline-design-load-profile",
+    "establish-k6-baseline-add-checks",
+    "establish-k6-baseline-run-and-read-results",
+    "establish-k6-baseline-identify-baseline-values",
+    "establish-k6-baseline-add-thresholds",
+    "establish-k6-baseline-validate-thresholds",
+    "establish-k6-baseline-save-share-results",
+    "establish-k6-baseline-end-journey"
+  ],
+  "depends": [],
+  "recommends": ["run-first-k6-test-lj"],
+  "suggests": ["detect-outages-synthetic-monitoring-lj", "create-availability-slo-lj"],
+  "provides": []
+}

--- a/establish-k6-baseline-lj/run-and-read-results/content.json
+++ b/establish-k6-baseline-lj/run-and-read-results/content.json
@@ -1,0 +1,59 @@
+{
+  "id": "establish-k6-baseline-run-and-read-results",
+  "title": "Run the load test and read results",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "In this milestone, you execute `baseline.js` and focus on the summary lines that matter for a baseline: duration, failures, checks, and throughput."
+    },
+    {
+      "type": "section",
+      "id": "run-and-interpret",
+      "title": "Run and interpret the summary",
+      "blocks": [
+        {
+          "type": "markdown",
+          "content": "You'll confirm the test completes cleanly before you treat any numbers as a benchmark."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Open your terminal and run:\n\n```bash\nk6 run baseline.js\n```\n\nk6 prints live progress while the scenario executes."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "When the test completes, review **`http_req_duration`**. The summary lists aggregations similar to:\n\n```text\nhttp_req_duration..: avg=180ms  min=95ms\n                     med=165ms  max=850ms\n                     p(90)=280ms  p(95)=350ms\n```\n\n- `avg` is easy to skew with outliers.\n- `p(90)` and `p(95)` describe most users' experience.\n- If `max` dwarfs `p(95)`, a small slice of requests is much slower."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Review **`http_req_failed`** for error rate:\n\n```text\nhttp_req_failed................: 0.00%   0 out of 1200\n```\n\nFor a healthy baseline this should stay at or near zero."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Review **`checks`** under **TOTAL RESULTS** on newer k6 versions:\n\n```text\nchecks_total.......: 2400    10.00/s\nchecks_succeeded...: 100.00% 2400 out of 2400\nchecks_failed......: 0.00%   0 out of 2400\n\n✓ status is 200\n✓ response body is not empty\n```\n\n100% `checks_succeeded` means every response satisfied your predicates."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Review **`iterations`** for throughput:\n\n```text\niterations.....................: 1200    10.00/s\n```\n\nThe per-second figure approximates completed iterations per second during the run."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Confirm the run looks stable: checks succeed, errors are negligible, and latency percentiles are not wildly noisy. Investigate anomalies before recording a baseline.\n\nPercentiles are more reliable than averages for baselines. An average of 200 ms could hide a few 2 s responses; p95 surfaces that risk."
+        },
+        {
+          "type": "markdown",
+          "content": "You can now read the summary well enough to pick baseline numbers in the next milestone."
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "In the next milestone, you extract concrete baseline values from these metrics."
+    }
+  ]
+}

--- a/establish-k6-baseline-lj/run-and-read-results/manifest.json
+++ b/establish-k6-baseline-lj/run-and-read-results/manifest.json
@@ -1,0 +1,26 @@
+{
+  "id": "establish-k6-baseline-run-and-read-results",
+  "type": "guide",
+  "description": "Hands-on guide: Run baseline.js locally and interpret http_req_duration, failures, checks, and iterations in the summary.",
+  "category": "take-action",
+  "author": {
+    "name": "bonnywelsford-source",
+    "team": "Grafana Documentation"
+  },
+  "startingLocation": "/testing-and-synthetics",
+  "targeting": {
+    "match": {
+      "and": [
+        { "targetPlatform": "cloud" },
+        { "urlPrefix": "/testing-and-synthetics" }
+      ]
+    }
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": ["establish-k6-baseline-add-checks"],
+  "recommends": ["establish-k6-baseline-identify-baseline-values"],
+  "suggests": [],
+  "provides": []
+}

--- a/establish-k6-baseline-lj/save-share-results/content.json
+++ b/establish-k6-baseline-lj/save-share-results/content.json
@@ -1,0 +1,90 @@
+{
+  "id": "establish-k6-baseline-save-share-results",
+  "title": "Save and share results in k6 Cloud",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "In this milestone, you authenticate the k6 CLI against Grafana Cloud, stream a local run to k6 Cloud, and review the saved run in the browser."
+    },
+    {
+      "type": "section",
+      "id": "cli-cloud-stream",
+      "title": "Stream results from your machine",
+      "blocks": [
+        {
+          "type": "markdown",
+          "content": "You'll log in with a personal token and stack slug, then execute locally while uploading metrics."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "In Grafana Cloud, open **Testing & synthetics** > **Performance** > **Settings** and copy your API token and stack slug.\n\nRun login locally (replace placeholders yourself; do not share tokens):\n\n```bash\nk6 cloud login --token <YOUR_API_TOKEN> --stack <YOUR_STACK_SLUG>\n```\n\nRefer to [Tokens and CLI authentication](https://grafana.com/docs/grafana-cloud/testing/k6/author-run/tokens-and-cli-authentication/) if you need more detail."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Execute the baseline while streaming metrics:\n\n```bash\nk6 cloud run --local-execution baseline.js\n```\n\n`--local-execution` keeps the load on your machine while persisting results to Grafana Cloud. This differs from a fully cloud-hosted run that uploads the script to Grafana infrastructure."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Copy the run URL printed near the end of the output, for example:\n\n```text\noutput: cloud (https://acmecorp.grafana.net/a/k6-app/runs/123456)\n```"
+        },
+        {
+          "type": "markdown",
+          "content": "The CLI portion is complete once you have a cloud run URL."
+        }
+      ]
+    },
+    {
+      "type": "section",
+      "id": "review-in-ui",
+      "title": "Review the run in Grafana Cloud",
+      "blocks": [
+        {
+          "type": "markdown",
+          "content": "You'll open the saved run and confirm overview, thresholds, and checks match what you saw locally."
+        },
+        {
+          "type": "multistep",
+          "content": "In the main menu, navigate to **Testing & synthetics > Performance**.",
+          "requirements": ["navmenu-open"],
+          "skippable": true,
+          "steps": [
+            { "action": "highlight", "reftarget": "a[data-testid='data-testid Nav menu item'][href='/testing-and-synthetics']" },
+            { "action": "highlight", "reftarget": "a[data-testid='data-testid Nav menu item'][href='/a/k6-app']" }
+          ]
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Paste the run URL into your browser (or locate the same run in the project list) and sign in to Grafana Cloud if prompted."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Review **Performance Overview** for response time trends, request rates, and other headline metrics from the streamed run."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "a[data-testid='data-testid Tab THRESHOLDS']",
+          "content": "Select the **Thresholds** tab and confirm each threshold shows the expected pass or fail state."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Open the **Checks** tab to inspect per-check pass rates. Share the URL with teammates so everyone references the same baseline artifact."
+        },
+        {
+          "type": "markdown",
+          "content": "You can now compare future runs against this stored baseline directly inside Grafana Cloud k6."
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "You have finished the hands-on milestones. Continue to the wrap-up for suggested next paths."
+    }
+  ]
+}

--- a/establish-k6-baseline-lj/save-share-results/manifest.json
+++ b/establish-k6-baseline-lj/save-share-results/manifest.json
@@ -1,0 +1,26 @@
+{
+  "id": "establish-k6-baseline-save-share-results",
+  "type": "guide",
+  "description": "Hands-on guide: Authenticate k6 with Grafana Cloud, run with local execution, and review thresholds and checks in the cloud UI.",
+  "category": "take-action",
+  "author": {
+    "name": "bonnywelsford-source",
+    "team": "Grafana Documentation"
+  },
+  "startingLocation": "/a/k6-app/runs",
+  "targeting": {
+    "match": {
+      "and": [
+        { "targetPlatform": "cloud" },
+        { "urlPrefix": "/a/k6-app/runs" }
+      ]
+    }
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": ["establish-k6-baseline-validate-thresholds"],
+  "recommends": ["establish-k6-baseline-end-journey"],
+  "suggests": [],
+  "provides": []
+}

--- a/establish-k6-baseline-lj/understand-baselines/content.json
+++ b/establish-k6-baseline-lj/understand-baselines/content.json
@@ -1,0 +1,34 @@
+{
+  "id": "establish-k6-baseline-understand-baselines",
+  "title": "The value of performance baselines",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "In this milestone, you learn what a performance baseline is and which metrics matter before you design load or write thresholds."
+    },
+    {
+      "type": "section",
+      "id": "baseline-concepts",
+      "title": "Baseline metrics",
+      "blocks": [
+        {
+          "type": "markdown",
+          "content": "You'll connect latency percentiles, throughput, and error rate as the core signals you will later capture under a controlled load profile."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Without a performance baseline, every test result is just a number with no context. A baseline establishes known-good behavior you can compare future runs against.\n\n**Response time (latency):** Averages hide outliers, so baselines lean on percentiles. **p95** means 95% of requests completed within that time; **p99** captures the slowest 1%. If p95 is 200 ms but p99 is 2 s, a small share of users see much worse latency.\n\n**Throughput (requests per second):** How many completed requests your system handles per second. If throughput stops increasing while virtual users rise, you are likely hitting a capacity limit.\n\n**Error rate:** The percentage of requests that return an error. Healthy baselines are usually near zero; any sustained increase signals a regression."
+        },
+        {
+          "type": "markdown",
+          "content": "You now know which three metrics form a baseline story: latency for speed, throughput for capacity, and error rate for reliability."
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "In the next milestone, you design a ramping virtual user load profile so your baseline reflects realistic traffic."
+    }
+  ]
+}

--- a/establish-k6-baseline-lj/understand-baselines/manifest.json
+++ b/establish-k6-baseline-lj/understand-baselines/manifest.json
@@ -1,0 +1,26 @@
+{
+  "id": "establish-k6-baseline-understand-baselines",
+  "type": "guide",
+  "description": "Concepts: why baselines matter and how latency percentiles, throughput, and error rate fit together.",
+  "category": "take-action",
+  "author": {
+    "name": "bonnywelsford-source",
+    "team": "Grafana Documentation"
+  },
+  "startingLocation": "/testing-and-synthetics",
+  "targeting": {
+    "match": {
+      "and": [
+        { "targetPlatform": "cloud" },
+        { "urlPrefix": "/testing-and-synthetics" }
+      ]
+    }
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": [],
+  "recommends": ["establish-k6-baseline-design-load-profile"],
+  "suggests": [],
+  "provides": []
+}

--- a/establish-k6-baseline-lj/validate-thresholds/content.json
+++ b/establish-k6-baseline-lj/validate-thresholds/content.json
@@ -1,0 +1,79 @@
+{
+  "id": "establish-k6-baseline-validate-thresholds",
+  "title": "Validate thresholds work",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "In this milestone, you prove thresholds behave correctly: they pass when metrics are healthy and fail with a non-zero exit code when intentionally violated."
+    },
+    {
+      "type": "section",
+      "id": "verify-passing",
+      "title": "Verify passing thresholds",
+      "blocks": [
+        {
+          "type": "markdown",
+          "content": "You'll confirm the happy path exits with code 0 before you deliberately break latency."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Run the test:\n\n```bash\nk6 run baseline.js\n```"
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "At the top of the summary, open the **THRESHOLDS** section and confirm each expression shows a pass marker:\n\n```text\nTHRESHOLDS\n  checks\n    ✓ 'rate>0.99' rate=100.00%\n\n  http_req_duration\n    ✓ 'p(95)<500' p(95)=54.42ms\n\n  http_req_failed\n    ✓ 'rate<0.01' rate=0.00%\n```\n\nA ✓ beside each row means the threshold succeeded. The `rate>0.99` check on **checks** enforces overall check pass rate, not p99 latency."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Print the shell exit status (bash example):\n\n```bash\necho $?\n```\n\nYou should see `0`, meaning k6 considered the run successful."
+        },
+        {
+          "type": "markdown",
+          "content": "Passing thresholds now line up with a zero exit code on your machine."
+        }
+      ]
+    },
+    {
+      "type": "section",
+      "id": "verify-failing",
+      "title": "Verify failing thresholds",
+      "blocks": [
+        {
+          "type": "markdown",
+          "content": "You'll tighten latency unrealistically so k6 must fail, then restore your real threshold."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Temporarily edit `baseline.js` so `http_req_duration` cannot pass, for example:\n\n```javascript\nthresholds: {\n  http_req_duration: ['p(95)<1'],\n  http_req_failed: ['rate<0.01'],\n  checks: ['rate>0.99'],\n},\n```\n\nNo real HTTP call finishes under 1 ms, so this should fail."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Run again:\n\n```bash\nk6 run baseline.js\n```\n\nThe **THRESHOLDS** section should show a failure on latency:\n\n```text\nTHRESHOLDS\n  checks\n    ✓ 'rate>0.99' rate=100.00%\n\n  http_req_duration\n    ✗ 'p(95)<1' p(95)=54.42ms\n\n  http_req_failed\n    ✓ 'rate<0.01' rate=0.00%\n```"
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Check the exit code:\n\n```bash\necho $?\n```\n\nExpect **`99`**, k6's threshold failure exit code, which CI systems treat as a failed build."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Restore your real latency threshold before continuing, for example:\n\n```javascript\nhttp_req_duration: ['p(95)<500'],\n```"
+        },
+        {
+          "type": "markdown",
+          "content": "You proved thresholds flip between pass and fail exactly when metrics cross your boundaries."
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "In the next milestone, you stream the same script to Grafana Cloud k6 for storage and sharing."
+    }
+  ]
+}

--- a/establish-k6-baseline-lj/validate-thresholds/manifest.json
+++ b/establish-k6-baseline-lj/validate-thresholds/manifest.json
@@ -1,0 +1,26 @@
+{
+  "id": "establish-k6-baseline-validate-thresholds",
+  "type": "guide",
+  "description": "Hands-on guide: Confirm thresholds pass with healthy settings, then force a failure and verify exit code 99.",
+  "category": "take-action",
+  "author": {
+    "name": "bonnywelsford-source",
+    "team": "Grafana Documentation"
+  },
+  "startingLocation": "/testing-and-synthetics",
+  "targeting": {
+    "match": {
+      "and": [
+        { "targetPlatform": "cloud" },
+        { "urlPrefix": "/testing-and-synthetics" }
+      ]
+    }
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": ["establish-k6-baseline-add-thresholds"],
+  "recommends": ["establish-k6-baseline-save-share-results"],
+  "suggests": [],
+  "provides": []
+}

--- a/index.json
+++ b/index.json
@@ -480,6 +480,114 @@
             }
         },
         {
+            "title": "The value of performance baselines",
+            "type": "interactive",
+            "description": "Concepts: why baselines matter and how latency percentiles, throughput, and error rate fit together.",
+            "url": "https://interactive-learning.grafana.net/guides/establish-k6-baseline-lj/understand-baselines/content.json",
+            "match": {
+                "and": [
+                    { "targetPlatform": "cloud" },
+                    { "urlPrefix": "/testing-and-synthetics" }
+                ]
+            }
+        },
+        {
+            "title": "Design your load profile",
+            "type": "interactive",
+            "description": "Hands-on guide: Create baseline.js with ramping stages and a default function that issues an HTTP request.",
+            "url": "https://interactive-learning.grafana.net/guides/establish-k6-baseline-lj/design-load-profile/content.json",
+            "match": {
+                "and": [
+                    { "targetPlatform": "cloud" },
+                    { "urlPrefix": "/testing-and-synthetics" }
+                ]
+            }
+        },
+        {
+            "title": "Add checks to your script",
+            "type": "interactive",
+            "description": "Hands-on guide: Import check from k6 and assert status and body on each response.",
+            "url": "https://interactive-learning.grafana.net/guides/establish-k6-baseline-lj/add-checks/content.json",
+            "match": {
+                "and": [
+                    { "targetPlatform": "cloud" },
+                    { "urlPrefix": "/testing-and-synthetics" }
+                ]
+            }
+        },
+        {
+            "title": "Run the load test and read results",
+            "type": "interactive",
+            "description": "Hands-on guide: Run baseline.js locally and interpret http_req_duration, failures, checks, and iterations in the summary.",
+            "url": "https://interactive-learning.grafana.net/guides/establish-k6-baseline-lj/run-and-read-results/content.json",
+            "match": {
+                "and": [
+                    { "targetPlatform": "cloud" },
+                    { "urlPrefix": "/testing-and-synthetics" }
+                ]
+            }
+        },
+        {
+            "title": "Identify your baseline values",
+            "type": "interactive",
+            "description": "Hands-on guide: Record p95 latency, error rate, and throughput from the summary and plan threshold headroom.",
+            "url": "https://interactive-learning.grafana.net/guides/establish-k6-baseline-lj/identify-baseline-values/content.json",
+            "match": {
+                "and": [
+                    { "targetPlatform": "cloud" },
+                    { "urlPrefix": "/testing-and-synthetics" }
+                ]
+            }
+        },
+        {
+            "title": "Add thresholds to your script",
+            "type": "interactive",
+            "description": "Hands-on guide: Add thresholds on http_req_duration, http_req_failed, and checks to enforce pass or fail behavior.",
+            "url": "https://interactive-learning.grafana.net/guides/establish-k6-baseline-lj/add-thresholds/content.json",
+            "match": {
+                "and": [
+                    { "targetPlatform": "cloud" },
+                    { "urlPrefix": "/testing-and-synthetics" }
+                ]
+            }
+        },
+        {
+            "title": "Validate thresholds work",
+            "type": "interactive",
+            "description": "Hands-on guide: Confirm thresholds pass with healthy settings, then force a failure and verify exit code 99.",
+            "url": "https://interactive-learning.grafana.net/guides/establish-k6-baseline-lj/validate-thresholds/content.json",
+            "match": {
+                "and": [
+                    { "targetPlatform": "cloud" },
+                    { "urlPrefix": "/testing-and-synthetics" }
+                ]
+            }
+        },
+        {
+            "title": "Save and share results in k6 Cloud",
+            "type": "interactive",
+            "description": "Hands-on guide: Authenticate k6 with Grafana Cloud, run with local execution, and review thresholds and checks in the cloud UI.",
+            "url": "https://interactive-learning.grafana.net/guides/establish-k6-baseline-lj/save-share-results/content.json",
+            "match": {
+                "and": [
+                    { "targetPlatform": "cloud" },
+                    { "urlPrefix": "/a/k6-app/runs" }
+                ]
+            }
+        },
+        {
+            "title": "Destination reached!",
+            "type": "interactive",
+            "description": "Wrap-up: recap baseline skills and suggested follow-on Grafana learning paths.",
+            "url": "https://interactive-learning.grafana.net/guides/establish-k6-baseline-lj/end-journey/content.json",
+            "match": {
+                "and": [
+                    { "targetPlatform": "cloud" },
+                    { "urlPrefix": "/a/k6-app" }
+                ]
+            }
+        },
+        {
             "title": "Tour the UK Carbon Intensity Dashboard",
             "url": "https://interactive-learning.grafana.net/guides/play-carbon-intensity/content.json",
             "description": "Explore live UK carbon intensity data with the Infinity data source and JQ expressions. Learn how this dashboard visualizes the electricity generation mix and carbon intensity across regions.",


### PR DESCRIPTION
Adds the `establish-k6-baseline-lj` Pathfinder package (nine milestones plus path manifest) and `index.json` entries so guides can be loaded from interactive-learning. This pairs with the docs learning path merged in https://github.com/grafana/website/pull/29519.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds new JSON guide/path content and registers it in `index.json`, with no runtime logic changes beyond loading additional guide definitions.
> 
> **Overview**
> Adds a new `establish-k6-baseline-lj` interactive learning path (path manifest plus milestone `content.json`/`manifest.json` files) covering baseline concepts, authoring a k6 script, adding checks/thresholds, validating exit codes, and streaming results to Grafana Cloud.
> 
> Updates `index.json` to register the new milestone guides so they can be surfaced in interactive-learning based on `targetPlatform`/`urlPrefix` matching.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a95ee9a49ef07f8aff3fc73cd4628fc3b26627f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->