### PR TITLE
Add interactive guide for configure IRM learning path

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -41,6 +41,7 @@
 /fleet-management-onboarding/                             @Jayclifford345
 /github-data-source-lj/                                   @chri2547
 /grafana-cloud-tour-lj/                                   @BeverlyJaneJ
+/grafana-irm-configuration-lj/                            @alyssawada
 /infinity-csv-lj/                                         @tacole02
 /infrastructure-alerting-lj/                              @JohnnyK-Grafana
 /irm-configuration/                                       @wettick

--- a/grafana-irm-configuration-lj/build-mental-model/content.json
+++ b/grafana-irm-configuration-lj/build-mental-model/content.json
@@ -1,0 +1,23 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "grafana-irm-configuration-build-mental-model",
+  "title": "Build a mental model of IRM",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "Understanding how IRM components work together helps you design effective incident response workflows. IRM consists of five core components that process alerts from detection to resolution: integrations, routes, escalation chains, schedules, and notification rules.\n\nEach component serves a specific purpose and together they ensure alerts and incidents reach the right people through the appropriate channels."
+    },
+    {
+      "type": "markdown",
+      "content": "The following diagram illustrates the different components of IRM and how they work together as alerts flow through the system:\n\n![Alert flow diagram showing alert source passing through Grafana IRM components](/media/docs/grafana-cloud/alerting-and-irm/screenshot-grafana-irm-alert-flow-diagram-lj.png)"
+    },
+    {
+      "type": "markdown",
+      "content": "Familiarize yourself with these components before you configure them in the next milestones:\n\n- **Integrations** connect alert and event sources to IRM. Common types include Grafana Alerting, external monitoring tools, ticketing systems, custom webhooks, and API based connections.\n- **Routes** apply conditional rules to direct alerts from an integration to specific escalation chains. Every integration has a default route that processes all alerts; add more routes for conditional logic (labels, severity, service, or content).\n- **Escalation chains** define a sequence of notification steps: who is notified, when, and with what importance. They set initial targets, wait intervals, escalation steps, and notification importance.\n- **Schedules** manage on-call rotations and determine who is currently responsible. Use them in escalation chains to notify the current on-call responder automatically.\n- **Notification rules** define user-specific notification methods (SMS, phone call, mobile push, email) with timing and escalation behavior."
+    },
+    {
+      "type": "markdown",
+      "content": "{{< docs/video id=\"Eu0iLDFVdy0\" >}}\nThis video provides a high-level walkthrough of configuring Grafana IRM, including connecting integrations, defining escalation chains and conditional routes, setting up on-call coverage, and creating notification rules.\n{{< /docs/video >}}\n\nIn the next milestone, you create an on-call schedule for your team."
+    }
+  ]
+}

--- a/grafana-irm-configuration-lj/build-mental-model/manifest.json
+++ b/grafana-irm-configuration-lj/build-mental-model/manifest.json
@@ -1,0 +1,21 @@
+{
+  "id": "grafana-irm-configuration-build-mental-model",
+  "type": "guide",
+  "description": "Review the five core IRM components and understand how alerts flow from source through routing, escalation, schedules, and notification rules.",
+  "category": "take-action",
+  "author": {
+    "name": "Alyssa Wada",
+    "team": "Grafana Documentation"
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": [
+    "grafana-irm-configuration-understand-value"
+  ],
+  "recommends": [
+    "grafana-irm-configuration-create-on-call-schedule"
+  ],
+  "suggests": [],
+  "provides": []
+}

--- a/grafana-irm-configuration-lj/connect-alert-rule/content.json
+++ b/grafana-irm-configuration-lj/connect-alert-rule/content.json
@@ -5,11 +5,60 @@
   "blocks": [
     {
       "type": "markdown",
-      "content": "In this milestone, you update or create an alert rule so IRM can receive alerts from Grafana Alerting. For firing alerts to create IRM Alert groups, the alert rule must include the IRM contact point you created in the previous milestone.\n\nTo add the IRM contact point to an existing alert rule, complete the following steps:"
+      "content": "In this milestone, you update an existing alert rule so IRM can receive alerts from Grafana Alerting. For firing alerts to create IRM Alert groups, the alert rule must include the IRM contact point you created in the previous milestone.\n\nTo open the alert rules list in Grafana Alerting, complete the following steps:"
+    },
+    {
+      "type": "guided",
+      "content": "Open the alert rules list and find your rule.",
+      "requirements": ["navmenu-open"],
+      "stepTimeout": 45000,
+      "steps": [
+        {
+          "action": "highlight",
+          "reftarget": "a[data-testid=\"data-testid Nav menu item\"][href=\"/alerting\"]",
+          "requirements": ["navmenu-open"],
+          "tooltip": "Expand the alerting section in the navigation menu."
+        },
+        {
+          "action": "highlight",
+          "reftarget": "a[data-testid=\"data-testid Nav menu item\"][href=\"/alerting/list\"]",
+          "requirements": ["navmenu-open"],
+          "tooltip": "Open the alert rules list."
+        },
+        {
+          "action": "highlight",
+          "reftarget": "input[data-testid=\"search-query-input\"]",
+          "skippable": true,
+          "tooltip": "Search by name, label, or folder to find the rule you want to connect to IRM."
+        }
+      ]
     },
     {
       "type": "markdown",
-      "content": "1. In your Grafana Cloud stack, click **Alerting** > **Alert rules**.\n1. Locate the rule you want to update.\n1. Click the rule name to open its edit view.\n1. Scroll to the **Contact points** section.\n1. Add the IRM contact point. Leave any existing contact points if you still need their notifications.\n1. Click **Save rule**."
+      "content": "Click the rule name or **Edit** on the rule row to open the rule edit view, then follow the steps below to add the IRM contact point:"
+    },
+    {
+      "type": "guided",
+      "content": "Add the IRM contact point to the alert rule.",
+      "stepTimeout": 45000,
+      "steps": [
+        {
+          "action": "highlight",
+          "reftarget": "[data-testid=\"routing-options-contact-point\"]",
+          "skippable": true,
+          "tooltip": "In the notifications step, select Contact point routing. Skip this step if the rule already uses contact point routing."
+        },
+        {
+          "action": "highlight",
+          "reftarget": "[data-testid=\"contact-point-picker\"]",
+          "tooltip": "Open the contact point picker and choose the IRM contact point you created in the previous milestone."
+        },
+        {
+          "action": "button",
+          "reftarget": "button[data-testid=\"save-rule\"]",
+          "tooltip": "Save the rule. The IRM contact point is now wired to this alert rule."
+        }
+      ]
     },
     {
       "type": "markdown",

--- a/grafana-irm-configuration-lj/connect-alert-rule/content.json
+++ b/grafana-irm-configuration-lj/connect-alert-rule/content.json
@@ -1,0 +1,19 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "grafana-irm-configuration-connect-alert-rule",
+  "title": "Connect an alert rule to IRM",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "In this milestone, you update or create an alert rule so IRM can receive alerts from Grafana Alerting. For firing alerts to create IRM Alert groups, the alert rule must include the IRM contact point you created in the previous milestone.\n\nTo add the IRM contact point to an existing alert rule, complete the following steps:"
+    },
+    {
+      "type": "markdown",
+      "content": "1. In your Grafana Cloud stack, click **Alerting** > **Alert rules**.\n1. Locate the rule you want to update.\n1. Click the rule name to open its edit view.\n1. Scroll to the **Contact points** section.\n1. Add the IRM contact point. Leave any existing contact points if you still need their notifications.\n1. Click **Save rule**."
+    },
+    {
+      "type": "markdown",
+      "content": "If you don't have an existing alert rule that you can modify, consider one of these options:\n\n- Duplicate an existing rule and modify the duplicate.\n- Use the [TestData data source](/docs/grafana-cloud/connect-externally-hosted/data-sources/testdata/) to create a temporary test rule.\n\nIf neither option works, you can still proceed to the next milestone and use the **Send demo alert** function in IRM to complete a limited configuration test.\n\nIn the next milestone, you trigger an alert to test your setup and verify escalation, schedule resolution, and notification delivery."
+    }
+  ]
+}

