### PR TITLE
Play GB Railways dashboard tour: Fixed broken selector and removed single step multisteps.

### DIFF
--- a/play-gb-railway-usage/content.json
+++ b/play-gb-railway-usage/content.json
@@ -48,34 +48,22 @@
           "completeEarly": true
         },
         {
-          "type": "guided",
-          "content": "Switch to the Transformations tab.",
-          "steps": [
-            {
-              "action": "highlight",
-              "reftarget": "button[data-testid='data-testid Tab Transformations']",
-              "description": "Click the Transformations tab.",
-              "lazyRender": true
-            }
-          ],
-          "completeEarly": true
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "button[data-testid='data-testid Tab Transformations']",
+          "content": "Switch to the **Transformations** tab.",
+          "lazyRender": true
         },
         {
           "type": "markdown",
           "content": "There's a single transformation: **Filter by value**, which keeps only the row where entries_exits_rank equals 2 and discards all other stations. The stat panel then displays the main_origin_or_destination field from that one remaining row — that's a panel display setting, not a transform."
         },
         {
-          "type": "guided",
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "button[data-testid='data-testid Back to dashboard button']",
           "content": "Return to the dashboard to continue.",
-          "steps": [
-            {
-              "action": "highlight",
-              "reftarget": "button[data-testid='data-testid Back to dashboard button']",
-              "description": "Click here to return to the dashboard.",
-              "lazyRender": true
-            }
-          ],
-          "completeEarly": true
+          "lazyRender": true
         },
         {
           "type": "markdown",
@@ -153,55 +141,37 @@
           "completeEarly": true
         },
         {
-          "type": "guided",
-          "content": "Switch to the Queries tab.",
-          "steps": [
-            {
-              "action": "highlight",
-              "reftarget": "button[data-testid='data-testid Tab Queries']",
-              "description": "Click the Queries tab.",
-              "lazyRender": true
-            }
-          ],
-          "completeEarly": true
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "button[data-testid='data-testid Tab Queries']",
+          "content": "Switch to the **Queries** tab.",
+          "lazyRender": true
         },
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "div[data-testid=\"query-editor-row\"] > :first-child",
+          "reftarget": "div[data-testid='infinity-query-row-wrapper-query-options']",
           "content": "The Infinity query type is set to **CSV** with source **Inline**. The entire Office of Rail and Road dataset — over 2,400 station rows — is pasted directly into the panel as a CSV string. There's no external URL, no database, and no scheduled refresh: the data lives inside the dashboard JSON itself.",
           "doIt": false,
           "lazyRender": true
         },
         {
-          "type": "guided",
-          "content": "Switch to the Transform data tab to see how the raw CSV is prepared.",
-          "steps": [
-            {
-              "action": "highlight",
-              "reftarget": "button[data-testid='data-testid Tab Transformations']",
-              "description": "Click the Transformations tab.",
-              "lazyRender": true
-            }
-          ],
-          "completeEarly": true
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "button[data-testid='data-testid Tab Transformations']",
+          "content": "Switch to the **Transformations** tab to see how the raw CSV is prepared.",
+          "lazyRender": true
         },
         {
           "type": "markdown",
           "content": "Three transforms clean up the raw CSV before any other panel can use it:\n\n1. **Organize fields** — reorders and renames columns to match the field names expected by downstream panels.\n2. **Convert field type** — casts the rank and entries/exits columns from strings to numbers so they can be sorted and calculated.\n3. **Sort by** — orders all rows by rank ascending, so rank 1 always appears first in every filtered view."
         },
         {
-          "type": "guided",
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "button[data-testid='data-testid Back to dashboard button']",
           "content": "Return to the dashboard to continue.",
-          "steps": [
-            {
-              "action": "highlight",
-              "reftarget": "button[data-testid='data-testid Back to dashboard button']",
-              "description": "Click here to return to the dashboard.",
-              "lazyRender": true
-            }
-          ],
-          "completeEarly": true
+          "lazyRender": true
         },
         {
           "type": "markdown",
@@ -239,17 +209,11 @@
           "completeEarly": true
         },
         {
-          "type": "guided",
-          "content": "Switch to the Transformations tab.",
-          "steps": [
-            {
-              "action": "highlight",
-              "reftarget": "button[data-testid='data-testid Tab Transformations']",
-              "description": "Click the Transformations tab.",
-              "lazyRender": true
-            }
-          ],
-          "completeEarly": true
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "button[data-testid='data-testid Tab Transformations']",
+          "content": "Switch to the **Transformations** tab.",
+          "lazyRender": true
         },
         {
           "type": "markdown",


### PR DESCRIPTION
In common with my other dashboard tours, the [GB Railways Dashboard](https://play.grafana.org/d/sixtbqt/great-britain-railway-station-usage) tour had become broken.  This PR fixes the selector used to highlight parts of the Infinity query UI and also replaces single step multi-step components with a single do it / show me.  I've tested this on Play.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to tour content JSON (selectors and step structure) and don’t affect backend logic or data handling, but could still break the tour flow if UI test IDs drift again.
> 
> **Overview**
> Fixes the Great Britain Railway Station Usage dashboard tour by converting several single-step `guided` blocks into simpler `interactive` highlight steps (removing redundant `steps`/`completeEarly` wrappers).
> 
> Also updates the Infinity query highlight selector in the Raw Data panel tour to target `div[data-testid='infinity-query-row-wrapper-query-options']`, addressing a previously broken highlight in the Queries UI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a5aa739a05368d924e2d796c04ff6d412c629bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->