### PR TITLE
Add deploy PR preview

### DIFF
--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -1,0 +1,30 @@
+name: Deploy PR preview
+
+permissions: {}
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - closed
+    paths:
+      - "**/content.json"
+
+jobs:
+  deploy-pr-preview:
+    uses: grafana/writers-toolkit/.github/workflows/deploy-preview.yml@jdb/deploy-preview
+    if: "!github.event.pull_request.head.repo.fork"
+    permissions:
+      contents: read
+      id-token: write
+      pull-requests: write
+      statuses: write
+    with:
+      branch: ${{ github.head_ref }}
+      build_script: build-interactive-tutorials
+      event_number: ${{ github.event.number }}
+      image: grafana/docs-base:latest
+      repo: interactive-tutorials
+      sha: ${{ github.event.pull_request.head.sha }}
+      title: ${{ github.event.pull_request.title }}

--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -5,6 +5,7 @@ permissions: {}
 on:
   pull_request:
     types:
+      - labeled
       - opened
       - synchronize
       - closed
@@ -14,7 +15,10 @@ on:
 jobs:
   deploy-pr-preview:
     uses: grafana/writers-toolkit/.github/workflows/deploy-preview.yml@jdb/deploy-preview
-    if: "!github.event.pull_request.head.repo.fork"
+    if: >-
+      !github.event.pull_request.head.repo.fork &&
+      (contains(github.event.pull_request.labels.*.name, 'deploy-preview') ||
+      github.event.action == 'closed')
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
This preview will use a different pre-build script to render a version of the website for the learning paths in this repository.

The intent is to build writer confidence in the presentation in both the interactive learning app and the website.
The app has tooling to test this and with this PR, now writers can also see and iterate on the website presentation.

Using appropriate package metadata and the modified build script, this workflow posts a link to a deploy preview which writers can use to browser /docs/learning-paths/

Relates to https://github.com/grafana/website/issues/30386

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>