--- a/grafana-irm-configuration-lj/connect-alert-rule/manifest.json
+++ b/grafana-irm-configuration-lj/connect-alert-rule/manifest.json
@@ -1,0 +1,21 @@
+{
+  "id": "grafana-irm-configuration-connect-alert-rule",
+  "type": "guide",
+  "description": "Add the IRM contact point to a Grafana alert rule so firing alerts generate IRM Alert groups.",
+  "category": "take-action",
+  "author": {
+    "name": "Alyssa Wada",
+    "team": "Grafana Documentation"
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": [
+    "grafana-irm-configuration-connect-grafana-alerting"
+  ],
+  "recommends": [
+    "grafana-irm-configuration-run-end-to-end-test"
+  ],
+  "suggests": [],
+  "provides": []
+}

--- a/grafana-irm-configuration-lj/connect-grafana-alerting/content.json
+++ b/grafana-irm-configuration-lj/connect-grafana-alerting/content.json
@@ -1,0 +1,85 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "grafana-irm-configuration-connect-grafana-alerting",
+  "title": "Connect Grafana Alerting as an integration",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "In this milestone, you connect Grafana Alerting as the alert source that feeds the schedule and escalation chain you already built. The integration sends Grafana Cloud alert rules to IRM for automatic grouping, routing, escalation, and notification.\n\nTo add Grafana Alerting as an integration and associate it with your escalation chain, complete the following steps:"
+    },
+    {
+      "type": "guided",
+      "content": "Add Grafana Alerting as an integration.",
+      "requirements": ["navmenu-open"],
+      "stepTimeout": 45000,
+      "steps": [
+        {
+          "action": "highlight",
+          "reftarget": "a[data-testid=\"data-testid Nav menu item\"][href=\"/a/grafana-irm-app/integrations\"]",
+          "requirements": ["navmenu-open"],
+          "tooltip": "Open the integrations list from the IRM navigation menu."
+        },
+        {
+          "action": "button",
+          "reftarget": "[data-pathfinder=\"add-integration-button\"]",
+          "tooltip": "Start adding a new integration."
+        },
+        {
+          "action": "highlight",
+          "reftarget": "[data-pathfinder=\"integration-grafanaalerting\"]",
+          "tooltip": "Choose Grafana Alerting as the integration type."
+        },
+        {
+          "action": "highlight",
+          "reftarget": "[data-pathfinder=\"integration-name-input\"]",
+          "tooltip": "Enter a descriptive name (for example, `Production SRE alerts`)."
+        },
+        {
+          "action": "highlight",
+          "reftarget": "div[data-testid=\"data-testid radio-button\"]:nth-match(2)",
+          "tooltip": "Choose to create a new contact point alongside this integration."
+        },
+        {
+          "action": "highlight",
+          "reftarget": "[data-pathfinder=\"new-contact-point-input\"]",
+          "tooltip": "Name the new contact point (for example, `Production IRM`)."
+        },
+        {
+          "action": "button",
+          "reftarget": "[data-pathfinder=\"save-integration-button\"]",
+          "tooltip": "Save the integration. The contact point is auto-created in Grafana Alerting."
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "The integration is now created in IRM, but alert rules won't create Alert groups until you assign the IRM contact point to those rules in the next milestone. First, route alerts from this integration to the escalation chain you built earlier."
+    },
+    {
+      "type": "guided",
+      "content": "Route alerts from the integration to your escalation chain.",
+      "stepTimeout": 45000,
+      "steps": [
+        {
+          "action": "highlight",
+          "reftarget": "[data-pathfinder=\"route-heading-0\"]",
+          "tooltip": "Expand the default route."
+        },
+        {
+          "action": "highlight",
+          "reftarget": "[data-testid=\"escalation-chain-select\"]",
+          "tooltip": "Open the escalation chain selector for this route."
+        },
+        {
+          "action": "highlight",
+          "reftarget": "[data-pathfinder=\"escalation-chain-option-0\"]",
+          "tooltip": "Select the chain you created in the previous milestone."
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "IRM now routes alerts from this integration to your escalation chain, which notifies the current on-call user from your schedule.\n\nIn the next milestone, you connect an alert rule so live alerts reach IRM through your new integration."
+    }
+  ]
+}

--- a/grafana-irm-configuration-lj/connect-grafana-alerting/manifest.json
+++ b/grafana-irm-configuration-lj/connect-grafana-alerting/manifest.json
@@ -1,0 +1,21 @@
+{
+  "id": "grafana-irm-configuration-connect-grafana-alerting",
+  "type": "guide",
+  "description": "Add Grafana Alerting as your first integration in IRM and associate it with your escalation chain so alerts flow to the right responders.",
+  "category": "take-action",
+  "author": {
+    "name": "Alyssa Wada",
+    "team": "Grafana Documentation"
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": [
+    "grafana-irm-configuration-create-escalation-chain"
+  ],
+  "recommends": [
+    "grafana-irm-configuration-connect-alert-rule"
+  ],
+  "suggests": [],
+  "provides": []
+}

--- a/grafana-irm-configuration-lj/content.json
+++ b/grafana-irm-configuration-lj/content.json
@@ -1,0 +1,31 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "grafana-irm-configuration-lj",
+  "title": "Configure Grafana IRM for incident response",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "Welcome to the Grafana learning path that shows you how to configure Grafana IRM (Incident Response Management) to manage incidents and organize on-call response. Grafana IRM is an observability native incident response solution that is embedded, side by side, with your existing monitoring and alerting workflows in Grafana Cloud.\n\nGrafana IRM bridges the gap between monitoring and incident response by providing automated alert routing, escalation chains, on-call scheduling, and notification management. IRM differs from traditional incident management tools by being deeply integrated with your observability data, enabling faster incident response and resolution."
+    },
+    {
+      "type": "markdown",
+      "content": "The following diagram represents how Grafana IRM helps you detect, respond to, and learn from incidents:\n\n![Grafana IRM detect, respond, learn framework](/media/docs/grafana-cloud/alerting-and-irm/irm-lj-diagram-small.png)\n\n- **Detect:** Identify a problem within your system.\n- **Respond:** Get the right people and processes in place to respond to the issue.\n- **Learn:** Solve, communicate, and grow from resolving the issue."
+    },
+    {
+      "type": "markdown",
+      "content": "## Here's what to expect\n\nWhen you complete this path, you'll be able to:\n\n- Understand the value of Grafana IRM for incident response and on-call management\n- Build a mental model of how IRM components work together\n- Set up an on-call schedule with a rotation layer\n- Create an escalation chain that routes alerts to the current on-call responder\n- Connect Grafana Alerting as an alert source and link it to your escalation chain\n- Connect an alert rule to IRM and test the complete configuration end to end"
+    },
+    {
+      "type": "markdown",
+      "content": "## Before you begin\n\nBefore you configure Grafana IRM, ensure that you have:\n\n- A Grafana Cloud account. To create an account, refer to [Grafana Cloud](https://grafana.com/signup/cloud/connect-account).\n- Admin or Editor permissions in your Grafana Cloud organization.\n- At least one team defined in Grafana Cloud with members assigned.\n- Basic familiarity with [Grafana Alerting](/docs/grafana-cloud/alerting-and-irm/alerting/fundamentals/) and how alerts are generated.\n- At least one alert rule defined in Grafana Alerting. To create one, refer to the [Create infrastructure alerts](/docs/learning-paths/infrastructure-alerting/) learning path."
+    },
+    {
+      "type": "markdown",
+      "content": "## Troubleshooting\n\nIf you get stuck, we've got your back! Where appropriate, troubleshooting information is just a click away."
+    },
+    {
+      "type": "markdown",
+      "content": "## More to explore\n\nWe understand you might want to explore other capabilities not strictly on this path. We'll provide you opportunities where it makes sense."
+    }
+  ]
+}

