### PR TITLE
Play 5K run dashboard tour: Fixed a selector that had broken, removed single step interactives.

### DIFF
--- a/play-5k-run-results/content.json
+++ b/play-5k-run-results/content.json
@@ -76,55 +76,37 @@
           "completeEarly": true
         },
         {
-          "type": "guided",
-          "content": "Switch to the Queries tab.",
-          "steps": [
-            {
-              "action": "highlight",
-              "reftarget": "button[data-testid='data-testid Tab Queries']",
-              "description": "Click the Queries tab.",
-              "lazyRender": true
-            }
-          ],
-          "completeEarly": true
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "button[data-testid='data-testid Tab Queries']",
+          "content": "Switch to the **Queries** tab.",
+          "lazyRender": true
         },
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "div[data-testid=\"query-editor-row\"] > :first-child",
+          "reftarget": "div[data-testid='infinity-query-row-wrapper-query-options']",
           "content": "The data source is Infinity with type CSV and source Inline — the entire dataset lives inside the dashboard as a plain text string. Each row is just two numbers: a finishing position and a Unix timestamp. There are no column headers, no runner names, nothing else.",
           "doIt": false,
           "lazyRender": true
         },
         {
-          "type": "guided",
-          "content": "Switch to the Transformations tab to see how the raw timestamps become useful race data.",
-          "steps": [
-            {
-              "action": "highlight",
-              "reftarget": "button[data-testid='data-testid Tab Transformations']",
-              "description": "Click the Transformations tab.",
-              "lazyRender": true
-            }
-          ],
-          "completeEarly": true
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "button[data-testid='data-testid Tab Transformations']",
+          "content": "Switch to the **Transformations** tab to see how the raw timestamps become useful race data.",
+          "lazyRender": true
         },
         {
           "type": "markdown",
           "content": "Six transformations run in sequence. The two most important are:\n\n**Calculate field — run_time**: subtracts the race start time (a fixed Unix timestamp representing 9:00am on race day) from each finisher's timestamp. This single step converts an absolute clock time into an elapsed race time in seconds. Every stat panel — winning time, mean, median, tail walker — is built on this derived field.\n\n**Calculate field — finish_bucket**: divides run_time by 300 (the number of seconds in 5 minutes) and then applies a floor function to round it down to a whole number. The result is a bucket index: 0 means the runner finished in the first 5 minutes, 1 in the second 5 minutes, and so on. This is the field that powers the Finishers by 5 Minute Period chart.\n\nThe remaining transforms handle type conversion, column reordering, and generating a sort key — useful plumbing, but the two calculate field steps above are where the real analysis happens."
         },
         {
-          "type": "guided",
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "button[data-testid='data-testid Back to dashboard button']",
           "content": "Return to the dashboard to look at how the bucket data is used.",
-          "steps": [
-            {
-              "action": "highlight",
-              "reftarget": "button[data-testid='data-testid Back to dashboard button']",
-              "description": "Click here to return to the dashboard.",
-              "lazyRender": true
-            }
-          ],
-          "completeEarly": true
+          "lazyRender": true
         },
         {
           "type": "markdown",
@@ -162,17 +144,11 @@
           "completeEarly": true
         },
         {
-          "type": "guided",
-          "content": "Switch to the Transformations tab.",
-          "steps": [
-            {
-              "action": "highlight",
-              "reftarget": "button[data-testid='data-testid Tab Transformations']",
-              "description": "Click the Transformations tab.",
-              "lazyRender": true
-            }
-          ],
-          "completeEarly": true
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "button[data-testid='data-testid Tab Transformations']",
+          "content": "Switch to the **Transformations** tab.",
+          "lazyRender": true
         },
         {
           "type": "markdown",


### PR DESCRIPTION
This fixes a selector that had become old/broken in the [Play 5K Run Dashboard](https://play.grafana.org/d/sixn5pn/analyzing-5k-run-results) tour.  I also took the opporunity to eliminate multi-steps that only had a single step.   I've retested this on Play.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk content-only updates to a guided tour JSON; main risk is tour UX breakage if the updated `data-testid` selectors don’t match the live Play dashboard.
> 
> **Overview**
> Fixes the Play 5K Run dashboard tour by updating a broken query editor `reftarget` selector and aligning the highlight target with the current Infinity query row wrapper.
> 
> Simplifies several single-step `guided` blocks into equivalent `interactive` highlight steps (Queries tab, Transformations tab, and Back to dashboard), reducing unnecessary nested `steps`/`completeEarly` structure while keeping the same user flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42297cfa14d05c45e61b16b0e6511e505f542a26. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->