### PR TITLE
Play NZ Geonet tour: Fixed broken selector, replaced single step multisteps with show me / do it

### DIFF
--- a/play-nz-geonet-tour/content.json
+++ b/play-nz-geonet-tour/content.json
@@ -108,37 +108,27 @@
           "completeEarly": true
         },
         {
-          "type": "guided",
-          "content": "Switch to the Query tab.",
-          "steps": [
-            {
-              "action": "highlight",
-              "reftarget": "button[data-testid='data-testid Tab Queries']",
-              "description": "Click the Query tab.",
-              "lazyRender": true
-            }
-          ],
-          "completeEarly": true
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "button[data-testid='data-testid Tab Queries']",
+          "content": "Switch to the **Queries** tab.",
+          "lazyRender": true
         },
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "div[data-testid=\"query-editor-row\"] > :first-child",
+          "reftarget": "div[data-testid='infinity-query-row-wrapper-query-options']",
           "content": "The Infinity query calls the GeoNet Earthquake API, fetching all earthquakes with a Modified Mercalli Intensity of 1 or above — the threshold for perceptible shaking. The parser is set to **jq-backend**, so the raw GeoJSON response passes directly through a JQ expression.",
           "doIt": false,
           "lazyRender": true
         },
         {
-          "type": "guided",
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "button[data-testid='infinity-query-row-collapse-show-parsing-options-&-result-fields']",
           "content": "Open the parsing options to reveal the JQ expression.",
-          "steps": [
-            {
-              "action": "highlight",
-              "reftarget": "button[data-testid='infinity-query-row-collapse-show-parsing-options-&-result-fields'] svg",
-              "description": "Click here to expand the parsing options.",
-              "lazyRender": true
-            }
-          ]
+          "showMe": false,
+          "lazyRender": true
         },
         {
           "type": "interactive",
@@ -149,17 +139,11 @@
           "lazyRender": true
         },
         {
-          "type": "guided",
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "button[data-testid='data-testid Back to dashboard button']",
           "content": "Return to the dashboard to continue.",
-          "steps": [
-            {
-              "action": "highlight",
-              "reftarget": "button[data-testid='data-testid Back to dashboard button']",
-              "description": "Click here to return to the dashboard.",
-              "lazyRender": true
-            }
-          ],
-          "completeEarly": true
+          "lazyRender": true
         },
         {
           "type": "markdown",
@@ -197,34 +181,22 @@
           "completeEarly": true
         },
         {
-          "type": "guided",
-          "content": "Switch to the Transform data tab.",
-          "steps": [
-            {
-              "action": "highlight",
-              "reftarget": "button[data-testid='data-testid Tab Transformations']",
-              "description": "Click the Transformations tab.",
-              "lazyRender": true
-            }
-          ],
-          "completeEarly": true
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "button[data-testid='data-testid Tab Transformations']",
+          "content": "Switch to the **Transformations** tab.",
+          "lazyRender": true
         },
         {
           "type": "markdown",
           "content": "Five transformations run in sequence to produce the chart:\n\n1. **Calculate field** — applies a floor function to the magnitude, rounding each earthquake down to a whole number band (e.g., 2.7 becomes 2).\n2. **Group by** — counts how many earthquakes fall into each band.\n3. **Organize fields** — renames magnitude_scale to magnitude and magnitude_scale (count) to occurrences, dropping the raw columns.\n4. **Sort by** — orders the bands from lowest to highest magnitude.\n5. **Convert field type** — converts the magnitude number to a string so it renders as a categorical x-axis label rather than a numeric axis."
         },
         {
-          "type": "guided",
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "button[data-testid='data-testid Back to dashboard button']",
           "content": "Return to the dashboard to continue.",
-          "steps": [
-            {
-              "action": "highlight",
-              "reftarget": "button[data-testid='data-testid Back to dashboard button']",
-              "description": "Click here to return to the dashboard.",
-              "lazyRender": true
-            }
-          ],
-          "completeEarly": true
+          "lazyRender": true
         },
         {
           "type": "markdown",
@@ -262,17 +234,11 @@
           "completeEarly": true
         },
         {
-          "type": "guided",
-          "content": "Switch to the Query tab.",
-          "steps": [
-            {
-              "action": "highlight",
-              "reftarget": "button[data-testid='data-testid Tab Queries']",
-              "description": "Click the Query tab.",
-              "lazyRender": true
-            }
-          ],
-          "completeEarly": true
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "button[data-testid='data-testid Tab Queries']",
+          "content": "Switch to the **Queries** tab.",
+          "lazyRender": true
         },
         {
           "type": "interactive",


### PR DESCRIPTION
The [Play NZ Geonet dashboard](https://play.grafana.org/d/simgmgk/new-zealand-geonet) tour had broken following a recent Grafana update.  This PR fixes the broken selector and also replaces a few multistep blocks that only had one step each with equivalent show me / do it blocks.  I've tested this on Play.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk content-only changes to tour JSON; main risk is tour steps could still break if Grafana test IDs change again.
> 
> **Overview**
> Fixes the Play NZ GeoNet dashboard tour after a Grafana UI update by **updating a broken query-row selector** in the Recent Earthquakes edit flow.
> 
> Simplifies several tour interactions by converting single-step `guided` blocks into equivalent `interactive` highlight steps (including tab switches and back-to-dashboard navigation), and replaces the parsing-options expand step with an `interactive` step using `showMe`/`lazyRender` semantics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37df2f16ce919937b359e1883102b206854da066. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->