--- a/grafana-irm-configuration-lj/create-escalation-chain/content.json
+++ b/grafana-irm-configuration-lj/create-escalation-chain/content.json
@@ -89,7 +89,7 @@
     },
     {
       "type": "markdown",
-      "content": "{{< admonition type=\"note\" >}}\nFor each notification step, you can choose **Default** or **Important** notification rules. **Important** is for critical, time-sensitive alerts. If you're not sure which to pick, set **Default** for now and update later. Make sure team members configure their [personal notification rules](/docs/grafana-cloud/alerting-and-irm/irm/manage/notifications/notification-rules/) for both rule sets.\n{{< /admonition >}}\n\nYour escalation chain now routes Alert groups to the current on-call responder from your schedule, waits 5 minutes, then escalates to the broader team if unacknowledged.\n\nIn the next milestone, you connect Grafana Alerting as the alert source that feeds this escalation chain."
+      "content": "{{< admonition type=\"note\" >}}\nFor each notification step, you can choose **Default** or **Important** notification rules. **Important** is for critical, time-sensitive alerts. If you're not sure which to pick, set **Default** for now and update later. Make sure team members configure their [personal notification rules](/docs/grafana-cloud/alerting-and-irm/irm/notify-responders/personal-notification-rules/) for both rule sets.\n{{< /admonition >}}\n\nYour escalation chain now routes Alert groups to the current on-call responder from your schedule, waits 5 minutes, then escalates to the broader team if unacknowledged.\n\nIn the next milestone, you connect Grafana Alerting as the alert source that feeds this escalation chain."
     }
   ]
 }

