### PR TITLE
Remove local path references

### DIFF
--- a/.cursor/skills/migrate-guide/SKILL.md
+++ b/.cursor/skills/migrate-guide/SKILL.md
@@ -72,7 +72,7 @@ If no rule matches, the guide has no targeting — omit the `targeting` field.
 
 ### Website learning path markdown (read-only, optional)
 
-Location: `/Users/davidallen/hax/website/content/docs/learning-paths/`
+Location: `<path_to_local_clone>/website/content/docs/learning-paths/`
 
 If the hardcoded path does not exist (e.g., on another machine or in CI), the agent may shallow-clone the `grafana/website` repo into a temporary directory and use that path instead; the structure under `content/docs/learning-paths/` is the same as in a local checkout.
 
@@ -82,7 +82,7 @@ If the website repo is unavailable, apply fallback rules from `docs/manifest-ref
 
 ### journeys.yaml (read-only, optional)
 
-Location: `/Users/davidallen/hax/website/content/docs/learning-paths/journeys.yaml`
+Location: `<path_to_local_clone>/website/content/docs/learning-paths/journeys.yaml`
 
 Provides inter-journey category and relationship data.
 
@@ -280,7 +280,7 @@ Invoked on a `*-lj` directory (e.g., `prometheus-lj/`).
 
 #### 1. Locate website markdown
 
-Map the directory name to the website path by stripping `-lj` (e.g., `prometheus-lj` → `prometheus`). Check for `/Users/davidallen/hax/website/content/docs/learning-paths/<path-name>/`.
+Map the directory name to the website path by stripping `-lj` (e.g., `prometheus-lj` → `prometheus`). Check for `<path_to_local_clone>/website/content/docs/learning-paths/<path-name>/`.
 
 If not found, apply fallback rules and flag for manual review.
 

--- a/adaptive-logs-recommendations/assets/migration-notes.md
+++ b/adaptive-logs-recommendations/assets/migration-notes.md
@@ -45,7 +45,7 @@ All INFOs are expected schema defaults. Validation passed with no errors or warn
 
 - The `Cursor Agent` commit author was filtered from `author.name` as it is automation.
 - The `author.name` field contains two GitHub handles: `brendamuir` and `Jayclifford345`, identified from `git log --follow` on `content.json`.
-- The validator CLI was not present at `dist/cli/cli/index.js` in the interactive-tutorials repo root. It was found and run successfully from `/Users/davidallen/hax/grafana-pathfinder-app/dist/cli/cli/index.js`.
+- The validator CLI was not present at `dist/cli/cli/index.js` in the interactive-tutorials repo root. It was found and run successfully from `<path_to_local_clone>/grafana-pathfinder-app/dist/cli/cli/index.js`.
 
 ## TODO
 

--- a/connect-prometheus-metrics/assets/migration-notes.md
+++ b/connect-prometheus-metrics/assets/migration-notes.md
@@ -39,10 +39,10 @@ No `index.json` rule exists for `connect-prometheus-metrics`. This is not a migr
 
 ## Validator Result
 
-CLI unavailable — blocker. The `dist/cli/cli/index.js` file does not exist in the `grafana-pathfinder-app` checkout at `/Users/davidallen/hax/grafana-pathfinder-app`. The CLI source is present at `src/cli/` but has not been built. Run `npm run build` (or equivalent) in the pathfinder-app repo to build the CLI, then re-run:
+CLI unavailable — blocker. The `dist/cli/cli/index.js` file does not exist in the `grafana-pathfinder-app` checkout at `<path_to_local_clone>/grafana-pathfinder-app`. The CLI source is present at `src/cli/` but has not been built. Run `npm run build` (or equivalent) in the pathfinder-app repo to build the CLI, then re-run:
 
 ```bash
