### PR TITLE
Update targets for IRM escalation chain configuration

### DIFF
--- a/irm-configuration/content.json
+++ b/irm-configuration/content.json
@@ -117,12 +117,12 @@
         },
         {
           "action": "highlight",
-          "reftarget": "[data-pathfinder=\"escalation-step-option-notifyusersfromon-callschedule\"]",
+          "reftarget": "div:text(\"Notify users from on-call schedule\")",
           "tooltip": "Add a notification step to notify users from the on-call schedule."
         },
         {
           "action": "highlight",
-          "reftarget": "[data-pathfinder=\"notify-schedule-select\"]",
+          "reftarget": "div[data-testid=\"input-wrapper\"] input[placeholder=\"Select Schedule\"]",
           "tooltip": "Select the on-call schedule you previously created."
         },
         {
@@ -132,7 +132,7 @@
         },
         {
           "action": "highlight",
-          "reftarget": "[data-pathfinder=\"escalation-step-option-wait\"]",
+          "reftarget": "div:text(\"Wait\")",
           "tooltip": "Add a wait step, and configure a wait time of 5 minutes."
         },
         {
@@ -142,7 +142,7 @@
         },
         {
           "action": "highlight",
-          "reftarget": "[data-pathfinder=\"escalation-step-option-notifyusers\"]",
+          "reftarget": "div:text(\"Notify users\")",
           "tooltip": "Select the user(s) you want to escalate to."
         }
       ]


### PR DESCRIPTION
A refactor of IRM escalation chains removed pathfinder attributes. Updating the targeting to fix the guide now, and will then re-add the `data-pathfinder` attributes in a second PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk content-only change that updates UI targeting selectors in the IRM configuration guide; primary risk is the walkthrough failing if the new text/testid selectors don’t match the UI in all environments.
> 
> **Overview**
> Updates the IRM setup learning-journey (`irm-configuration/content.json`) to retarget the escalation-chain configuration steps after a UI refactor removed several `data-pathfinder` attributes.
> 
> The guide now highlights escalation step options and the schedule selector using text-based and `data-testid`/placeholder CSS selectors instead of the removed `data-pathfinder` hooks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d70c6e9c15b2e2e9b910ed88a0abb6e845ee5cd6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->