--- a/grafana-irm-configuration-lj/create-escalation-chain/content.json
+++ b/grafana-irm-configuration-lj/create-escalation-chain/content.json
@@ -1,0 +1,95 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "grafana-irm-configuration-create-escalation-chain",
+  "title": "Create an escalation chain",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "In this milestone, you create a basic escalation chain as the next step of your alert flow.\n\nEscalation chains define a sequence of notification steps for Alert groups: who gets notified, when they get notified, and what to do if an Alert group remains unacknowledged. A well-designed escalation chain ensures timely attention from the right people while avoiding unnecessary noise."
+    },
+    {
+      "type": "markdown",
+      "content": "For this example, you configure an escalation chain that notifies the current on-call user, then escalates to the broader team after 5 minutes if the alert remains unacknowledged:\n\n![Escalation chain that notifies the current on-call user from the selected schedule and then escalates to the rest of the team if unacknowledged after 5 minutes](/media/docs/grafana-cloud/alerting-and-irm/screenshot-grafana-irm-escalatino-chain-with-schedule-lj.png)\n\nTo create the escalation chain, complete the following steps:"
+    },
+    {
+      "type": "guided",
+      "content": "Create a new escalation chain.",
+      "requirements": ["navmenu-open"],
+      "stepTimeout": 45000,
+      "steps": [
+        {
+          "action": "highlight",
+          "reftarget": "a[data-testid=\"data-testid Nav menu item\"][href=\"/a/grafana-irm-app/escalations\"]",
+          "requirements": ["navmenu-open"],
+          "tooltip": "Open the escalation chains list from the IRM navigation menu."
+        },
+        {
+          "action": "button",
+          "reftarget": "[data-pathfinder=\"new-escalation-chain-button\"]",
+          "tooltip": "Start creating a new chain."
+        },
+        {
+          "action": "highlight",
+          "reftarget": "[data-pathfinder=\"escalation-chain-name-input\"]",
+          "tooltip": "Enter a descriptive name (for example, `Production - Default`)."
+        },
+        {
+          "action": "button",
+          "reftarget": "[data-pathfinder=\"save-escalation-chain-button\"]",
+          "tooltip": "Save the chain so you can add steps to it."
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "Now add the notification, wait, and escalation steps. The first step pages the on-call user from your schedule, the second waits 5 minutes, and the third escalates to the broader team."
+    },
+    {
+      "type": "guided",
+      "content": "Add steps to your escalation chain.",
+      "stepTimeout": 45000,
+      "skippable": true,
+      "steps": [
+        {
+          "action": "highlight",
+          "reftarget": "[data-pathfinder=\"timeline-item-1\"]",
+          "tooltip": "Add the first escalation step."
+        },
+        {
+          "action": "highlight",
+          "reftarget": "div:text(\"Notify users from on-call schedule\")",
+          "tooltip": "Choose to notify users from an on-call schedule."
+        },
+        {
+          "action": "highlight",
+          "reftarget": "div[data-testid=\"input-wrapper\"] input[placeholder=\"Select Schedule\"]",
+          "tooltip": "Select the schedule you created in the previous milestone."
+        },
+        {
+          "action": "highlight",
+          "reftarget": "[data-pathfinder=\"timeline-item-2\"]",
+          "tooltip": "Add a second step to introduce a wait."
+        },
+        {
+          "action": "highlight",
+          "reftarget": "div:text(\"Wait\")",
+          "tooltip": "Choose Wait, then set the wait time to `5 minutes`."
+        },
+        {
+          "action": "highlight",
+          "reftarget": "[data-pathfinder=\"timeline-item-3\"]",
+          "tooltip": "Add a third step to escalate when no one acknowledges."
+        },
+        {
+          "action": "highlight",
+          "reftarget": "div:text(\"Notify users\")",
+          "tooltip": "Choose Notify users, then select the broader team to escalate to."
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "{{< admonition type=\"note\" >}}\nFor each notification step, you can choose **Default** or **Important** notification rules. **Important** is for critical, time-sensitive alerts. If you're not sure which to pick, set **Default** for now and update later. Make sure team members configure their [personal notification rules](/docs/grafana-cloud/alerting-and-irm/irm/manage/notifications/notification-rules/) for both rule sets.\n{{< /admonition >}}\n\nYour escalation chain now routes Alert groups to the current on-call responder from your schedule, waits 5 minutes, then escalates to the broader team if unacknowledged.\n\nIn the next milestone, you connect Grafana Alerting as the alert source that feeds this escalation chain."
+    }
+  ]
+}

--- a/grafana-irm-configuration-lj/create-escalation-chain/manifest.json
+++ b/grafana-irm-configuration-lj/create-escalation-chain/manifest.json
@@ -1,0 +1,21 @@
+{
+  "id": "grafana-irm-configuration-create-escalation-chain",
+  "type": "guide",
+  "description": "Build a basic escalation chain that notifies the on-call user from your schedule and escalates to the team if the alert remains unacknowledged.",
+  "category": "take-action",
+  "author": {
+    "name": "Alyssa Wada",
+    "team": "Grafana Documentation"
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": [
+    "grafana-irm-configuration-create-on-call-schedule"
+  ],
+  "recommends": [
+    "grafana-irm-configuration-connect-grafana-alerting"
+  ],
+  "suggests": [],
+  "provides": []
+}

--- a/grafana-irm-configuration-lj/create-on-call-schedule/content.json
+++ b/grafana-irm-configuration-lj/create-on-call-schedule/content.json
@@ -1,0 +1,80 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "grafana-irm-configuration-create-on-call-schedule",
+  "title": "Create a basic on-call schedule",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "In this milestone, you create a basic schedule that uses a single rotation with team members taking turns to be on call. This schedule lets you route alerts sent to your escalation chain based on the current on-call assignment.\n\nSchedules provide a structured way to manage team on-call coverage and automate shift handoffs. When used in escalation chains, IRM identifies who is on-call for a schedule and sends alert notifications to the appropriate users."
+    },
+    {
+      "type": "markdown",
+      "content": "For this example, you configure a 24-hour daily handoff rotation:\n\n![On-call schedule creation screen with three users rotating daily between a 24-hour shift](/media/docs/grafana-cloud/alerting-and-irm/screenshot-grafana-irm-on-call-schedule-lj.png)\n\nTo create a new schedule, complete the following steps:"
+    },
+    {
+      "type": "guided",
+      "content": "Create a new on-call schedule.",
+      "requirements": ["navmenu-open"],
+      "stepTimeout": 45000,
+      "steps": [
+        {
+          "action": "highlight",
+          "reftarget": "a[data-testid=\"data-testid Nav menu item\"][href=\"/a/grafana-irm-app/schedules\"]",
+          "requirements": ["navmenu-open"],
+          "tooltip": "Open the schedule list from the IRM navigation menu."
+        },
+        {
+          "action": "button",
+          "reftarget": "[data-pathfinder=\"new-schedule-button\"]",
+          "tooltip": "Start creating a new schedule."
+        },
+        {
+          "action": "button",
+          "reftarget": "[data-pathfinder=\"create-web-schedule-button\"]",
+          "tooltip": "Choose a guided on-call rotation setup."
+        },
+        {
+          "action": "highlight",
+          "reftarget": "[data-pathfinder=\"schedule-name\"]",
+          "tooltip": "Enter a descriptive name for the schedule (for example, `Production SRE`)."
+        },
+        {
+          "action": "button",
+          "reftarget": "[data-pathfinder=\"save-schedule-button\"]",
+          "tooltip": "Save the schedule. The rotation configuration modal opens automatically."
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "Now configure a single rotation layer. The first user in the rotation is on call when the schedule starts."
+    },
+    {
+      "type": "guided",
+      "content": "Add a rotation layer to your schedule.",
+      "stepTimeout": 45000,
+      "steps": [
+        {
+          "action": "highlight",
+          "reftarget": "div[data-testid=\"schedule-rotations\"] button:first-of-type",
+          "skippable": true,
+          "tooltip": "Add a new rotation. Skip this step if the rotation editor is already open."
+        },
+        {
+          "action": "highlight",
+          "reftarget": "[data-pathfinder=\"add-user-select\"]",
+          "tooltip": "Select at least one responder. Drag to reorder; the top user is first on-call."
+        },
+        {
+          "action": "button",
+          "reftarget": "[data-pathfinder=\"save-rotation-button\"]",
+          "tooltip": "Save the rotation."
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "{{< admonition type=\"tip\" >}}\nAdd yourself as the current on-call user for initial testing to avoid sending notifications to teammates. Make sure your [personal notification rules](/docs/grafana-cloud/alerting-and-irm/irm/manage/notifications/notification-rules/) are configured so you actually receive the test notifications.\n{{< /admonition >}}\n\nTo verify the schedule, return to **Schedules** and locate the new schedule. View **Final schedule** to confirm rotation coverage and timing, and verify **On-call now** shows the expected user.\n\nIn the next milestone, you create an escalation chain that routes alerts to the current on-call responder from this schedule."
+    }
+  ]
+}

--- a/grafana-irm-configuration-lj/create-on-call-schedule/content.json
+++ b/grafana-irm-configuration-lj/create-on-call-schedule/content.json
@@ -74,7 +74,7 @@
     },
     {
       "type": "markdown",
-      "content": "{{< admonition type=\"tip\" >}}\nAdd yourself as the current on-call user for initial testing to avoid sending notifications to teammates. Make sure your [personal notification rules](/docs/grafana-cloud/alerting-and-irm/irm/manage/notifications/notification-rules/) are configured so you actually receive the test notifications.\n{{< /admonition >}}\n\nTo verify the schedule, return to **Schedules** and locate the new schedule. View **Final schedule** to confirm rotation coverage and timing, and verify **On-call now** shows the expected user.\n\nIn the next milestone, you create an escalation chain that routes alerts to the current on-call responder from this schedule."
+      "content": "{{< admonition type=\"tip\" >}}\nAdd yourself as the current on-call user for initial testing to avoid sending notifications to teammates. Make sure your [personal notification rules](/docs/grafana-cloud/alerting-and-irm/irm/notify-responders/personal-notification-rules/) are configured so you actually receive the test notifications.\n{{< /admonition >}}\n\nTo verify the schedule, return to **Schedules** and locate the new schedule. View **Final schedule** to confirm rotation coverage and timing, and verify **On-call now** shows the expected user.\n\nIn the next milestone, you create an escalation chain that routes alerts to the current on-call responder from this schedule."
     }
   ]
 }