-node /Users/davidallen/hax/grafana-pathfinder-app/dist/cli/cli/index.js validate --package /Users/davidallen/hax/interactive-tutorials/connect-prometheus-metrics
+node <path_to_local_clone>/grafana-pathfinder-app/dist/cli/cli/index.js validate --package <path_to_local_clone>/interactive-tutorials/connect-prometheus-metrics
 ```
 
 ## Surprises / Notes

--- a/detect-outages-synthetic-monitoring-lj/assets/migration-notes.md
+++ b/detect-outages-synthetic-monitoring-lj/assets/migration-notes.md
@@ -25,7 +25,7 @@ step_count: 7
 - Also checked `featured.json` — no matching learning-journey rules.
 
 ### Website markdown
-- **Path:** `/Users/davidallen/hax/website/content/docs/learning-paths/detect-outages-synthetic-monitoring/`
+- **Path:** `<path_to_local_clone>/website/content/docs/learning-paths/detect-outages-synthetic-monitoring/`
 - **_index.md:** Read successfully. Extracted `journey.group: data-availability`, title, description.
 - **Step index.md files:** All 7 steps read. Extracted weight, description, pathfinder_data, side_journeys.
 - No `journey.links.to` in _index.md frontmatter (no recommends at path level).

--- a/docs/manifest-reference.md
+++ b/docs/manifest-reference.md
@@ -317,7 +317,7 @@ Copy the `match` object from the `index.json` rule directly into `targeting.matc
 
 Within paths, step directory names are identical in both repos. The website markdown `pathfinder_data` frontmatter provides the authoritative mapping (e.g., `pathfinder_data: prometheus-lj/add-data-source`).
 
-Website learning path markdown location: `<website-repo>/content/docs/learning-paths/` (default local checkout: `/Users/davidallen/hax/website/content/docs/learning-paths/`)
+Website learning path markdown location: `<website-repo>/content/docs/learning-paths/` (default local checkout: `<path_to_local_clone>/website/content/docs/learning-paths/`)
 
 ---
 

--- a/enable-block-editor/assets/migration-notes.md
+++ b/enable-block-editor/assets/migration-notes.md
@@ -30,10 +30,10 @@ migrated_at: "2026-03-09T00:00:00Z"
 
 ## Validator Result
 
-**CLI unavailable (blocker).** The Pathfinder CLI at `dist/cli/cli/index.js` was not found in either the `interactive-tutorials` repo or the `grafana-pathfinder-app` checkout at `/Users/davidallen/hax/grafana-pathfinder-app/dist/cli/`. The `dist/` directory exists but does not contain the CLI bundle — it appears the CLI has not been built. To complete Phase 1 validation, run `npm run build` (or equivalent) in the `grafana-pathfinder-app` checkout and then re-run:
+**CLI unavailable (blocker).** The Pathfinder CLI at `dist/cli/cli/index.js` was not found in either the `interactive-tutorials` repo or the `grafana-pathfinder-app` checkout at `<path_to_local_clone>/grafana-pathfinder-app/dist/cli/`. The `dist/` directory exists but does not contain the CLI bundle — it appears the CLI has not been built. To complete Phase 1 validation, run `npm run build` (or equivalent) in the `grafana-pathfinder-app` checkout and then re-run:
 
 ```bash
-node /Users/davidallen/hax/grafana-pathfinder-app/dist/cli/cli/index.js validate --package /Users/davidallen/hax/interactive-tutorials/enable-block-editor
+node <path_to_local_clone>/grafana-pathfinder-app/dist/cli/cli/index.js validate --package <path_to_local_clone>/interactive-tutorials/enable-block-editor
 ```
 
 ## Surprises / Notes

--- a/github-data-source-lj/assets/migration-notes.md
+++ b/github-data-source-lj/assets/migration-notes.md
@@ -36,7 +36,7 @@ No files outside `github-data-source-lj/` were touched.
 - Used for `id` and `title` fields in each step manifest.
 
 ### Website markdown
-- Path: `/Users/davidallen/hax/website/content/docs/learning-paths/github-data-source/`
+- Path: `<path_to_local_clone>/website/content/docs/learning-paths/github-data-source/`
 - `_index.md`: title, description, journey.group (data-availability), journey.links.to (github-visualize)
 - All 6 step `index.md` files: weight, step number, pathfinder_data, description, side_journeys
 - All steps had `pathfinder_data` frontmatter — no directory name fallback needed.

--- a/influxdb-data-source-lj/assets/migration-notes.md
+++ b/influxdb-data-source-lj/assets/migration-notes.md
@@ -41,7 +41,7 @@ migrated_at: "2026-04-07T00:00:00Z"
 
 ## Flags for Manual Review
 
