### PR TITLE
Add Pathfinder package for k6 Script Authoring (generate-from-prompt)

### DIFF
--- a/k6-script-authoring-assistant-lj/content.json
+++ b/k6-script-authoring-assistant-lj/content.json
@@ -1,0 +1,14 @@
+{
+  "id": "k6-script-authoring-assistant-lj",
+  "title": "Author k6 scripts with Grafana Assistant",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "This interactive path mirrors the [Author k6 scripts with Grafana Assistant](https://grafana.com/docs/learning-paths/k6-script-authoring-assistant/) learning path. Milestones are being added here as interactive guides; more steps will appear as they ship.\n\nYou use **k6 Script Authoring** in Grafana Assistant to turn prompts into review-ready k6 drafts, then continue in the Grafana Cloud k6 script editor or optional local runs."
+    },
+    {
+      "type": "markdown",
+      "content": "## Before you begin\n\n- A Grafana Cloud account with access to **Testing & synthetics** and Grafana Assistant.\n- For optional local smoke steps only, install k6. See [Install k6](https://grafana.com/docs/k6/latest/set-up/install-k6/).\n\nRefer to [Use k6 Script Authoring mode](https://grafana.com/docs/grafana-cloud/testing/k6/author-run/k6-script-authoring-mode/) for full product behavior."
+    }
+  ]
+}

--- a/k6-script-authoring-assistant-lj/generate-from-prompt/content.json
+++ b/k6-script-authoring-assistant-lj/generate-from-prompt/content.json
@@ -1,0 +1,119 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "k6-script-authoring-assistant-generate-from-prompt",
+  "title": "Generate a script from a plain-language prompt",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "This milestone is hands-on with **QuickPizza** at `https://quickpizza.grafana.com`. You do not need your own API or credentials to complete the steps.\n\nYou open Grafana Assistant, choose **k6 Script Authoring**, paste a starter prompt, then continue in the Cloud script editor when possible."
+    },
+    {
+      "type": "section",
+      "id": "open-performance-and-assistant",
+      "title": "Open Performance and Grafana Assistant",
+      "blocks": [
+        {
+          "type": "markdown",
+          "content": "You will open **Testing & synthetics**, go to **Performance**, then open Grafana Assistant from the toolbar."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "a[data-testid='data-testid Nav menu item'][href='/testing-and-synthetics']",
+          "content": "In the main menu, select **Testing & synthetics**.",
+          "requirements": ["navmenu-open"]
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "a[data-testid='data-testid Nav menu item'][href='/a/k6-app']",
+          "content": "Select **Performance** (Grafana Cloud k6).",
+          "requirements": ["navmenu-open"]
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "div[data-testid='data-testid Nav toolbar'] button[data-testid='extension-toolbar-button-open']",
+          "content": "Open **Assistant** from the top toolbar.",
+          "hint": "If you do not see the Assistant control, confirm Assistant is enabled for your stack or ask your administrator."
+        },
+        {
+          "type": "markdown",
+          "content": "You should now see the Assistant panel and be in the Grafana Cloud k6 Performance area."
+        }
+      ]
+    },
+    {
+      "type": "section",
+      "id": "script-authoring-and-prompt",
+      "title": "Choose k6 Script Authoring and paste the QuickPizza prompt",
+      "requirements": ["section-completed:open-performance-and-assistant"],
+      "blocks": [
+        {
+          "type": "markdown",
+          "content": "You will select **k6 Script Authoring** in the Assistant mode selector, then paste the example prompt in your own words if you prefer."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "In the Assistant panel, open the **mode selector** (bottom of the panel) and choose **k6 Script Authoring**.\n\nPaste a prompt that names QuickPizza, success criteria, pacing, and a short run length. For example:\n\n> Create a minimal k6 HTTP test for `https://quickpizza.grafana.com` that checks for a 200 response, uses `sleep(1)` between iterations, and runs for 10 iterations.\n\nTreat the reply as a **draft**. Wording can differ by stack and model.\n\nFor product details and optional OpenAPI context, refer to [Use k6 Script Authoring mode](https://grafana.com/docs/grafana-cloud/testing/k6/author-run/k6-script-authoring-mode/#write-a-new-test)."
+        },
+        {
+          "type": "markdown",
+          "content": "You should see Assistant return a k6 script draft you can copy or continue with in the script editor."
+        }
+      ]
+    },
+    {
+      "type": "section",
+      "id": "cloud-script-editor-and-verify",
+      "title": "Open the script editor and smoke-check (recommended)",
+      "requirements": ["section-completed:script-authoring-and-prompt"],
+      "blocks": [
+        {
+          "type": "markdown",
+          "content": "You will ask Assistant to open the Cloud script editor, pick a k6 project, then save or run a short test from the UI."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Ask Assistant to open the k6 script editor—for example: **Open the k6 script editor.** Assistant asks which k6 project should hold the test; pick the project you want.\n\nIn the editor, use **Create** to save or **Create and Run** for a short smoke run. Refer to [Open the k6 script editor](https://grafana.com/docs/grafana-cloud/testing/k6/author-run/k6-script-authoring-mode/#open-the-k6-script-editor) and [Use the script editor](https://grafana.com/docs/grafana-cloud/testing/k6/author-run/script-editor/).\n\nOptional: if you have an OpenAPI or Swagger spec, attach or paste it in the same thread before or after the prompt so the draft has fewer placeholder `// TODO:` comments."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Review the draft and confirm it includes a request to `https://quickpizza.grafana.com` (or paths under that host), at least one `check()` for status 200, `sleep(1)` or equivalent pacing, and sensible `options` for a short run."
+        },
+        {
+          "type": "markdown",
+          "content": "You should have validated the draft in Cloud or be ready to copy it for an optional local check."
+        }
+      ]
+    },
+    {
+      "type": "section",
+      "id": "optional-local-k6-run",
+      "title": "Optional: local k6 smoke run",
+      "requirements": ["section-completed:cloud-script-editor-and-verify"],
+      "blocks": [
+        {
+          "type": "markdown",
+          "content": "If you use a local file instead of only Cloud runs, you will smoke-test with the k6 CLI."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Copy the script into a file such as `quickpizza-assistant.js`, then run:\n\n```bash\nk6 run --iterations 1 quickpizza-assistant.js\n```\n\nSkip this section if you stay entirely in the script editor."
+        },
+        {
+          "type": "markdown",
+          "content": "You can skip local CLI work when Cloud-only validation is enough for your team."
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "In the next milestone on the learning path, you either discover endpoints from your stack's telemetry or stay on QuickPizza for conversion and improvement steps.\n\nContinue on [Discover real endpoints and generate a script](https://grafana.com/docs/learning-paths/k6-script-authoring-assistant/discover-generate/) when you are ready."
+    }
+  ]
+}

--- a/k6-script-authoring-assistant-lj/generate-from-prompt/content.json
+++ b/k6-script-authoring-assistant-lj/generate-from-prompt/content.json
@@ -113,6 +113,10 @@
     },
     {
       "type": "markdown",
+      "content": "**More to explore (optional):** at this point in the path you can read [Author and run tests in Grafana Cloud k6](https://grafana.com/docs/grafana-cloud/testing/k6/author-run/) for a broader view of authoring in Cloud.\n\n**Example prompt to copy** for QuickPizza in Assistant:\n\n```\nCreate a minimal k6 HTTP test for https://quickpizza.grafana.com that checks for a 200 response, uses sleep(1) between iterations, and runs for 10 iterations.\n```\n\nCompare Assistant output to what you expect from [Write your first k6 test script](https://grafana.com/docs/learning-paths/run-first-k6-test/write-test-script/) before you change load or add CI."
+    },
+    {
+      "type": "markdown",
       "content": "In the next milestone on the learning path, you either discover endpoints from your stack's telemetry or stay on QuickPizza for conversion and improvement steps.\n\nContinue on [Discover real endpoints and generate a script](https://grafana.com/docs/learning-paths/k6-script-authoring-assistant/discover-generate/) when you are ready."
     }
   ]