--- a/grafana-irm-configuration-lj/create-on-call-schedule/manifest.json
+++ b/grafana-irm-configuration-lj/create-on-call-schedule/manifest.json
@@ -1,0 +1,21 @@
+{
+  "id": "grafana-irm-configuration-create-on-call-schedule",
+  "type": "guide",
+  "description": "Create a basic on-call schedule with a single rotation layer that you can use in escalation chains to notify the current responder.",
+  "category": "take-action",
+  "author": {
+    "name": "Alyssa Wada",
+    "team": "Grafana Documentation"
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": [
+    "grafana-irm-configuration-build-mental-model"
+  ],
+  "recommends": [
+    "grafana-irm-configuration-create-escalation-chain"
+  ],
+  "suggests": [],
+  "provides": []
+}

--- a/grafana-irm-configuration-lj/create-on-call-schedule/manifest.json
+++ b/grafana-irm-configuration-lj/create-on-call-schedule/manifest.json
@@ -10,9 +10,7 @@
   "testEnvironment": {
     "tier": "cloud"
   },
-  "depends": [
-    "grafana-irm-configuration-build-mental-model"
-  ],
+  "depends": [],
   "recommends": [
     "grafana-irm-configuration-create-escalation-chain"
   ],

--- a/grafana-irm-configuration-lj/end-journey/content.json
+++ b/grafana-irm-configuration-lj/end-journey/content.json
@@ -13,7 +13,7 @@
     },
     {
       "type": "markdown",
-      "content": "---\n\n### More to explore (optional)\n\nThe world is your oyster! Read more about how you can:\n\n- [Configure notification rules](/docs/grafana-cloud/alerting-and-irm/irm/manage/notifications/notification-rules/)\n- [Install the Grafana IRM mobile app](/docs/grafana-cloud/alerting-and-irm/irm/mobile-app/)\n- [Sync Grafana IRM contacts to your phone](/docs/grafana-cloud/alerting-and-irm/irm/manage/notifications/phone-and-sms/#sync-irm-phone-numbers-to-your-contacts)\n- [Configure IRM as code](/docs/grafana-cloud/alerting-and-irm/irm/set-up/infra-as-code/)\n- [Connect your Slack workspace](/docs/grafana-cloud/alerting-and-irm/irm/configure/integrations/irm-slack/)\n- [Manage incidents with Grafana IRM](/docs/grafana-cloud/alerting-and-irm/irm/use/incident-management/)"
+      "content": "---\n\n### More to explore (optional)\n\nThe world is your oyster! Read more about how you can:\n\n- [Configure personal notification rules](/docs/grafana-cloud/alerting-and-irm/irm/notify-responders/personal-notification-rules/)\n- [Install the Grafana IRM mobile app](/docs/grafana-cloud/alerting-and-irm/irm/mobile-app/)\n- [Sync Grafana IRM contacts to your phone](/docs/grafana-cloud/alerting-and-irm/irm/notify-responders/phone-and-sms/#sync-irm-phone-numbers-to-your-contacts)\n- [Configure IRM as code](/docs/grafana-cloud/alerting-and-irm/irm/set-up/infra-as-code/)\n- [Connect your Slack workspace](/docs/grafana-cloud/alerting-and-irm/irm/integrations/chat-and-collaboration/slack/)\n- [Manage incidents with Grafana IRM](/docs/grafana-cloud/alerting-and-irm/irm/manage-incidents/)"
     },
     {
       "type": "markdown",

--- a/grafana-irm-configuration-lj/end-journey/content.json
+++ b/grafana-irm-configuration-lj/end-journey/content.json
@@ -1,0 +1,23 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "grafana-irm-configuration-end-journey",
+  "title": "Destination reached!",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "Congratulations on completing this learning path! Job well done!\n\nWe hope you've enjoyed traveling with us as you:\n\n- Learned about the value of Grafana IRM for incident response and on-call management\n- Built a mental model of IRM components and workflows\n- Created an on-call schedule with a rotation layer\n- Created an escalation chain that routes alerts to the current on-call responder\n- Connected Grafana Alerting as an integration and linked it to your escalation chain\n- Connected an alert rule to IRM using contact points\n- Tested your IRM configuration from alert generation to acknowledgment"
+    },
+    {
+      "type": "markdown",
+      "content": "You've completed the foundational setup for Grafana IRM. This basic configuration demonstrates how IRM routes alerts through escalation chains and schedules, but there's much more you can do to customize IRM for your team's needs. Consider setting up additional schedules, configuring more notification channels, or connecting additional alert rules to expand your incident response coverage."
+    },
+    {
+      "type": "markdown",
+      "content": "---\n\n### More to explore (optional)\n\nThe world is your oyster! Read more about how you can:\n\n- [Configure notification rules](/docs/grafana-cloud/alerting-and-irm/irm/manage/notifications/notification-rules/)\n- [Install the Grafana IRM mobile app](/docs/grafana-cloud/alerting-and-irm/irm/mobile-app/)\n- [Sync Grafana IRM contacts to your phone](/docs/grafana-cloud/alerting-and-irm/irm/manage/notifications/phone-and-sms/#sync-irm-phone-numbers-to-your-contacts)\n- [Configure IRM as code](/docs/grafana-cloud/alerting-and-irm/irm/set-up/infra-as-code/)\n- [Connect your Slack workspace](/docs/grafana-cloud/alerting-and-irm/irm/configure/integrations/irm-slack/)\n- [Manage incidents with Grafana IRM](/docs/grafana-cloud/alerting-and-irm/irm/use/incident-management/)"
+    },
+    {
+      "type": "markdown",
+      "content": "---\n\n### Related paths\n\nConsider taking the following paths to build on what you learned:\n\n- [Create infrastructure alerts in Grafana Cloud](/docs/learning-paths/infrastructure-alerting/)"
+    }
+  ]
+}

--- a/grafana-irm-configuration-lj/end-journey/manifest.json
+++ b/grafana-irm-configuration-lj/end-journey/manifest.json
@@ -1,0 +1,19 @@
+{
+  "id": "grafana-irm-configuration-end-journey",
+  "type": "guide",
+  "description": "Celebrate completing the Grafana IRM configuration learning path and explore what to do next.",
+  "category": "take-action",
+  "author": {
+    "name": "Alyssa Wada",
+    "team": "Grafana Documentation"
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": [
+    "grafana-irm-configuration-run-end-to-end-test"
+  ],
+  "recommends": [],
+  "suggests": [],
+  "provides": []
+}