-- **No website markdown found**: `/Users/davidallen/hax/website/content/docs/learning-paths/influxdb-data-source/` does not exist. All fields that would normally derive from `_index.md` used fallback values.
+- **No website markdown found**: `<path_to_local_clone>/website/content/docs/learning-paths/influxdb-data-source/` does not exist. All fields that would normally derive from `_index.md` used fallback values.
 - **No recommender rules found**: No `learning-journey` type rules matching `influxdb-data-source` in the recommender. Targeting omitted.
 - **No index.json rule found**: No matching entry in index.json for this learning path.
 - **No journeys.yaml entry found**: `influxdb-data-source` is not listed in journeys.yaml. No journey links or related journeys available.

--- a/irm-configuration/assets/migration-notes.md
+++ b/irm-configuration/assets/migration-notes.md
@@ -40,5 +40,5 @@ All INFO messages are expected — omitting `repository`, `language`, `schemaVer
 
 ## Surprises / Notes
 
-- The CLI path referenced in the skill (`dist/cli/cli/index.js` relative to the repo root) does not exist in this repo. The validator was found and run from `/Users/davidallen/hax/grafana-pathfinder-app/dist/cli/cli/index.js`.
+- The CLI path referenced in the skill (`dist/cli/cli/index.js` relative to the repo root) does not exist in this repo. The validator was found and run from `<path_to_local_clone>/grafana-pathfinder-app/dist/cli/cli/index.js`.
 - `testEnvironment.tier` is `local` because the match expression contains only `urlPrefixIn` predicates — no `source` rule and no `targetPlatform: "cloud"`. This means the guide is expected to work on any locally-running Grafana instance with the IRM app installed, not just Grafana Cloud. Flag for manual review if Cloud-only targeting is intended.

--- a/k8s-cpu/assets/migration-notes.md
+++ b/k8s-cpu/assets/migration-notes.md
@@ -32,13 +32,13 @@ migrated_at: "2026-03-09T00:00:00Z"
 ## Validator Result
 
 **BLOCKER: CLI unavailable.** The Pathfinder CLI was not found at either:
-- `/Users/davidallen/hax/interactive-tutorials/dist/cli/cli/index.js`
-- `/Users/davidallen/hax/grafana-pathfinder-app/dist/cli/cli/index.js`
+- `<path_to_local_clone>/interactive-tutorials/dist/cli/cli/index.js`
+- `<path_to_local_clone>/grafana-pathfinder-app/dist/cli/cli/index.js`
 
-The `grafana-pathfinder-app` repo is checked out at `/Users/davidallen/hax/grafana-pathfinder-app/` but the CLI has not been built (no `dist/cli/` directory). To validate, run `yarn build` or the equivalent CLI build step in that repo, then re-run:
+The `grafana-pathfinder-app` repo is checked out at `<path_to_local_clone>/grafana-pathfinder-app/` but the CLI has not been built (no `dist/cli/` directory). To validate, run `yarn build` or the equivalent CLI build step in that repo, then re-run:
 
 ```bash