--- a/k6-script-authoring-assistant-lj/generate-from-prompt/content.json
+++ b/k6-script-authoring-assistant-lj/generate-from-prompt/content.json
@@ -35,7 +35,8 @@
           "action": "highlight",
           "reftarget": "div[data-testid='data-testid Nav toolbar'] button[data-testid='extension-toolbar-button-open']",
           "content": "Open **Assistant** from the top toolbar.",
-          "hint": "If you do not see the Assistant control, confirm Assistant is enabled for your stack or ask your administrator."
+          "hint": "If you do not see the Assistant control, confirm Assistant is enabled for your stack or ask your administrator.",
+          "requirements": ["on-page:/a/k6-app"]
         },
         {
           "type": "markdown",
@@ -54,8 +55,7 @@
           "content": "You will select **k6 Script Authoring** in the Assistant mode selector, then paste the example prompt in your own words if you prefer."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "In the Assistant panel, open the **mode selector** (bottom of the panel) and choose **k6 Script Authoring**.\n\nPaste a prompt that names QuickPizza, success criteria, pacing, and a short run length. For example:\n\n> Create a minimal k6 HTTP test for `https://quickpizza.grafana.com` that checks for a 200 response, uses `sleep(1)` between iterations, and runs for 10 iterations.\n\nTreat the reply as a **draft**. Wording can differ by stack and model.\n\nFor product details and optional OpenAPI context, refer to [Use k6 Script Authoring mode](https://grafana.com/docs/grafana-cloud/testing/k6/author-run/k6-script-authoring-mode/#write-a-new-test)."
         },
         {
@@ -75,13 +75,11 @@
           "content": "You will ask Assistant to open the Cloud script editor, pick a k6 project, then save or run a short test from the UI."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Ask Assistant to open the k6 script editor—for example: **Open the k6 script editor.** Assistant asks which k6 project should hold the test; pick the project you want.\n\nIn the editor, use **Create** to save or **Create and Run** for a short smoke run. Refer to [Open the k6 script editor](https://grafana.com/docs/grafana-cloud/testing/k6/author-run/k6-script-authoring-mode/#open-the-k6-script-editor) and [Use the script editor](https://grafana.com/docs/grafana-cloud/testing/k6/author-run/script-editor/).\n\nOptional: if you have an OpenAPI or Swagger spec, attach or paste it in the same thread before or after the prompt so the draft has fewer placeholder `// TODO:` comments."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Review the draft and confirm it includes a request to `https://quickpizza.grafana.com` (or paths under that host), at least one `check()` for status 200, `sleep(1)` or equivalent pacing, and sensible `options` for a short run."
         },
         {
@@ -101,8 +99,7 @@
           "content": "If you use a local file instead of only Cloud runs, you will smoke-test with the k6 CLI."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Copy the script into a file such as `quickpizza-assistant.js`, then run:\n\n```bash\nk6 run --iterations 1 quickpizza-assistant.js\n```\n\nSkip this section if you stay entirely in the script editor."
         },
         {

--- a/k6-script-authoring-assistant-lj/generate-from-prompt/manifest.json
+++ b/k6-script-authoring-assistant-lj/generate-from-prompt/manifest.json
@@ -8,14 +8,6 @@
     "team": "Grafana Documentation"
   },
   "startingLocation": "/a/k6-app",
-  "targeting": {
-    "match": {
-      "and": [
-        { "urlPrefix": "/a/k6-app" },
-        { "targetPlatform": "cloud" }
-      ]
-    }
-  },
   "testEnvironment": {
     "tier": "cloud"
   },

--- a/k6-script-authoring-assistant-lj/generate-from-prompt/manifest.json
+++ b/k6-script-authoring-assistant-lj/generate-from-prompt/manifest.json
@@ -1,0 +1,26 @@
+{
+  "id": "k6-script-authoring-assistant-generate-from-prompt",
+  "type": "guide",
+  "description": "Open Grafana Assistant in k6 Script Authoring mode and generate a first QuickPizza draft from a plain-language prompt.",
+  "category": "take-action",
+  "author": {
+    "name": "Grafana Documentation",
+    "team": "Grafana Documentation"
+  },
+  "startingLocation": "/a/k6-app",
+  "targeting": {
+    "match": {
+      "and": [
+        { "urlPrefix": "/a/k6-app" },
+        { "targetPlatform": "cloud" }
+      ]
+    }
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": [],
+  "recommends": [],
+  "suggests": [],
+  "provides": []
+}

--- a/k6-script-authoring-assistant-lj/manifest.json
+++ b/k6-script-authoring-assistant-lj/manifest.json
@@ -1,0 +1,29 @@
+{
+  "id": "k6-script-authoring-assistant-lj",
+  "type": "path",
+  "description": "Use Grafana Assistant k6 Script Authoring mode to generate, refine, and validate k6 scripts for Grafana Cloud k6.",
+  "category": "take-action",
+  "author": {
+    "name": "Grafana Documentation",
+    "team": "Grafana Documentation"
+  },
+  "startingLocation": "/a/k6-app",
+  "targeting": {
+    "match": {
+      "and": [
+        { "urlPrefix": "/a/k6-app" },
+        { "targetPlatform": "cloud" }
+      ]
+    }
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "milestones": [
+    "k6-script-authoring-assistant-generate-from-prompt"
+  ],
+  "depends": [],
+  "recommends": [],
+  "suggests": [],
+  "provides": []
+}


### PR DESCRIPTION
Adds the k6-script-authoring-assistant-lj Pathfinder package with a Generate a script from a plain-language prompt guide: scripted highlights for Testing & synthetics, Performance, and the Assistant toolbar control, plus markdown steps for Script Authoring mode, prompt/editor flows, and optional local k6 run until stable selectors exist for those surfaces.

Pairs with the website learning path PR that sets pathfinder_data to this package and syncs data/docs/interactive-learning/k6-script-authoring-assistant-lj/

website: [#30548](https://github.com/grafana/website/pull/30548)

Correlate k6 observability Pathfinder package moved to [#335](https://github.com/grafana/interactive-tutorials/pull/335) (paired with website branch docs/correlate-k6-observability-learning-path).