--- a/grafana-irm-configuration-lj/manifest.json
+++ b/grafana-irm-configuration-lj/manifest.json
@@ -27,8 +27,6 @@
     "tier": "cloud"
   },
   "milestones": [
-    "grafana-irm-configuration-understand-value",
-    "grafana-irm-configuration-build-mental-model",
     "grafana-irm-configuration-create-on-call-schedule",
     "grafana-irm-configuration-create-escalation-chain",
     "grafana-irm-configuration-connect-grafana-alerting",

--- a/grafana-irm-configuration-lj/manifest.json
+++ b/grafana-irm-configuration-lj/manifest.json
@@ -1,0 +1,45 @@
+{
+  "id": "grafana-irm-configuration-lj",
+  "type": "path",
+  "description": "Step-by-step guide: Configure Grafana IRM for incident response by setting up on-call schedules, escalation chains, integrations, and end-to-end alert testing.",
+  "category": "take-action",
+  "author": {
+    "name": "Alyssa Wada",
+    "team": "Grafana Documentation"
+  },
+  "startingLocation": "/a/grafana-irm-app",
+  "targeting": {
+    "match": {
+      "and": [
+        {
+          "urlPrefixIn": [
+            "/a/grafana-irm-app",
+            "/alerting"
+          ]
+        },
+        {
+          "targetPlatform": "cloud"
+        }
+      ]
+    }
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "milestones": [
+    "grafana-irm-configuration-understand-value",
+    "grafana-irm-configuration-build-mental-model",
+    "grafana-irm-configuration-create-on-call-schedule",
+    "grafana-irm-configuration-create-escalation-chain",
+    "grafana-irm-configuration-connect-grafana-alerting",
+    "grafana-irm-configuration-connect-alert-rule",
+    "grafana-irm-configuration-run-end-to-end-test",
+    "grafana-irm-configuration-end-journey"
+  ],
+  "depends": [],
+  "recommends": [],
+  "suggests": [
+    "infrastructure-alerting-lj"
+  ],
+  "provides": []
+}

--- a/grafana-irm-configuration-lj/run-end-to-end-test/content.json
+++ b/grafana-irm-configuration-lj/run-end-to-end-test/content.json
@@ -1,0 +1,31 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "grafana-irm-configuration-run-end-to-end-test",
+  "title": "Test your IRM configuration",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "In this milestone, you test your configuration to verify that IRM creates an Alert group from a firing alert and executes escalation and notification steps as expected."
+    },
+    {
+      "type": "markdown",
+      "content": "{{< admonition type=\"note\" >}}\nBefore you test, configure your [personal notification rules](/docs/grafana-cloud/alerting-and-irm/irm/manage/notifications/notification-rules/) so you receive notifications through your preferred channels. The default notification method is your Grafana Cloud account email. If you're testing against a production alert rule, duplicate the rule first or revert any changes immediately after testing using the **Versions** tab.\n{{< /admonition >}}\n\nTo test your setup from an alert rule, complete the following steps:"
+    },
+    {
+      "type": "markdown",
+      "content": "1. Trigger the alert rule to fire:\n   1. In **Alerting** > **Alert rules**, locate the rule connected to your IRM contact point.\n   1. Open the rule and click **Edit** to lower the conditions so the rule fires (for example, set CPU > `5%`).\n   1. If necessary, lower the evaluation period to `1 minute` so it fires quickly.\n   1. Save the rule, wait one evaluation cycle, and confirm the rule shows a firing state.\n1. Verify the new Alert group in IRM:\n   1. In the IRM navigation menu, click **Alert Groups**.\n   1. Locate the new Alert group created by the firing rule.\n   1. Open the Alert group details.\n1. In the timeline, verify escalation chain selection, the correct on-call user identification, and first notification attempts.\n1. If you configured wait and escalation steps, wait for the delay to elapse and verify the next steps fire.\n1. When you're ready, acknowledge the Alert group to stop further escalation and notifications.\n1. Restore the alert rule conditions and confirm it returns to a non-firing (OK) state after the next evaluation."
+    },
+    {
+      "type": "markdown",
+      "content": "If you don't have an alert rule connected to IRM, you can run a partial test by sending a demo alert from the integration page:\n\n1. In the IRM navigation menu, click **Integrations** and open your Grafana Alerting integration.\n1. Click **Send demo alert**.\n1. Review and optionally customize the demo alert payload, then click **Send Alert**.\n1. Verify escalation and notification steps execute as expected.\n1. When you're ready, acknowledge and resolve the Alert group."
+    },
+    {
+      "type": "markdown",
+      "content": "When your test is successful, you observe the following:\n\n- A new Alert group appears in **IRM** > **Alert Groups** within a few seconds of the alert firing.\n- The Alert group timeline shows escalation chain selection, on-call user identification based on your schedule, notification attempts with timestamps, and escalation steps progressing on the configured delays.\n- You receive notifications through your configured channels (email, mobile app, Slack, SMS, etc.) at the expected times.\n- When you acknowledge the Alert group, the timeline shows the acknowledgment and all further escalation and notifications stop."
+    },
+    {
+      "type": "markdown",
+      "content": "If your test doesn't produce the expected results, work through these checks:\n\nIf no Alert group is created after the rule fires, confirm in **Alerting** > **Alert rules** that the rule shows a **Firing** state and that the evaluation period has elapsed since you made changes. In the alert rule, verify the IRM contact point is listed in the **Contact points** section. Then in **Alerting** > **Contact points**, open your IRM contact point and review **Recent delivery attempts** for errors.\n\nIf the Alert group appears but you don't receive notifications, check **IRM** > **Settings** > **Personal notification rules** and confirm you have active rules and that your preferred channels (phone, mobile app) are connected. For mobile push, confirm the IRM mobile app is installed and signed in. For SMS or phone calls, verify your phone number is verified in your notification preferences.\n\nIf the timeline doesn't show expected escalation steps, in **IRM** > **Escalation chains** confirm the chain attached to your integration includes the expected steps and wait intervals. If the chain references a schedule, verify the schedule has active on-call users for the current time period. Look for any error messages in the timeline, especially \"No one on-call\" or similar.\n\nIn the final milestone, you review what you accomplished and plan next steps."
+    }
+  ]
+}