-node /Users/davidallen/hax/grafana-pathfinder-app/dist/cli/cli/index.js validate --package /Users/davidallen/hax/interactive-tutorials/k8s-cpu
+node <path_to_local_clone>/grafana-pathfinder-app/dist/cli/cli/index.js validate --package <path_to_local_clone>/interactive-tutorials/k8s-cpu
 ```
 
 ## Flags for Manual Review

--- a/rca-demo-ops/assets/migration-notes.md
+++ b/rca-demo-ops/assets/migration-notes.md
@@ -36,7 +36,7 @@ No `index.json` rule exists for `rca-demo-ops`. This is not a migration error â€
 
 ## Validator Result
 
-Command: `node /Users/davidallen/hax/grafana-pathfinder-app/dist/cli/cli/index.js validate --package /Users/davidallen/hax/interactive-tutorials/rca-demo-ops`
+Command: `node <path_to_local_clone>/grafana-pathfinder-app/dist/cli/cli/index.js validate --package <path_to_local_clone>/interactive-tutorials/rca-demo-ops`
 
 Result: PASS (exit 0)
 

--- a/rca-demo/assets/migration-notes.md
+++ b/rca-demo/assets/migration-notes.md
@@ -36,7 +36,7 @@ No `index.json` rule exists for `rca-demo`. This is not a migration error — ta
 
 ## Validator Result
 
-Command: `node /Users/davidallen/hax/grafana-pathfinder-app/dist/cli/cli/index.js validate --package /Users/davidallen/hax/interactive-tutorials/rca-demo`
+Command: `node <path_to_local_clone>/grafana-pathfinder-app/dist/cli/cli/index.js validate --package <path_to_local_clone>/interactive-tutorials/rca-demo`
 
 Result: **PASS** (exit 0)
 
@@ -46,7 +46,7 @@ Warnings (all expected):
 
 ## Surprises / Notes
 
-- The `dist/cli/cli/index.js` was not present in the `interactive-tutorials` repo root (the path `interactive-tutorials/dist/cli/cli/index.js` does not exist). The validator was found at `/Users/davidallen/hax/grafana-pathfinder-app/dist/cli/cli/index.js`.
+- The `dist/cli/cli/index.js` was not present in the `interactive-tutorials` repo root (the path `interactive-tutorials/dist/cli/cli/index.js` does not exist). The validator was found at `<path_to_local_clone>/grafana-pathfinder-app/dist/cli/cli/index.js`.
 - `rca-demo` is a demo-only guide (navigates to custom RCA demo dashboards and the `grafana-asserts-app`). It appears to be an internally-authored demo rather than a public-facing tutorial, which may explain the absence of an `index.json` rule.
 
 ## TODO

--- a/sm-setting-up-your-first-check/assets/migration-notes.md
+++ b/sm-setting-up-your-first-check/assets/migration-notes.md
@@ -39,4 +39,4 @@ INFO messages (expected, non-blocking):
 
 - `Cursor Agent <cursoragent@cursor.com>` appeared in git history and was excluded as an automation author.
 - The `testEnvironment` tier is `cloud` (not `local`) because the match expression contains `targetPlatform: "cloud"`, even though no `source` predicate is present. No `instance` field is set (correct — `instance` is only set when a `source` value is available).
-- The CLI was not found at `dist/cli/cli/index.js` within the `interactive-tutorials` repo; it was found at `/Users/davidallen/hax/grafana-pathfinder-app/dist/cli/cli/index.js`.
+- The CLI was not found at `dist/cli/cli/index.js` within the `interactive-tutorials` repo; it was found at `<path_to_local_clone>/grafana-pathfinder-app/dist/cli/cli/index.js`.

--- a/transform-data/assets/migration-notes.md
+++ b/transform-data/assets/migration-notes.md
@@ -51,7 +51,7 @@ Validation: PASS. All INFOs are expected (schema defaults for omitted optional f
 
 - The directory name (`transform-data`) does not match the `content.json` id (`find-transformations`) or the index.json URL path segment (`find-transformations`). This is a naming inconsistency in the repo but does not block migration — the manifest `id` correctly uses `find-transformations` from content.json.
 - Git authors for `content.json`: Tom Glenn, Isabel Matwawana. `author.name` was not included in manifest per convention (team field is sufficient for standalone guides; name is optional).
-- CLI was not found at `dist/cli/cli/index.js` relative to the repo root. Validation was run from the grafana-pathfinder-app checkout at `/Users/davidallen/hax/grafana-pathfinder-app/dist/cli/cli/index.js`.
+- CLI was not found at `dist/cli/cli/index.js` relative to the repo root. Validation was run from the grafana-pathfinder-app checkout at `<path_to_local_clone>/grafana-pathfinder-app/dist/cli/cli/index.js`.
 
 ## TODO
 

--- a/welcome-to-play/assets/migration-notes.md
+++ b/welcome-to-play/assets/migration-notes.md
@@ -70,7 +70,7 @@ No recommender rules found for `welcome-to-play`. This is expected -- the guide 
 ## Data Quality Issues
 
 - All three index.json rules share identical `description` text -- recommend differentiating them upstream
-- No website markdown exists for this guide at `/Users/davidallen/hax/website/content/docs/learning-paths/welcome-to-play/`
+- No website markdown exists for this guide at `<path_to_local_clone>/website/content/docs/learning-paths/welcome-to-play/`
 - No `journeys.yaml` entry exists for this guide
 - Step ordering was inferred from content (homepage first, then sub-pages) -- no weight data available
 - Each step has its own `pathfinder_data`-less mapping; directory names were used for matching


### PR DESCRIPTION
## Summary
- Removed leaked local path references from migration notes and docs
- Replaced with generic `<path_to_local_clone>` across 15 files (23 occurrences)

🤖 Generated with [Claude Code](https://claude.com/claude-code)