### PR TITLE
fix(deploy): continue-on-error for build-courses until pathfinder-app#868 merges

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -196,6 +196,7 @@ jobs:
       # for direct authoring-tool access.
 
       - name: Build courses platform indexes
+        continue-on-error: true
         run: node pathfinder-app/dist/cli/cli/index.js build-courses courses/ -o courses/
 
       - name: 'Publish courses to GCS'


### PR DESCRIPTION
## Summary

- Adds `continue-on-error: true` to the `Build courses platform indexes` step so a missing `build-courses` CLI command no longer breaks the entire deploy workflow.

## Context

`build-courses` does not exist in `grafana-pathfinder-app@main` yet — it ships with [grafana-pathfinder-app#868](https://github.com/grafana/grafana-pathfinder-app/pull/868), which is code-complete and fully green but blocked on approval while the auto-merge bot is disabled during the active incident.

Every deploy since 2026-05-13 has failed at this step. The `Publish courses to GCS` step is already skipped on failure, so course-index publishing simply pauses until #868 lands — all other deploy steps complete normally.

This is a temporary workaround. Once grafana-pathfinder-app#868 merges, `continue-on-error` can be removed.

Closes #321

## Test plan

- [ ] Verify the next deploy run succeeds end-to-end
- [ ] Remove `continue-on-error: true` after grafana-pathfinder-app#868 merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)