--- a/grafana-irm-configuration-lj/run-end-to-end-test/content.json
+++ b/grafana-irm-configuration-lj/run-end-to-end-test/content.json
@@ -9,7 +9,7 @@
     },
     {
       "type": "markdown",
-      "content": "{{< admonition type=\"note\" >}}\nBefore you test, configure your [personal notification rules](/docs/grafana-cloud/alerting-and-irm/irm/manage/notifications/notification-rules/) so you receive notifications through your preferred channels. The default notification method is your Grafana Cloud account email. If you're testing against a production alert rule, duplicate the rule first or revert any changes immediately after testing using the **Versions** tab.\n{{< /admonition >}}\n\nTo test your setup from an alert rule, complete the following steps:"
+      "content": "{{< admonition type=\"note\" >}}\nBefore you test, configure your [personal notification rules](/docs/grafana-cloud/alerting-and-irm/irm/notify-responders/personal-notification-rules/) so you receive notifications through your preferred channels. The default notification method is your Grafana Cloud account email. If you're testing against a production alert rule, duplicate the rule first or revert any changes immediately after testing using the **Versions** tab.\n{{< /admonition >}}\n\nTo test your setup from an alert rule, complete the following steps:"
     },
     {
       "type": "markdown",
@@ -17,15 +17,42 @@
     },
     {
       "type": "markdown",
-      "content": "If you don't have an alert rule connected to IRM, you can run a partial test by sending a demo alert from the integration page:\n\n1. In the IRM navigation menu, click **Integrations** and open your Grafana Alerting integration.\n1. Click **Send demo alert**.\n1. Review and optionally customize the demo alert payload, then click **Send Alert**.\n1. Verify escalation and notification steps execute as expected.\n1. When you're ready, acknowledge and resolve the Alert group."
+      "content": "If you don't have an alert rule connected to IRM, you can run a partial test by sending a demo alert from the integration page."
+    },
+    {
+      "type": "guided",
+      "content": "Send a demo alert and view the resulting Alert group.",
+      "requirements": ["navmenu-open"],
+      "stepTimeout": 45000,
+      "skippable": true,
+      "steps": [
+        {
+          "action": "highlight",
+          "reftarget": "a[data-testid=\"data-testid Nav menu item\"][href=\"/a/grafana-irm-app/integrations\"]",
+          "requirements": ["navmenu-open"],
+          "tooltip": "Open the integrations list and select your Grafana Alerting integration."
+        },
+        {
+          "action": "button",
+          "reftarget": "[data-pathfinder=\"send-demo-alert-button\"]",
+          "tooltip": "Trigger a demo alert. Review and optionally customize the payload."
+        },
+        {
+          "action": "button",
+          "reftarget": "[data-pathfinder=\"submit-send-alert-button\"]",
+          "tooltip": "Confirm and send the demo alert."
+        },
+        {
+          "action": "highlight",
+          "reftarget": "a[data-testid=\"data-testid Nav menu item\"][href=\"/a/grafana-irm-app/alert-groups\"]",
+          "requirements": ["navmenu-open"],
+          "tooltip": "Open Alert groups to see the demo alert and its escalation timeline."
+        }
+      ]
     },
     {
       "type": "markdown",
-      "content": "When your test is successful, you observe the following:\n\n- A new Alert group appears in **IRM** > **Alert Groups** within a few seconds of the alert firing.\n- The Alert group timeline shows escalation chain selection, on-call user identification based on your schedule, notification attempts with timestamps, and escalation steps progressing on the configured delays.\n- You receive notifications through your configured channels (email, mobile app, Slack, SMS, etc.) at the expected times.\n- When you acknowledge the Alert group, the timeline shows the acknowledgment and all further escalation and notifications stop."
-    },
-    {
-      "type": "markdown",
-      "content": "If your test doesn't produce the expected results, work through these checks:\n\nIf no Alert group is created after the rule fires, confirm in **Alerting** > **Alert rules** that the rule shows a **Firing** state and that the evaluation period has elapsed since you made changes. In the alert rule, verify the IRM contact point is listed in the **Contact points** section. Then in **Alerting** > **Contact points**, open your IRM contact point and review **Recent delivery attempts** for errors.\n\nIf the Alert group appears but you don't receive notifications, check **IRM** > **Settings** > **Personal notification rules** and confirm you have active rules and that your preferred channels (phone, mobile app) are connected. For mobile push, confirm the IRM mobile app is installed and signed in. For SMS or phone calls, verify your phone number is verified in your notification preferences.\n\nIf the timeline doesn't show expected escalation steps, in **IRM** > **Escalation chains** confirm the chain attached to your integration includes the expected steps and wait intervals. If the chain references a schedule, verify the schedule has active on-call users for the current time period. Look for any error messages in the timeline, especially \"No one on-call\" or similar.\n\nIn the final milestone, you review what you accomplished and plan next steps."
+      "content": "When your test is successful, you observe the following:\n\n- A new Alert group appears in **IRM** > **Alert Groups** within a few seconds of the alert firing.\n- The Alert group timeline shows escalation chain selection, on-call user identification based on your schedule, notification attempts with timestamps, and escalation steps progressing on the configured delays.\n- You receive notifications through your configured channels (email, mobile app, Slack, SMS) at the expected times.\n- When you acknowledge the Alert group, the timeline shows the acknowledgment and all further escalation and notifications stop.\n\nIf your test doesn't produce the expected results, check the troubleshooting links at the bottom of this page.\n\nIn the final milestone, you review what you accomplished and plan next steps."
     }
   ]
 }

