### PR TITLE
Add interactive highlights for navigation sections

### DIFF
--- a/git-sync-guide/content.json
+++ b/git-sync-guide/content.json
@@ -18,6 +18,26 @@
         {
           "type": "interactive",
           "action": "highlight",
+          "reftarget": "div[data-testid='data-testid navigation mega-menu'] button[aria-label='Expand section: Administration']",
+          "content": "Open **Administration** from the main menu.",
+          "requirements": [
+            "navmenu-open",
+            "exists-reftarget"
+          ]
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "div[data-testid='data-testid navigation mega-menu'] button[aria-label='Expand section: General']",
+          "content": "Open **General** from the Administration menu.",
+          "requirements": [
+            "navmenu-open",
+            "exists-reftarget"
+          ]
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
           "reftarget": "a[data-testid='data-testid Nav menu item'][href='/admin/provisioning']",
           "content": "Open **Provisioning** from the main menu.",
           "tooltip": "Provisioning manages external sources of Grafana resources like Git repositories.",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk content-only change to an interactive guide JSON; main risk is selector brittleness if navigation labels/testids change.
> 
> **Overview**
> Updates `git-sync-guide/content.json` to include two new *interactive highlight* steps that guide users through expanding **Administration** and **General** in the navigation before selecting **Provisioning**.
> 
> Also normalizes the JSON file ending (adds trailing newline).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6800bef008d8afd9d24bf5f804072627e1d2727. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->