### PR TITLE
fix(send-logs-alloy-loki-lj): update Collector Setup nav path for flat Connections menu

### DIFF
--- a/send-logs-alloy-loki-lj/install-alloy/content.json
+++ b/send-logs-alloy-loki-lj/install-alloy/content.json
@@ -33,7 +33,7 @@
             },
             {
               "action": "highlight",
-              "reftarget": "a[data-testid='data-testid Nav menu item'][href='/a/grafana-collector-app/collector-setup']"
+              "reftarget": "a[data-testid='data-testid Nav menu item'][href='/a/grafana-collector-app/alloy']"
             }
           ]
         },

--- a/send-logs-alloy-loki-lj/install-alloy/content.json
+++ b/send-logs-alloy-loki-lj/install-alloy/content.json
@@ -24,7 +24,7 @@
       "blocks": [
         {
           "type": "multistep",
-          "content": "Navigate to **Connections > Collector**.",
+          "content": "Navigate to **Connections > Collector Setup**.",
           "requirements": ["navmenu-open"],
           "steps": [
             {
@@ -33,7 +33,7 @@
             },
             {
               "action": "highlight",
-              "reftarget": "a[data-testid='data-testid Nav menu item'][href='/a/grafana-collector-app']"
+              "reftarget": "a[data-testid='data-testid Nav menu item'][href='/a/grafana-collector-app/collector-setup']"
             }
           ]
         },


### PR DESCRIPTION
Updates the navigation instruction in the install-alloy milestone to reflect the new flat Connections menu in Grafana Cloud, where Collector Setup sits directly under Connections rather than nested under a Collector group.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation/guide tweak only; the main potential issue is the updated `reftarget` selector or URL could be incorrect and break the guided highlight step.
> 
> **Overview**
> Updates the Install Alloy learning-journey step to match Grafana Cloud’s flattened Connections navigation by changing the instruction from **Connections > Collector** to **Connections > Collector Setup**.
> 
> Adjusts the corresponding nav highlight target from `/a/grafana-collector-app` to `/a/grafana-collector-app/alloy` so the guided walkthrough points at the new menu destination.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90f0cde01bd62d772243510a8416da3b17dff52c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->