--- a/grafana-irm-configuration-lj/run-end-to-end-test/content.json
+++ b/grafana-irm-configuration-lj/run-end-to-end-test/content.json
@@ -9,15 +9,43 @@
     },
     {
       "type": "markdown",
-      "content": "{{< admonition type=\"note\" >}}\nBefore you test, configure your [personal notification rules](/docs/grafana-cloud/alerting-and-irm/irm/notify-responders/personal-notification-rules/) so you receive notifications through your preferred channels. The default notification method is your Grafana Cloud account email. If you're testing against a production alert rule, duplicate the rule first or revert any changes immediately after testing using the **Versions** tab.\n{{< /admonition >}}\n\nTo test your setup from an alert rule, complete the following steps:"
+      "content": "{{< admonition type=\"note\" >}}\nBefore you test, configure your [personal notification rules](/docs/grafana-cloud/alerting-and-irm/irm/notify-responders/personal-notification-rules/) so you receive notifications through your preferred channels. The default notification method is your Grafana Cloud account email. If you're testing against a production alert rule, duplicate the rule first or revert any changes immediately after testing using the **Versions** tab.\n{{< /admonition >}}\n\nTo trigger the alert rule from Grafana Alerting, complete the following steps:"
     },
     {
       "type": "markdown",
-      "content": "1. Trigger the alert rule to fire:\n   1. In **Alerting** > **Alert rules**, locate the rule connected to your IRM contact point.\n   1. Open the rule and click **Edit** to lower the conditions so the rule fires (for example, set CPU > `5%`).\n   1. If necessary, lower the evaluation period to `1 minute` so it fires quickly.\n   1. Save the rule, wait one evaluation cycle, and confirm the rule shows a firing state.\n1. Verify the new Alert group in IRM:\n   1. In the IRM navigation menu, click **Alert Groups**.\n   1. Locate the new Alert group created by the firing rule.\n   1. Open the Alert group details.\n1. In the timeline, verify escalation chain selection, the correct on-call user identification, and first notification attempts.\n1. If you configured wait and escalation steps, wait for the delay to elapse and verify the next steps fire.\n1. When you're ready, acknowledge the Alert group to stop further escalation and notifications.\n1. Restore the alert rule conditions and confirm it returns to a non-firing (OK) state after the next evaluation."
+      "content": "1. In **Alerting** > **Alert rules**, locate the rule connected to your IRM contact point.\n1. Open the rule and click **Edit** to lower the conditions so the rule fires (for example, set CPU > `5%`).\n1. If necessary, lower the evaluation period to `1 minute` so it fires quickly.\n1. Save the rule, wait one evaluation cycle, and confirm the rule shows a firing state."
     },
     {
       "type": "markdown",
-      "content": "If you don't have an alert rule connected to IRM, you can run a partial test by sending a demo alert from the integration page."
+      "content": "After the rule fires, verify the resulting Alert group in IRM and acknowledge it:"
+    },
+    {
+      "type": "guided",
+      "content": "Verify and acknowledge the new Alert group.",
+      "requirements": ["navmenu-open"],
+      "stepTimeout": 45000,
+      "steps": [
+        {
+          "action": "highlight",
+          "reftarget": "a[data-testid=\"data-testid Nav menu item\"][href=\"/a/grafana-irm-app/alert-groups\"]",
+          "requirements": ["navmenu-open"],
+          "tooltip": "Open the Alert groups list in IRM."
+        },
+        {
+          "action": "highlight",
+          "reftarget": "[data-testid=\"integration-url\"]:nth-match(1) a",
+          "tooltip": "Open the most recent Alert group to view its details and timeline."
+        },
+        {
+          "action": "highlight",
+          "reftarget": "button:text(\"Acknowledge\")",
+          "tooltip": "Acknowledge the Alert group to stop further escalation and notifications."
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "On the Alert group details page, review the timeline to verify escalation chain selection, on-call user identification, notification attempts, and any wait and escalation steps you configured. After acknowledging, restore the alert rule conditions and confirm the rule returns to a non-firing (OK) state after the next evaluation.\n\nIf you don't have an alert rule connected to IRM, you can run a partial test by sending a demo alert from the integration page:"
     },
     {
       "type": "guided",

--- a/grafana-irm-configuration-lj/run-end-to-end-test/manifest.json
+++ b/grafana-irm-configuration-lj/run-end-to-end-test/manifest.json
@@ -1,0 +1,21 @@
+{
+  "id": "grafana-irm-configuration-run-end-to-end-test",
+  "type": "guide",
+  "description": "Trigger an alert to verify IRM creates an Alert group and executes escalation and notifications as configured.",
+  "category": "take-action",
+  "author": {
+    "name": "Alyssa Wada",
+    "team": "Grafana Documentation"
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": [
+    "grafana-irm-configuration-connect-alert-rule"
+  ],
+  "recommends": [
+    "grafana-irm-configuration-end-journey"
+  ],
+  "suggests": [],
+  "provides": []
+}

--- a/grafana-irm-configuration-lj/understand-value/content.json
+++ b/grafana-irm-configuration-lj/understand-value/content.json
@@ -1,0 +1,23 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "grafana-irm-configuration-understand-value",
+  "title": "Understand the value of IRM in Grafana Cloud",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "Observability systems are complicated. There are nodes, pods, services, and system resources, sometimes thousands of them, all connected in a complex web of relationships. Behind all of that is the group of people who keep these systems healthy.\n\nWhen something goes wrong those people must identify the cause and restore service fast. Downtime is expensive and the response work itself is stressful and draining for the people involved. Grafana IRM is built for those people."
+    },
+    {
+      "type": "markdown",
+      "content": "{{< docs/video id=\"y_Ewv9azoE4\" >}}\nGrafana IRM unifies alert routing, on-call scheduling, incident coordination, and post-incident learning in one observability-native workflow. Hear from experts on best practices and how historical incident data improves escalation, reduces MTTR, and strengthens reliability.\n{{< /docs/video >}}"
+    },
+    {
+      "type": "markdown",
+      "content": "Grafana IRM (Incident Response Management) makes incident response observability-native. Instead of pushing alerts into a separate silo, IRM sits inside Grafana Cloud alongside the metrics, logs, traces, and profiles that generated the alert. This placement removes context switching, shortens investigation time, and enables faster, more reliable response.\n\nTeams that rely on disconnected tools and manual on-call processes face alert fatigue, unclear ownership, and slow responses. Observability-native IRM replaces those scattered workflows by embedding on-call management and incident response directly in your observability ecosystem."
+    },
+    {
+      "type": "markdown",
+      "content": "With Grafana IRM, you can:\n\n- Integrate with Grafana Alerting or any external monitoring tools\n- Automate and conditionally route alerts to the right on-call responder without manual triage\n- Manage on-call schedules with custom rotations and shift swaps\n- Configure diverse notification rules with personal escalation sequences\n- Reduce tool and context switching during high-pressure incidents\n- Scale incident processes as teams and services grow\n\nIn the next milestone, you build a mental model of IRM components and how they work together from alert source to notifying the right people and resolving the issue."
+    }
+  ]
+}

--- a/grafana-irm-configuration-lj/understand-value/manifest.json
+++ b/grafana-irm-configuration-lj/understand-value/manifest.json
@@ -1,0 +1,19 @@
+{
+  "id": "grafana-irm-configuration-understand-value",
+  "type": "guide",
+  "description": "Understand what observability-native incident response means in Grafana Cloud and how IRM fits into existing monitoring workflows.",
+  "category": "take-action",
+  "author": {
+    "name": "Alyssa Wada",
+    "team": "Grafana Documentation"
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": [],
+  "recommends": [
+    "grafana-irm-configuration-build-mental-model"
+  ],
+  "suggests": [],
+  "provides": []
+}


### PR DESCRIPTION
Adds the grafana-irm-configuration-lj learning path Pathfinder package.

Supports an upcoming Pathfinder experiment comparing the standalone IRM interactive guide with the interactive Configure IRM learning path.

Related [Website PR](http://github.com/grafana/website/pull/30670) updating the learning path and wiring the learning path pages to the Pathfinder package


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk content-only change: adds new Pathfinder learning path JSON packages and a CODEOWNERS entry, with no runtime logic or security-sensitive behavior changes.
> 
> **Overview**
> Adds a new `grafana-irm-configuration-lj` Pathfinder learning path package with a `path` manifest plus eight milestone guides covering IRM value, component mental model, schedule and escalation setup, Grafana Alerting integration, alert-rule wiring, end-to-end testing, and completion.
> 
> Updates `.github/CODEOWNERS` to assign ownership of the new `grafana-irm-configuration-lj/` directory.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3da6b68a077d41b58ade1d220901f6b3513f895. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->