### PR TITLE
Update nav guidance for the Categorize a Fleet learning path/interactive guide

### DIFF
--- a/categorize-collector-fleet-lj/navigate-to-fleet/content.json
+++ b/categorize-collector-fleet-lj/navigate-to-fleet/content.json
@@ -17,11 +17,10 @@
         },
         {
           "type": "multistep",
-          "content": "Navigate to **Connections** > **Collector** > **Fleet Management**.",
+          "content": "Navigate to **Connections** > **Fleet Management**.",
           "requirements": ["navmenu-open"],
           "steps": [
             { "action": "highlight", "reftarget": "a[data-testid='data-testid Nav menu item'][href='/connections']" },
-            { "action": "highlight", "reftarget": "a[data-testid='data-testid Nav menu item'][href='/a/grafana-collector-app']" },
             { "action": "highlight", "reftarget": "a[data-testid='data-testid Nav menu item'][href='/a/grafana-collector-app/fleet-management']" }
           ]
         },


### PR DESCRIPTION
This PR updates both the textual guidance and the interactivity to reflect the new flattened nav in Grafana Cloud.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only changes interactive-guide copy and a highlighted navigation step, with no runtime logic or data handling changes.
> 
> **Overview**
> Updates the `Navigate to Fleet Management` milestone to reflect the new flattened Grafana Cloud nav by changing the instruction from **Connections > Collector > Fleet Management** to **Connections > Fleet Management** and removing the intermediate menu highlight step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da40b6e0bf951007fe292c11383f1a2f5d6d0b65. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->