### PR TITLE
Add guide for SHGA

### DIFF
--- a/assistant-self-hosted/content.json
+++ b/assistant-self-hosted/content.json
@@ -56,34 +56,38 @@
             ]
         },
         {
-            "type": "markdown",
-            "content": "# Connect to Grafana Cloud\n\n"
-        },
-        {
-            "type": "markdown",
-            "content": "Next, you need to connect to Grafana Cloud. You can do this either via a quick connect button or through manual configuration. Quick connect is the simplest and recommended option."
-        },
-        {
             "type": "section",
             "id": "connect-to-grafana-cloud",
-            "title": "Connect",
+            "title": "Connect to Grafana Cloud",
             "requirements": [
                 "section-completed:open-grafana-assistant-plugin"
             ],
             "blocks": [
                 {
                     "type": "markdown",
-                    "content": "Clicking the \"**Connect to Grafana Cloud\"** button will connect your on-premise Grafana Assistant instance to Grafana Assistant in your Grafana Cloud stack.  \n\nChoose the **Organization** and **Stack**. Then click \"**Authorize connection\"**."
+                    "content": "Connect your self-hosted Grafana Assistant to Grafana Cloud; **Quick connect** is the simplest and recommended path."
+                },
+                {
+                    "type": "interactive",
+                    "action": "navigate",
+                    "reftarget": "/plugins/grafana-assistant-app?page=connection",
+                    "content": "Ensure you are on the Grafana Assistant **Connection** settings tab. If you do not see it, refresh the page, or click on the following button.",
+                    "hint": "If this URL does not open the right tab in your build, use **Record** to capture navigation that works, or click the **Connection** tab manually.",
+                    "verify": "on-page:/plugins/grafana-assistant-app"
+                },
+                {
+                    "type": "markdown",
+                    "content": "Clicking **Connect to Grafana Cloud** links your self-hosted Grafana Assistant to Grafana Assistant in your Grafana Cloud stack. Choose the **Organization** and **Stack**, then click **Authorize connection**."
                 },
                 {
                     "type": "interactive",
                     "action": "button",
                     "reftarget": "Connect to Grafana Cloud",
-                    "content": "Click the \"**Connect to Grafana Cloud**\" button.",
+                    "content": "Click **Connect to Grafana Cloud**.",
                     "requirements": [
                         "on-page:/plugins/grafana-assistant-app"
                     ],
-                    "hint": "Open **Grafana Assistant** first using **Open the plugin** above (you should be on **/plugins/grafana-assistant-app**)."
+                    "hint": "Complete the **Connection** navigation step above if this button is not visible."
                 },
                 {
                     "type": "markdown",
@@ -110,6 +114,10 @@
             "id": "launch-grafana-assistant",
             "title": "Open Grafana Assistant",
             "blocks": [
+                {
+                    "type": "markdown",
+                    "content": "You did it! Now it's time to try Grafana Assistant. After you go to Grafana Assistant, there will be some recommendations. Additionally, an example you can test out is asking \"What are my datasources?\"."
+                },
                 {
                     "type": "interactive",
                     "action": "highlight",

--- a/assistant-self-hosted/content.json
+++ b/assistant-self-hosted/content.json
@@ -1,0 +1,125 @@
+{
+    "id": "assistant-self-hosted",
+    "title": "Getting Started with Grafana Assistant for self-hosted Grafana",
+    "blocks": [
+        {
+            "type": "markdown",
+            "content": "Grafana Assistant is an AI-powered observability agent for Grafana that helps you monitor, troubleshoot, and manage your systems through natural language conversations. Instead of learning complex query languages or memorizing dashboard locations, you can ask simple questions like \"Show me CPU usage\" or \"Create a dashboard for my database.\""
+        },
+        {
+            "type": "markdown",
+            "content": "In this guide, you will configure and set up Grafana Assistant for your self-hosted Grafana instance.  \n\nFirst, go to the Grafana Assistant plugin, ensure it is installed, and configure it."
+        },
+        {
+            "type": "section",
+            "id": "open-grafana-assistant-plugin",
+            "title": "Go to Grafana Assistant plugin",
+            "autoCollapse": true,
+            "blocks": [
+                {
+                    "type": "markdown",
+                    "content": "You will open the plugin catalog and launch Grafana Assistant."
+                },
+                {
+                    "type": "interactive",
+                    "action": "navigate",
+                    "reftarget": "/plugins",
+                    "content": "Go to **Plugins**.",
+                    "verify": "on-page:/plugins"
+                },
+                {
+                    "type": "interactive",
+                    "action": "formfill",
+                    "reftarget": "div[data-testid='input-wrapper'] input[placeholder='Search Grafana plugins']",
+                    "targetvalue": "assistant",
+                    "content": "Search for **Grafana Assistant**.",
+                    "requirements": [
+                        "on-page:/plugins"
+                    ]
+                },
+                {
+                    "type": "interactive",
+                    "action": "highlight",
+                    "reftarget": "div[data-testid='plugin-list'] a[href='/plugins/grafana-assistant-app']",
+                    "content": "Open **Grafana Assistant**.",
+                    "requirements": [
+                        "on-page:/plugins"
+                    ]
+                },
+                {
+                    "type": "interactive",
+                    "action": "button",
+                    "reftarget": "Install",
+                    "content": "Click the \"Install\" button (Skip if already installed)",
+                    "skippable": true
+                }
+            ]
+        },
+        {
+            "type": "markdown",
+            "content": "# Connect to Grafana Cloud\n\n"
+        },
+        {
+            "type": "markdown",
+            "content": "Next, you need to connect to Grafana Cloud. You can do this either via a quick connect button or through manual configuration. Quick connect is the simplest and recommended option."
+        },
+        {
+            "type": "section",
+            "id": "connect-to-grafana-cloud",
+            "title": "Connect",
+            "requirements": [
+                "section-completed:open-grafana-assistant-plugin"
+            ],
+            "blocks": [
+                {
+                    "type": "markdown",
+                    "content": "Clicking the \"**Connect to Grafana Cloud\"** button will connect your on-premise Grafana Assistant instance to Grafana Assistant in your Grafana Cloud stack.  \n\nChoose the **Organization** and **Stack**. Then click \"**Authorize connection\"**."
+                },
+                {
+                    "type": "interactive",
+                    "action": "button",
+                    "reftarget": "Connect to Grafana Cloud",
+                    "content": "Click the \"**Connect to Grafana Cloud**\" button.",
+                    "requirements": [
+                        "on-page:/plugins/grafana-assistant-app"
+                    ],
+                    "hint": "Open **Grafana Assistant** first using **Open the plugin** above (you should be on **/plugins/grafana-assistant-app**)."
+                },
+                {
+                    "type": "markdown",
+                    "content": "Next, confirm that **Connection Settings** shows a green **Connected** state. The guide only checks that this page shows the success banner; it does not call Grafana Cloud for you."
+                },
+                {
+                    "type": "interactive",
+                    "action": "highlight",
+                    "reftarget": "div[class*='connectionBanner']",
+                    "content": "Find the green **Connected** banner and your Grafana Assistant backend URL to confirm setup worked.",
+                    "requirements": [
+                        "on-page:/plugins/grafana-assistant-app"
+                    ],
+                    "objectives": [
+                        "exists-reftarget"
+                    ],
+                    "hint": "If there is no green **Connected** banner, the connection is not OK yet: finish **Quick connect** or **Save & connect** on manual config, fix any red error under **Connection Settings**, reload the page, or check network and credentials. This step completes only when that banner appears.",
+                    "doIt": false
+                }
+            ]
+        },
+        {
+            "type": "section",
+            "id": "launch-grafana-assistant",
+            "title": "Open Grafana Assistant",
+            "blocks": [
+                {
+                    "type": "interactive",
+                    "action": "highlight",
+                    "reftarget": "div[data-testid='data-testid Nav toolbar'] button[data-testid='extension-toolbar-button-open']",
+                    "content": "Click on the Grafana Assistant button to open it.",
+                    "requirements": [
+                        "exists-reftarget"
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/assistant-self-hosted/content.json
+++ b/assistant-self-hosted/content.json
@@ -113,6 +113,9 @@
             "type": "section",
             "id": "launch-grafana-assistant",
             "title": "Open Grafana Assistant",
+            "requirements": [
+                "section-completed:connect-to-grafana-cloud"
+            ],
             "blocks": [
                 {
                     "type": "markdown",

--- a/assistant-self-hosted/manifest.json
+++ b/assistant-self-hosted/manifest.json
@@ -1,0 +1,33 @@
+{
+  "id": "assistant-self-hosted",
+  "type": "guide",
+  "description": "Hands-on guide: Configure and connect Grafana Assistant on self-hosted Grafana.",
+  "category": "general",
+  "author": {
+    "name": "Tiffany Jernigan (tiffanyfay)",
+    "team": "interactive-learning"
+  },
+  "startingLocation": "/",
+  "targeting": {
+    "match": {
+      "or": [
+        {
+          "urlRegex": "^/?$"
+        },
+        {
+          "urlPrefix": "/connections"
+        },
+        {
+          "urlPrefix": "/plugins/grafana-pathfinder-app"
+        }
+      ]
+    }
+  },
+  "testEnvironment": {
+    "tier": "local"
+  },
+  "depends": [],
+  "recommends": [],
+  "suggests": [],
+  "provides": []
+}

--- a/assistant-self-hosted/manifest.json
+++ b/assistant-self-hosted/manifest.json
@@ -14,7 +14,6 @@
         {
           "or": [
             { "urlRegex": "^/?$" },
-            { "urlPrefix": "/dashboards" },
             { "urlPrefix": "/connections" },
             { "urlPrefix": "/plugins/grafana-assistant-app" }
           ]

--- a/assistant-self-hosted/manifest.json
+++ b/assistant-self-hosted/manifest.json
@@ -10,16 +10,15 @@
   "startingLocation": "/",
   "targeting": {
     "match": {
-      "or": [
+      "and": [
         {
-          "urlRegex": "^/?$"
+          "or": [
+            { "urlRegex": "^/?$" },
+            { "urlPrefix": "/dashboards" },
+            { "urlPrefix": "/connections" }
+          ]
         },
-        {
-          "urlPrefix": "/connections"
-        },
-        {
-          "urlPrefix": "/plugins/grafana-pathfinder-app"
-        }
+        { "targetPlatform": "oss" }
       ]
     }
   },

--- a/assistant-self-hosted/manifest.json
+++ b/assistant-self-hosted/manifest.json
@@ -15,7 +15,8 @@
           "or": [
             { "urlRegex": "^/?$" },
             { "urlPrefix": "/dashboards" },
-            { "urlPrefix": "/connections" }
+            { "urlPrefix": "/connections" },
+            { "urlPrefix": "/plugins/grafana-assistant-app" }
           ]
         },
         { "targetPlatform": "oss" }


### PR DESCRIPTION
This guide is to show users how to set up self-hosted Grafana Assistant

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds new interactive-learning guide content and metadata only; no runtime code paths or security-sensitive logic are modified.
> 
> **Overview**
> Introduces a new interactive guide, `assistant-self-hosted`, that walks OSS/self-hosted users through installing the Grafana Assistant plugin, connecting it to Grafana Cloud, and launching the assistant.
> 
> Adds the guide manifest with OSS-only targeting and a step-by-step `content.json` including navigation, form-fill, button, and verification/highlight steps (including a skippable install step and a connected-banner check).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 413a292e355e00d2bbf50bb30890b0907373fac4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->