### PR TITLE
Fixes broken interactions in the tour for The Traitors dashboard on Play.

### DIFF
--- a/play-traitors-uk-tour/content.json
+++ b/play-traitors-uk-tour/content.json
@@ -158,7 +158,7 @@
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "div[data-testid=\"query-editor-row\"] > :first-child",
+          "reftarget": "div[data-testid='data-testid Query editor row']:nth-match(1)",
           "content": "Now, take a look at the Google Sheets query configuration.  There's no range of cells specified here, so the query will read every cell in the spreadsheet.",
           "doIt": false,
           "lazyRender": true
@@ -195,7 +195,7 @@
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "div[data-testid='query-editor-row'] div:nth-match(58)",
+          "reftarget": "div[data-testid='data-testid Query editor row'] div:nth-match(58)",
           "content": "Study the SQL expression that we're using here to summarize the data.",
           "requirements": [
             "exists-reftarget"
@@ -204,17 +204,11 @@
           "lazyRender": true
         },
         {
-          "type": "guided",
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "button[data-testid='data-testid Hide response'] svg:nth-match(1)",
           "content": "Hide the results of the original Google Sheets query.",
-          "steps": [
-            {
-              "action": "highlight",
-              "reftarget": "button[data-testid='data-testid Hide response'] svg:nth-match(1)",
-              "description": "Click to hide the data returned by the query.",
-              "lazyRender": true
-            }
-          ],
-          "completeEarly": true
+          "lazyRender": true
         },
         {
           "type": "interactive",
@@ -228,17 +222,11 @@
           "lazyRender": true
         },
         {
-          "type": "guided",
-          "content": "To continue our tour, click the \"Back to dashboard\" button to exit the panel editor.",
-          "steps": [
-            {
-              "action": "highlight",
-              "reftarget": "button[data-testid='data-testid Back to dashboard button']",
-              "description": "Click the button to return to the dashboard view.",
-              "lazyRender": true
-            }
-          ],
-          "completeEarly": true
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "button[data-testid='data-testid Back to dashboard button']",
+          "content": "To continue our tour, click the **Back to dashboard** button to exit the panel editor.",
+          "lazyRender": true
         }
       ]
     },
@@ -278,7 +266,7 @@
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "div[data-testid='query-editor-row'] div:nth-match(58)",
+          "reftarget": "div[data-testid='data-testid Query editor row'] div:nth-match(58)",
           "content": "Now study the SQL expression that returns this data.",
           "requirements": [
             "exists-reftarget"
@@ -291,17 +279,11 @@
           "content": "Note that the SQL expression is significantly more complex than the previous example.  This is because we want to perform the following steps before showing the data on the bar chart:\n\n1. Count the number of votes received by each player.\n2. Sort the data so that players appear in descending order of votes received.\n3. Determine if a player is still active in the game so that their bar can be displayed in a different colour.\n\nThe good news here is that you don't have to be a SQL expert to create and manage expressions of this complexity.  This expression was written by Grafana Assistant!\n\n"
         },
         {
-          "type": "guided",
-          "content": "Click the \"Back to dashboard\" button to continue the tour.",
-          "steps": [
-            {
-              "action": "highlight",
-              "reftarget": "button[data-testid='data-testid Back to dashboard button']",
-              "description": "Click the button to return to the dashboard view.",
-              "lazyRender": true
-            }
-          ],
-          "completeEarly": true
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "button[data-testid='data-testid Back to dashboard button']",
+          "content": "Click the **Back to dashboard** button to continue the tour.",
+          "lazyRender": true
         }
       ]
     },
@@ -336,7 +318,7 @@
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "div[data-testid='query-editor-row'] div:nth-match(58)",
+          "reftarget": "div[data-testid='data-testid Query editor row'] div:nth-match(58)",
           "content": "Study the SQL expression used to determine Adam's status in the game.  Note the use of ${player} which is the dashboard variable.  The value of the variable (in this case \"Adam\") will be substituted into the SQL expression when it is evaluated.",
           "requirements": [
             "exists-reftarget"


### PR DESCRIPTION
I noticed that a couple of things were broken on the [Traitors Dashboard](https://play.grafana.org/d/siqtdwm/the-traitors-uk-series-4) tour while demo'ing it at GrafanaCon.  This PR fixes those and also removed single step guided sections, replacing them with regular interactions.

I've tested this on Play.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk content-only changes: updates tour JSON selectors and step types; main risk is UI selector drift causing highlights/click prompts to miss targets.
> 
> **Overview**
> Fixes broken interactions in `play-traitors-uk-tour/content.json` by updating several `reftarget` CSS selectors (notably the query editor row targets) to match current `data-testid` values.
> 
> Simplifies multiple single-step `guided` blocks (e.g., hiding query results and returning *Back to dashboard*) into equivalent `interactive` highlight steps, adjusting copy/formatting accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49f6866a9ec12af11b44d048d98ba01b43021beb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->