### PR TITLE
Add guides for cloud migration assistant

### DIFF
--- a/.playwright-mcp/console-2026-05-21T21-47-40-415Z.log
+++ b/.playwright-mcp/console-2026-05-21T21-47-40-415Z.log
@@ -1,0 +1,7392 @@
+[  326269ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326272ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326276ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326277ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326278ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326278ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326279ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326279ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326280ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326280ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326281ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326281ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326282ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326282ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326282ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326283ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326283ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326284ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326284ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326284ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326285ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326285ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326285ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326286ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326286ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326295ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326296ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326296ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326297ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326297ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326297ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326298ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326298ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326298ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326299ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326299ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326299ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326300ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326300ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326300ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326301ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326301ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326301ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326302ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326302ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326302ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326303ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326303ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326303ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326304ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326304ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326304ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326305ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326305ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326305ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326306ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326312ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326314ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326314ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326315ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326316ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326317ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326317ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326318ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326318ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326320ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326320ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326320ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326321ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326321ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326321ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326322ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326322ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326322ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326322ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326323ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326323ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326323ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326323ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326324ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326324ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326324ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326324ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326325ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326325ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326326ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326326ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326326ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326327ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326331ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326331ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326331ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326332ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326332ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326332ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326332ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326332ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326333ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326333ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326334ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326334ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326334ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326335ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326335ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326335ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326336ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326336ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326336ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326336ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326337ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326337ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326337ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326338ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326338ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326338ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326339ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326339ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326339ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326339ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326340ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326340ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326340ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326340ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326341ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326341ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326341ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326342ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326342ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326343ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326343ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326343ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326344ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326345ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326345ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326345ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326346ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326346ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326346ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326347ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326347ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326351ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326352ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326352ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326352ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326352ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326353ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326355ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326355ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326355ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326355ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326355ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326356ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326356ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326356ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326356ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326357ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326357ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326357ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326357ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326358ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326358ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326358ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326358ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326358ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326359ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326359ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326359ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326359ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326359ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326359ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326360ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326360ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326360ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326366ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326369ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326369ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326369ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326370ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326370ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326370ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326371ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326371ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326371ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326371ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326371ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326372ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326372ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326372ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326373ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326373ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326373ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326373ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326373ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326373ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326373ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326374ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326374ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326374ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326374ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326374ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326374ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326374ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326375ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326375ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326375ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326375ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326375ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326375ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326375ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326376ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326376ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326376ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326376ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326376ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326377ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326377ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326377ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326377ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326377ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326377ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326377ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326377ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326378ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326379ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326379ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326379ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326380ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326380ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326380ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326380ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326380ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326381ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326381ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326381ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326382ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326382ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326382ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326385ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326386ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326386ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326387ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326387ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326387ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326388ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326388ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326388ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326389ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326389ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326389ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326389ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326390ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326390ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326390ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326390ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326390ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326390ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326391ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326391ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326391ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326391ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326391ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326391ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326391ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326391ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326391ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326392ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326392ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326392ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326392ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326392ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326392ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326392ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326392ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326393ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326393ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326393ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326393ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326393ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326398ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326398ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326398ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326403ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326406ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326406ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326406ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326406ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326406ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326406ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326407ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326407ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326407ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326407ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326407ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326408ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326408ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326408ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326408ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326408ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326409ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326409ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326409ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326409ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326409ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326409ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326410ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326410ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326410ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326410ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326410ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326410ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326410ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326411ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326411ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326411ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326411ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326411ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326411ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326411ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326412ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326412ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326412ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326412ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326412ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326412ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326412ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326413ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326413ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326413ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326413ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326413ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326413ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326414ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326414ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326414ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326414ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326414ms] [WARNING] Error checking descendant selector "> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326415ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326416ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326416ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326416ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326416ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326417ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326417ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326417ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326418ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326418ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326418ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326418ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326418ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326418ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326418ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326419ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326419ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326419ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326419ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326419ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326419ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326419ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326420ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326420ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326420ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326420ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326420ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326420ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326421ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326421ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326421ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326421ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326421ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326422ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326422ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326422ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326422ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326423ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326423ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326423ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326424ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326424ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326424ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326424ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326424ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326425ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326425ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326425ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326425ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326425ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326426ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326426ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326426ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326426ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326426ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326426ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326427ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326427ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326427ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326427ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326427ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326428ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326428ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326428ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326428ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326429ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326429ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326429ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326429ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326429ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326429ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326429ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326430ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326430ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326430ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326430ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326430ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326430ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326431ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326431ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326431ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326431ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326431ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326431ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326431ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326432ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326432ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326432ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326432ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326433ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326434ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326434ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326434ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326434ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326434ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326435ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326435ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326435ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326435ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326435ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326435ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326436ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326436ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326436ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326436ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326436ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326436ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326436ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326437ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326437ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326437ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326437ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326437ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326437ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326437ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326438ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326438ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326438ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326438ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326438ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326439ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326439ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326439ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326440ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326440ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326440ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326440ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326441ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326441ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326441ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326441ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326442ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326442ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326442ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326442ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326442ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326443ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326443ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326443ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326443ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326443ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326444ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326444ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326444ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326444ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326445ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326445ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326445ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326445ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326445ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326445ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326446ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326446ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326446ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326446ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326446ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326446ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326446ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326447ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326447ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326447ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326447ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326447ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326447ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326447ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326448ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326448ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326448ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326448ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326448ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326448ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326449ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326449ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326449ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326449ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326449ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326449ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326450ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326450ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326450ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326450ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326450ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326450ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326450ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326451ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326451ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326451ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326451ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326451ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326451ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326452ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326452ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326452ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326452ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326452ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326452ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326452ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326453ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326453ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326453ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326453ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326453ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326453ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326454ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326454ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326454ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326454ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326454ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326454ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326455ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326455ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326455ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326455ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326455ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326455ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326455ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326456ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326456ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326456ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326456ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326456ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326456ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326457ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326457ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326457ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326457ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326457ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326458ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326458ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326458ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326458ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326458ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326460ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326460ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326460ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326460ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326460ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326461ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326461ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326461ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326461ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326461ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326461ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326461ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326462ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326462ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326462ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326462ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326462ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326462ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326463ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326463ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326463ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326463ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326463ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326463ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326463ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326464ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326464ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326464ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326464ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326464ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326464ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326465ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326465ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326465ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326465ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326465ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326465ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326465ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326466ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326466ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326466ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326467ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326467ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326467ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326468ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326468ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326468ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326468ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326468ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326468ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326469ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326469ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326469ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326469ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326469ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326469ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326470ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326470ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326470ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326470ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326470ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326470ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326471ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326471ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326471ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326471ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326471ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326471ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326472ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326472ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326472ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326472ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326472ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326472ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326472ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326473ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326473ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326473ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326473ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326473ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326474ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326474ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326474ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326474ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326474ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326474ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326475ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326475ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326475ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326475ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326475ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326475ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326476ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326476ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326476ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326476ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326477ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326477ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326478ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326478ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326478ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326478ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326479ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615
+[  326479ms] [WARNING] Error checking descendant selector "> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']": SyntaxError: Failed to execute 'querySelectorAll' on 'Element': '> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button']' is not a valid selector.
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:74500
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:75695
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:616:78534)
+    at qe (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:175418)
+    at n (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176523)
+    at n.next (<anonymous>)
+    at _e (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:174964)
+    at i (http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176934)
+    at http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:58:176995
+    at new Promise (<anonymous>) @ http://localhost:3000/public/plugins/grafana-pathfinder-app/702.js?_cache=5747cbcc4a9e7038e3e3:615

--- a/cloud-migration-assistant-lj/cloud/content.json
+++ b/cloud-migration-assistant-lj/cloud/content.json
@@ -106,7 +106,7 @@
           "type": "interactive",
           "action": "highlight",
           "reftarget": "a[data-testid='data-testid Nav menu item'][href='/alerting/list']",
-          "content": "If you migrated alerting resources, navigate to **Alerts & IRM** > **Alerting** > **Alert rules** to verify alert rules are present. By default, alert rules are migrated in a 'paused' state to prevent duplicate notifications from both your self-managed and cloud instances.",
+          "content": "If you migrated alerting resources, navigate to **Alerts & IRM** > **Alerting** > **Alert rules** to verify alert rules are present. By default, alert rules are migrated in a 'paused' state to prevent duplicate notifications from both your self-managed and Grafana Cloud instances.",
           "requirements": [
             "navmenu-open"
           ],
@@ -128,7 +128,7 @@
       "blocks": [
         {
           "type": "markdown",
-          "content": "Alert rules are migrated in a paused state by default to prevent duplicate notifications from both your self-managed and cloud instances. Once you've verified your alerting configuration works correctly in Grafana Cloud, you can activate your alert rules."
+          "content": "Alert rules are migrated in a paused state by default to prevent duplicate notifications from both your self-managed and Grafana Cloud instances. Once you've verified your alerting configuration works correctly in Grafana Cloud, you can activate your alert rules."
         },
         {
           "type": "interactive",
@@ -143,7 +143,7 @@
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "[role='radiogroup']:has(input[id^='option-grouped'])",
+          "reftarget": "[data-testid='data-testid radio-button']:has(input[title='Grouped'])",
           "content": "Ensure you are in the **Grouped** view. This is the default view and shows alert rules organized by folder.",
           "requirements": [
             "on-page:/alerting/list"

--- a/cloud-migration-assistant-lj/cloud/content.json
+++ b/cloud-migration-assistant-lj/cloud/content.json
@@ -1,0 +1,133 @@
+{
+  "id": "cloud-migration-assistant-cloud",
+  "title": "Migrate to Grafana Cloud — Cloud steps",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "This guide covers the steps you perform in your Grafana Cloud instance during a migration: generating a migration token, verifying migrated resources, and activating alert rules."
+    },
+    {
+      "type": "section",
+      "title": "Generate a migration token",
+      "blocks": [
+        {
+          "type": "markdown",
+          "content": "You'll generate a secure token that authenticates your self-managed instance with this Grafana Cloud stack."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "a[data-testid='data-testid Nav menu item'][href='/admin/migrate-to-cloud']",
+          "content": "Open the navigation menu and select **Administration** > **General** > **Migrate to Grafana Cloud**.",
+          "requirements": ["navmenu-open"]
+        },
+        {
+          "type": "interactive",
+          "action": "button",
+          "reftarget": "Generate a migration token",
+          "content": "Click **Generate a migration token**.",
+          "requirements": ["on-page:/admin/migrate-to-cloud"],
+          "doIt": false
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Copy the migration token and store it securely — you need it to connect your self-managed instance."
+        },
+        {
+          "type": "markdown",
+          "content": "You generated a migration token that your self-managed instance uses to authenticate with Grafana Cloud."
+        }
+      ]
+    },
+    {
+      "type": "section",
+      "title": "Verify migrated resources",
+      "blocks": [
+        {
+          "type": "markdown",
+          "content": "You'll verify that dashboards, data sources, and alerting resources transferred correctly to your Cloud stack."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Complete the **Connect to Grafana Cloud**, **Build a migration snapshot**, and **Upload resources to Grafana Cloud** sections in the self-managed guide before continuing."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "a[data-testid='data-testid Nav menu item'][href='/dashboards']",
+          "content": "Navigate to **Dashboards** and verify that your folder structure is preserved and dashboards appear in their expected locations.",
+          "requirements": ["navmenu-open"]
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Open a migrated dashboard and confirm that visualizations render correctly, data source connections work, and queries return expected data."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "a[data-testid='data-testid Nav menu item'][href='/connections']",
+          "content": "Navigate to **Connections** and verify your data sources were migrated with their credentials.",
+          "requirements": ["navmenu-open"]
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "a[data-testid='data-testid Nav menu item'][href='/alerting/list']",
+          "content": "Navigate to **Alerting** > **Alert rules** and verify that migrated alert rules are present in a paused state.",
+          "requirements": ["navmenu-open"],
+          "skippable": true
+        },
+        {
+          "type": "markdown",
+          "content": "You verified that dashboards, data sources, and alert rules transferred correctly to Grafana Cloud."
+        }
+      ]
+    },
+    {
+      "type": "section",
+      "title": "Activate alert rules",
+      "blocks": [
+        {
+          "type": "markdown",
+          "content": "You'll resume paused alert rules so they begin evaluating in Grafana Cloud — skip this section if you did not migrate alerting resources."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "a[data-testid='data-testid Nav menu item'][href='/alerting/list']",
+          "content": "Navigate to **Alerting** > **Alert rules**.",
+          "requirements": ["navmenu-open"]
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Before resuming rules here, disable or silence the corresponding alerts in your self-managed instance to prevent duplicate notifications.",
+          "skippable": true
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Locate the folder containing your migrated alert rules, click its **Actions** menu, and select **Resume all rule evaluation**. Repeat for each folder with paused rules.",
+          "skippable": true
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Verify that resumed alert rules show a **Normal** state and that notifications reach the correct contact points.",
+          "skippable": true
+        },
+        {
+          "type": "markdown",
+          "content": "You activated alert rules in Grafana Cloud and confirmed they evaluate and notify correctly."
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "You completed the cloud-side migration steps: token generation, resource verification, and alert rule activation."
+    }
+  ]
+}

--- a/cloud-migration-assistant-lj/cloud/content.json
+++ b/cloud-migration-assistant-lj/cloud/content.json
@@ -1,6 +1,6 @@
 {
   "id": "cloud-migration-assistant-cloud",
-  "title": "Migrate to Grafana Cloud — Cloud steps",
+  "title": "Migrate to Grafana Cloud \u2014 Cloud steps",
   "blocks": [
     {
       "type": "markdown",
@@ -19,20 +19,23 @@
           "action": "highlight",
           "reftarget": "a[data-testid='data-testid Nav menu item'][href='/admin/migrate-to-cloud']",
           "content": "Open the navigation menu and select **Administration** > **General** > **Migrate to Grafana Cloud**.",
-          "requirements": ["navmenu-open"]
+          "requirements": [
+            "navmenu-open"
+          ]
         },
         {
           "type": "interactive",
           "action": "button",
           "reftarget": "Generate a migration token",
           "content": "Click **Generate a migration token**.",
-          "requirements": ["on-page:/admin/migrate-to-cloud"],
+          "requirements": [
+            "on-page:/admin/migrate-to-cloud"
+          ],
           "doIt": false
         },
         {
-          "type": "interactive",
-          "action": "noop",
-          "content": "Copy the migration token and store it securely — you need it to connect your self-managed instance."
+          "type": "markdown",
+          "content": "Copy the migration token and store it securely \u2014 you need it to connect your self-managed instance."
         },
         {
           "type": "markdown",
@@ -49,8 +52,7 @@
           "content": "You'll verify that dashboards, data sources, and alerting resources transferred correctly to your Cloud stack."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Complete the **Connect to Grafana Cloud**, **Build a migration snapshot**, and **Upload resources to Grafana Cloud** sections in the self-managed guide before continuing."
         },
         {
@@ -58,11 +60,12 @@
           "action": "highlight",
           "reftarget": "a[data-testid='data-testid Nav menu item'][href='/dashboards']",
           "content": "Navigate to **Dashboards** and verify that your folder structure is preserved and dashboards appear in their expected locations.",
-          "requirements": ["navmenu-open"]
+          "requirements": [
+            "navmenu-open"
+          ]
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Open a migrated dashboard and confirm that visualizations render correctly, data source connections work, and queries return expected data."
         },
         {
@@ -70,14 +73,18 @@
           "action": "highlight",
           "reftarget": "a[data-testid='data-testid Nav menu item'][href='/connections']",
           "content": "Navigate to **Connections** and verify your data sources were migrated with their credentials.",
-          "requirements": ["navmenu-open"]
+          "requirements": [
+            "navmenu-open"
+          ]
         },
         {
           "type": "interactive",
           "action": "highlight",
           "reftarget": "a[data-testid='data-testid Nav menu item'][href='/alerting/list']",
           "content": "Navigate to **Alerting** > **Alert rules** and verify that migrated alert rules are present in a paused state.",
-          "requirements": ["navmenu-open"],
+          "requirements": [
+            "navmenu-open"
+          ],
           "skippable": true
         },
         {
@@ -92,32 +99,28 @@
       "blocks": [
         {
           "type": "markdown",
-          "content": "You'll resume paused alert rules so they begin evaluating in Grafana Cloud — skip this section if you did not migrate alerting resources."
+          "content": "You'll resume paused alert rules so they begin evaluating in Grafana Cloud \u2014 skip this section if you did not migrate alerting resources."
         },
         {
           "type": "interactive",
           "action": "highlight",
           "reftarget": "a[data-testid='data-testid Nav menu item'][href='/alerting/list']",
           "content": "Navigate to **Alerting** > **Alert rules**.",
-          "requirements": ["navmenu-open"]
+          "requirements": [
+            "navmenu-open"
+          ]
         },
         {
-          "type": "interactive",
-          "action": "noop",
-          "content": "Before resuming rules here, disable or silence the corresponding alerts in your self-managed instance to prevent duplicate notifications.",
-          "skippable": true
+          "type": "markdown",
+          "content": "Before resuming rules here, disable or silence the corresponding alerts in your self-managed instance to prevent duplicate notifications."
         },
         {
-          "type": "interactive",
-          "action": "noop",
-          "content": "Locate the folder containing your migrated alert rules, click its **Actions** menu, and select **Resume all rule evaluation**. Repeat for each folder with paused rules.",
-          "skippable": true
+          "type": "markdown",
+          "content": "Locate the folder containing your migrated alert rules, click its **Actions** menu, and select **Resume all rule evaluation**. Repeat for each folder with paused rules."
         },
         {
-          "type": "interactive",
-          "action": "noop",
-          "content": "Verify that resumed alert rules show a **Normal** state and that notifications reach the correct contact points.",
-          "skippable": true
+          "type": "markdown",
+          "content": "Verify that resumed alert rules show a **Normal** state and that notifications reach the correct contact points."
         },
         {
           "type": "markdown",

--- a/cloud-migration-assistant-lj/cloud/content.json
+++ b/cloud-migration-assistant-lj/cloud/content.json
@@ -1,10 +1,10 @@
 {
   "id": "cloud-migration-assistant-cloud",
-  "title": "Migrate to Grafana Cloud \u2014 Cloud steps",
+  "title": "Migrate to Grafana Cloud — Cloud steps",
   "blocks": [
     {
       "type": "markdown",
-      "content": "This guide covers the steps you perform in your Grafana Cloud instance during a migration: generating a migration token, verifying migrated resources, and activating alert rules."
+      "content": "This guide walks you through the steps performed in your **Grafana Cloud** instance during a migration. You should complete these steps alongside the self-managed steps guide, which covers actions performed on your self-managed Grafana instance."
     },
     {
       "type": "section",
@@ -12,16 +12,21 @@
       "blocks": [
         {
           "type": "markdown",
-          "content": "You'll generate a secure token that authenticates your self-managed instance with this Grafana Cloud stack."
+          "content": "The migration token authenticates your self-managed instance with your Grafana Cloud stack, establishing a secure connection for resource transfer. This token enables encrypted communication between the two instances and ensures that only authorized migrations can occur."
+        },
+        {
+          "type": "markdown",
+          "content": "Sign in to your Grafana Cloud instance, for example `mystack.grafana.net`."
         },
         {
           "type": "interactive",
           "action": "highlight",
           "reftarget": "a[data-testid='data-testid Nav menu item'][href='/admin/migrate-to-cloud']",
-          "content": "Open the navigation menu and select **Administration** > **General** > **Migrate to Grafana Cloud**.",
+          "content": "Open the navigation menu on the left side of the screen and select **Administration** > **General** > **Migrate to Grafana Cloud**.",
           "requirements": [
             "navmenu-open"
-          ]
+          ],
+          "doIt": false
         },
         {
           "type": "interactive",
@@ -35,11 +40,29 @@
         },
         {
           "type": "markdown",
-          "content": "Copy the migration token and store it securely \u2014 you need it to connect your self-managed instance."
+          "content": "Copy the migration token to your clipboard. Store this token securely — you need it to connect your self-managed instance to Grafana Cloud."
         },
         {
           "type": "markdown",
-          "content": "You generated a migration token that your self-managed instance uses to authenticate with Grafana Cloud."
+          "content": "The token is displayed and ready to copy. Return to the self-managed steps guide to connect your self-managed instance using this token."
+        }
+      ]
+    },
+    {
+      "type": "section",
+      "title": "Connect and upload from self-managed",
+      "blocks": [
+        {
+          "type": "markdown",
+          "content": "You'll complete the connection, snapshot, and upload steps on your self-managed Grafana instance."
+        },
+        {
+          "type": "markdown",
+          "content": "Complete the **Connect instances**, **Build snapshot**, and **Upload snapshot** steps in the self-managed guide on your self-managed Grafana instance."
+        },
+        {
+          "type": "markdown",
+          "content": "Once the upload is complete, return here to verify your migrated resources."
         }
       ]
     },
@@ -49,88 +72,141 @@
       "blocks": [
         {
           "type": "markdown",
-          "content": "You'll verify that dashboards, data sources, and alerting resources transferred correctly to your Cloud stack."
+          "content": "Verification ensures your migrated resources work correctly in Grafana Cloud and that all configurations were preserved during migration. This step helps identify any issues before you switch users to the cloud environment."
         },
         {
           "type": "markdown",
-          "content": "Complete the **Connect to Grafana Cloud**, **Build a migration snapshot**, and **Upload resources to Grafana Cloud** sections in the self-managed guide before continuing."
+          "content": "Sign in to your Grafana Cloud instance."
         },
         {
           "type": "interactive",
           "action": "highlight",
           "reftarget": "a[data-testid='data-testid Nav menu item'][href='/dashboards']",
-          "content": "Navigate to **Dashboards** and verify that your folder structure is preserved and dashboards appear in their expected locations.",
+          "content": "Navigate to **Home** > **Dashboards** to view your migrated dashboards. Verify that your folder structure is preserved and dashboards appear in their original locations.",
           "requirements": [
             "navmenu-open"
-          ]
+          ],
+          "doIt": false
         },
         {
           "type": "markdown",
-          "content": "Open a migrated dashboard and confirm that visualizations render correctly, data source connections work, and queries return expected data."
+          "content": "Open a migrated dashboard and verify:\n\n- Visualizations render correctly\n- Data source connections work\n- Queries return expected data"
         },
         {
           "type": "interactive",
           "action": "highlight",
           "reftarget": "a[data-testid='data-testid Nav menu item'][href='/connections']",
-          "content": "Navigate to **Connections** and verify your data sources were migrated with their credentials.",
+          "content": "Navigate to **Connections** > **Data sources** to verify your data sources were migrated with their credentials.",
           "requirements": [
             "navmenu-open"
-          ]
+          ],
+          "doIt": false
         },
         {
           "type": "interactive",
           "action": "highlight",
           "reftarget": "a[data-testid='data-testid Nav menu item'][href='/alerting/list']",
-          "content": "Navigate to **Alerting** > **Alert rules** and verify that migrated alert rules are present in a paused state.",
+          "content": "If you migrated alerting resources, navigate to **Alerts & IRM** > **Alerting** > **Alert rules** to verify alert rules are present. By default, alert rules are migrated in a 'paused' state to prevent duplicate notifications from both your self-managed and cloud instances.",
           "requirements": [
             "navmenu-open"
           ],
-          "skippable": true
+          "doIt": false
         },
         {
           "type": "markdown",
-          "content": "You verified that dashboards, data sources, and alert rules transferred correctly to Grafana Cloud."
+          "content": "Check the UIDs of migrated resources match the originals, allowing you to correlate resources between instances."
+        },
+        {
+          "type": "markdown",
+          "content": "Your resources appear in Grafana Cloud with preserved folder structures, working data source connections, and correct configurations."
         }
       ]
     },
     {
       "type": "section",
-      "title": "Activate alert rules",
+      "title": "Manually resume alert rules",
       "blocks": [
         {
           "type": "markdown",
-          "content": "You'll resume paused alert rules so they begin evaluating in Grafana Cloud \u2014 skip this section if you did not migrate alerting resources."
+          "content": "Alert rules are migrated in a paused state by default to prevent duplicate notifications from both your self-managed and cloud instances. Once you've verified your alerting configuration works correctly in Grafana Cloud, you can activate your alert rules."
         },
         {
           "type": "interactive",
           "action": "highlight",
           "reftarget": "a[data-testid='data-testid Nav menu item'][href='/alerting/list']",
-          "content": "Navigate to **Alerting** > **Alert rules**.",
+          "content": "In your Grafana Cloud instance, navigate to **Alerts & IRM** > **Alerting** > **Alert rules**.",
           "requirements": [
             "navmenu-open"
-          ]
+          ],
+          "doIt": false
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[role='radiogroup']:has(input[id^='option-grouped'])",
+          "content": "Ensure you are in the **Grouped** view. This is the default view and shows alert rules organized by folder.",
+          "requirements": [
+            "on-page:/alerting/list"
+          ],
+          "doIt": false
         },
         {
           "type": "markdown",
-          "content": "Before resuming rules here, disable or silence the corresponding alerts in your self-managed instance to prevent duplicate notifications."
+          "content": "Before resuming alert rules here, disable or silence the corresponding alerts in your self-managed instance to avoid receiving duplicate notifications."
         },
         {
           "type": "markdown",
-          "content": "Locate the folder containing your migrated alert rules, click its **Actions** menu, and select **Resume all rule evaluation**. Repeat for each folder with paused rules."
+          "content": "Locate the folder containing your migrated alert rules."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[role='treeitem']:first-child [aria-label='Folder actions']",
+          "content": "Click the **Actions** button next to the folder name and select **Resume all rule evaluation**. This resumes all alert rules within that folder. To resume a specific rule instead, click the **More** button next to the rule name and select **Resume rule evaluation**.",
+          "requirements": [
+            "on-page:/alerting/list"
+          ],
+          "doIt": false
         },
         {
           "type": "markdown",
-          "content": "Verify that resumed alert rules show a **Normal** state and that notifications reach the correct contact points."
+          "content": "Repeat for each folder or specific rule containing paused alert rules. There is no single button to resume all rules at once — you must resume them per folder or per rule."
         },
         {
           "type": "markdown",
-          "content": "You activated alert rules in Grafana Cloud and confirmed they evaluate and notify correctly."
+          "content": "Verify that alert rules show a **Normal** state."
+        },
+        {
+          "type": "markdown",
+          "content": "Monitor alert notifications to confirm they fire correctly and reach the right contact points."
+        },
+        {
+          "type": "markdown",
+          "content": "Your alert rules are now active and sending notifications through the correct contact points."
+        }
+      ]
+    },
+    {
+      "type": "section",
+      "title": "Re-migrate alert rules in an active state",
+      "blocks": [
+        {
+          "type": "markdown",
+          "content": "As an alternative to manually resuming rules, you can re-migrate alert rules in their original active state from your self-managed instance."
+        },
+        {
+          "type": "markdown",
+          "content": "If you prefer to migrate alert rules in their original state, you can configure a setting on your self-managed instance and re-upload the snapshot. Switch to the **self-managed guide** and follow the optional **Re-migrate alert rules in an active state** section to complete this from your self-managed instance."
+        },
+        {
+          "type": "markdown",
+          "content": "After re-uploading, your alert rules will reflect their original state in Grafana Cloud."
         }
       ]
     },
     {
       "type": "markdown",
-      "content": "You completed the cloud-side migration steps: token generation, resource verification, and alert rule activation."
+      "content": "Congratulations on completing this journey! You have:\n\n- Understood the value of automated migration to Grafana Cloud\n- Verified the prerequisites for a successful migration\n- Generated a secure migration token on your Grafana Cloud instance\n- Connected your self-managed instance to Grafana Cloud\n- Built a snapshot of your Grafana resources\n- Uploaded resources to Grafana Cloud with real-time progress tracking\n- Verified your migrated resources in Grafana Cloud\n- Activated alert rules in Grafana Cloud or re-migrated them in an active state\n- Gained confidence in managing cloud migrations efficiently"
     }
   ]
 }

--- a/cloud-migration-assistant-lj/cloud/content.json
+++ b/cloud-migration-assistant-lj/cloud/content.json
@@ -21,8 +21,8 @@
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "a[data-testid='data-testid Nav menu item'][href='/admin/migrate-to-cloud']",
-          "content": "Open the navigation menu on the left side of the screen and select **Administration** > **General** > **Migrate to Grafana Cloud**.",
+          "reftarget": "a[data-testid='data-testid Nav menu item'][href='/admin']",
+          "content": "Select **Administration** > **General** > **Migrate to Grafana Cloud**.",
           "requirements": [
             "navmenu-open"
           ],

--- a/cloud-migration-assistant-lj/cloud/manifest.json
+++ b/cloud-migration-assistant-lj/cloud/manifest.json
@@ -1,0 +1,12 @@
+{
+  "id": "cloud-migration-assistant-cloud",
+  "type": "guide",
+  "description": "Generate a migration token, verify migrated resources, and activate alert rules in your Grafana Cloud stack.",
+  "category": "cloud-migration",
+  "author": { "team": "Grafana Documentation", "name": "jvaldez" },
+  "testEnvironment": { "tier": "cloud" },
+  "depends": [],
+  "recommends": ["cloud-migration-assistant-oss"],
+  "suggests": [],
+  "provides": []
+}

--- a/cloud-migration-assistant-lj/content.json
+++ b/cloud-migration-assistant-lj/content.json
@@ -8,7 +8,7 @@
     },
     {
       "type": "markdown",
-      "content": "This journey spans two Grafana instances. The **Cloud** guide covers token generation and resource verification on your Grafana Cloud stack. The **Self-managed** guide covers connecting, building a snapshot, and uploading resources from your on-premise instance."
+      "content": "This journey spans two Grafana instances. The **Cloud** guide covers token generation and resource verification on your Grafana Cloud stack. The **Self-managed** guide covers connecting, building a snapshot, and uploading resources from your self-managed instance."
     },
     {
       "type": "markdown",

--- a/cloud-migration-assistant-lj/content.json
+++ b/cloud-migration-assistant-lj/content.json
@@ -1,0 +1,22 @@
+{
+  "id": "cloud-migration-assistant-lj",
+  "title": "Migrate to Grafana Cloud with the Migration Assistant",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "The Grafana Cloud Migration Assistant automates moving dashboards, data sources, folders, plugins, library panels, and alerting resources from a self-managed Grafana instance to Grafana Cloud."
+    },
+    {
+      "type": "markdown",
+      "content": "This journey spans two Grafana instances. The **Cloud** guide covers token generation and resource verification on your Grafana Cloud stack. The **Self-managed** guide covers connecting, building a snapshot, and uploading resources from your on-premise instance."
+    },
+    {
+      "type": "markdown",
+      "content": "### Before you begin"
+    },
+    {
+      "type": "markdown",
+      "content": "Ensure you have:\n\n- Grafana server administrator access on the self-managed instance\n- Admin role access on your Grafana Cloud stack\n- Internet access from the self-managed instance\n- A single-replica deployment (scale down HA setups before migrating)"
+    }
+  ]
+}

--- a/cloud-migration-assistant-lj/manifest.json
+++ b/cloud-migration-assistant-lj/manifest.json
@@ -1,0 +1,24 @@
+{
+  "id": "cloud-migration-assistant-lj",
+  "type": "path",
+  "description": "Migrate dashboards, data sources, folders, plugins, and alerting resources from self-managed Grafana to Grafana Cloud using the Migration Assistant.",
+  "category": "cloud-migration",
+  "author": { "team": "Grafana Documentation", "name": "jvaldez" },
+  "startingLocation": "/admin/migrate-to-cloud",
+  "targeting": {
+    "match": {
+      "or": [
+        { "urlPrefix": "/admin/migrate-to-cloud" }
+      ]
+    }
+  },
+  "testEnvironment": { "tier": "cloud" },
+  "milestones": [
+    "cloud-migration-assistant-cloud",
+    "cloud-migration-assistant-oss"
+  ],
+  "depends": [],
+  "recommends": [],
+  "suggests": [],
+  "provides": []
+}

--- a/cloud-migration-assistant-lj/oss/content.json
+++ b/cloud-migration-assistant-lj/oss/content.json
@@ -1,0 +1,208 @@
+{
+  "id": "cloud-migration-assistant-oss",
+  "title": "Migrate to Grafana Cloud — Self-managed steps",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "This guide walks you through the steps performed on your self-managed Grafana instance: connecting to Grafana Cloud, building a migration snapshot, and uploading your resources."
+    },
+    {
+      "type": "section",
+      "title": "Verify prerequisites",
+      "blocks": [
+        {
+          "type": "markdown",
+          "content": "You'll confirm your environment meets the requirements for a successful migration."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Verify you have Grafana server administrator access on this self-managed instance and Admin role access on your target Grafana Cloud stack."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Confirm this instance has internet access. If you use a highly available setup, scale down to a single replica before migrating."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "If your network uses an allowlist, add the required Grafana Cloud IPs and URLs. Refer to the [Grafana Cloud Migration Assistant documentation](https://grafana.com/docs/grafana/latest/administration/migrate-to-grafana-cloud/) for the current list."
+        },
+        {
+          "type": "markdown",
+          "content": "You confirmed your environment is ready for migration."
+        }
+      ]
+    },
+    {
+      "type": "section",
+      "title": "Connect to Grafana Cloud",
+      "blocks": [
+        {
+          "type": "markdown",
+          "content": "You'll connect this self-managed instance to your Grafana Cloud stack using the migration token generated in the Cloud guide."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "a[data-testid='data-testid Nav menu item'][href='/admin/migrate-to-cloud']",
+          "content": "Open the navigation menu and select **Administration** > **General** > **Migrate to Grafana Cloud**.",
+          "requirements": ["navmenu-open"]
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='migrate-to-cloud-connect-session-modal-button']",
+          "content": "Click **Migrate this instance to Cloud**.",
+          "requirements": ["on-page:/admin/migrate-to-cloud"],
+          "doIt": false
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Paste the migration token from your Cloud instance into the **Migration token** field and click **Connect to this Stack**."
+        },
+        {
+          "type": "markdown",
+          "content": "You connected your self-managed instance to Grafana Cloud and can now build a migration snapshot."
+        }
+      ]
+    },
+    {
+      "type": "section",
+      "title": "Build a migration snapshot",
+      "blocks": [
+        {
+          "type": "markdown",
+          "content": "You'll select which resources to migrate and create a snapshot of their current state."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "div:has(> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-'])",
+          "content": "Review the available resource types: dashboards, folders, data sources, app plugins, panel plugins, library panels, and alerting resources.",
+          "requirements": ["on-page:/admin/migrate-to-cloud"]
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Select the checkbox next to each resource type you want to migrate. Dependencies are automatically included when you select a resource that requires them."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='migrate-to-cloud-configure-snapshot-build-snapshot-button']",
+          "content": "Click **Build snapshot**.",
+          "requirements": ["on-page:/admin/migrate-to-cloud"],
+          "doIt": false
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Wait for the snapshot to complete. The interface displays progress as resources are captured."
+        },
+        {
+          "type": "markdown",
+          "content": "You created a snapshot of your selected resources, ready for upload to Grafana Cloud."
+        }
+      ]
+    },
+    {
+      "type": "section",
+      "title": "Upload resources to Grafana Cloud",
+      "blocks": [
+        {
+          "type": "markdown",
+          "content": "You'll upload the snapshot to transfer your resources to Grafana Cloud with real-time progress tracking."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='migrate-to-cloud-summary-upload-snapshot-button']",
+          "content": "Click **Upload snapshot** to begin the transfer.",
+          "requirements": ["on-page:/admin/migrate-to-cloud"],
+          "doIt": false
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Monitor the real-time progress as the **Status** column updates for each resource. Successfully migrated resources show **Uploaded to cloud**."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "For any resources with errors, expand the error details to understand what requires manual resolution."
+        },
+        {
+          "type": "markdown",
+          "content": "You uploaded your resources to Grafana Cloud and can now verify them in your Cloud instance using the Cloud guide."
+        }
+      ]
+    },
+    {
+      "type": "section",
+      "title": "Re-migrate alert rules as active (optional)",
+      "blocks": [
+        {
+          "type": "markdown",
+          "content": "You'll optionally re-migrate alert rules in their original active state instead of manually resuming them in Cloud."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Edit your Grafana configuration file (`grafana.ini` or `custom.ini`) and add:\n\n```ini\n[cloud_migration]\nalert_rules_state = unchanged\n```",
+          "skippable": true
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Save the configuration file and restart your Grafana instance.",
+          "skippable": true
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "a[data-testid='data-testid Nav menu item'][href='/admin/migrate-to-cloud']",
+          "content": "Navigate back to **Administration** > **General** > **Migrate to Grafana Cloud**.",
+          "requirements": ["navmenu-open"],
+          "skippable": true
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='migrate-to-cloud-summary-reconfigure-snapshot-button']",
+          "content": "Click **Reconfigure snapshot** to return to the resource selection screen.",
+          "requirements": ["on-page:/admin/migrate-to-cloud"],
+          "skippable": true
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='migrate-to-cloud-configure-snapshot-build-snapshot-button']",
+          "content": "Select your resources and click **Build snapshot** to create a new snapshot with the updated alert rule state.",
+          "requirements": ["on-page:/admin/migrate-to-cloud"],
+          "doIt": false,
+          "skippable": true
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='migrate-to-cloud-summary-upload-snapshot-button']",
+          "content": "Click **Upload snapshot** to re-upload your resources. Alert rules are migrated in their original state without creating duplicates.",
+          "requirements": ["on-page:/admin/migrate-to-cloud"],
+          "doIt": false,
+          "skippable": true
+        },
+        {
+          "type": "markdown",
+          "content": "You re-migrated alert rules in their original active state, avoiding the need to manually resume them in Cloud."
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "You completed the self-managed migration steps. Switch to the Cloud guide to verify your resources and activate alert rules in Grafana Cloud."
+    }
+  ]
+}

--- a/cloud-migration-assistant-lj/oss/content.json
+++ b/cloud-migration-assistant-lj/oss/content.json
@@ -55,22 +55,18 @@
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "a[data-testid='data-testid Nav menu item'][href='/admin/migrate-to-cloud']",
-          "content": "Navigate to **Home** > **Administration** > **General** > **Migrate to Grafana Cloud**.",
+          "reftarget": "a[data-testid='data-testid Nav menu item'][href='/admin']",
+          "content": "Navigate to **Administration** > **General** > **Migrate to Grafana Cloud**.",
           "requirements": [
             "navmenu-open"
           ],
           "doIt": false
         },
         {
-          "type": "markdown",
-          "content": "Next, you'll click **Migrate this instance to Cloud**. A modal will appear where you need to:\n\n1. Paste your migration token into the **Migration token** field\n2. Click **Connect to this Stack**"
-        },
-        {
           "type": "interactive",
           "action": "highlight",
           "reftarget": "[data-testid='migrate-to-cloud-connect-session-modal-button']",
-          "content": "Click **Migrate this instance to Cloud**, then paste your token and click **Connect to this Stack** in the modal that appears.",
+          "content": "Click **Migrate this instance to Cloud**. A modal appears where you need to:\n\n1. Paste your migration token into the **Migration token** field\n2. Click **Connect to this Stack**",
           "requirements": [
             "on-page:/admin/migrate-to-cloud"
           ],
@@ -223,7 +219,7 @@
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "a[data-testid='data-testid Nav menu item'][href='/admin/migrate-to-cloud']",
+          "reftarget": "a[data-testid='data-testid Nav menu item'][href='/admin']",
           "content": "Navigate back to **Administration** > **General** > **Migrate to Grafana Cloud**.",
           "requirements": [
             "navmenu-open"

--- a/cloud-migration-assistant-lj/oss/content.json
+++ b/cloud-migration-assistant-lj/oss/content.json
@@ -1,59 +1,76 @@
 {
   "id": "cloud-migration-assistant-oss",
-  "title": "Migrate to Grafana Cloud \u2014 Self-managed steps",
+  "title": "Migrate to Grafana Cloud — Self-managed steps",
   "blocks": [
     {
       "type": "markdown",
-      "content": "This guide walks you through the steps performed on your self-managed Grafana instance: connecting to Grafana Cloud, building a migration snapshot, and uploading your resources."
+      "content": "Migrating from a self-managed Grafana instance to Grafana Cloud traditionally requires extensive API knowledge, custom scripts, and manual configuration of each resource. This process can take hours or days, depending on the complexity of your environment, and is prone to errors that can disrupt monitoring and alerting workflows."
+    },
+    {
+      "type": "markdown",
+      "content": "The Grafana Cloud Migration Assistant eliminates these challenges by automating the entire migration process. With a simple UI-guided workflow, you can securely migrate dashboards, data sources, folders, plugins, library panels, and alerting resources to Grafana Cloud in minutes, with real-time progress tracking and automatic validation."
+    },
+    {
+      "type": "markdown",
+      "content": "The Grafana Cloud Migration Assistant provides the following advantages over manual migration:\n\n- Eliminate the need for API knowledge or scripting\n- Migrate all resources in minutes instead of hours or days\n- Securely transfer credentials and sensitive data with encryption\n- Preserve resource UIDs and folder hierarchies automatically\n- Track migration progress in real-time with detailed status updates\n- Reduce errors through automated validation and verification"
+    },
+    {
+      "type": "markdown",
+      "content": "Successful migrations require proper preparation of both your self-managed Grafana instance and your Grafana Cloud environment. Taking time to verify these prerequisites prevents migration issues and ensures a smooth transition."
+    },
+    {
+      "type": "markdown",
+      "content": "Before starting your migration, verify the following prerequisites:\n\n1. Ensure you have Grafana server administrator access on the self-managed instance\n2. Confirm you have Admin role access on your Grafana Cloud stack\n3. Verify your self-managed instance has internet access\n4. If using a highly-available setup, scale down to one replica\n5. Add required IPs and URLs to your network allowlist (if applicable)"
     },
     {
       "type": "section",
-      "title": "Verify prerequisites",
+      "title": "Generate a migration token",
       "blocks": [
         {
           "type": "markdown",
-          "content": "You'll confirm your environment meets the requirements for a successful migration."
+          "content": "You'll generate the migration token on your Grafana Cloud instance."
         },
         {
           "type": "markdown",
-          "content": "Verify you have Grafana server administrator access on this self-managed instance and Admin role access on your target Grafana Cloud stack."
+          "content": "Complete this step in your **Grafana Cloud stack** to generate a migration token. Open the Cloud guide in your interactive learning when you're in your Cloud environment."
         },
         {
           "type": "markdown",
-          "content": "Confirm this instance has internet access. If you use a highly available setup, scale down to a single replica before migrating."
-        },
-        {
-          "type": "markdown",
-          "content": "If your network uses an allowlist, add the required Grafana Cloud IPs and URLs. Refer to the [Grafana Cloud Migration Assistant documentation](https://grafana.com/docs/grafana/latest/administration/migrate-to-grafana-cloud/) for the current list."
-        },
-        {
-          "type": "markdown",
-          "content": "You confirmed your environment is ready for migration."
+          "content": "Once you have the token, return to this guide to connect your self-managed instance."
         }
       ]
     },
     {
       "type": "section",
-      "title": "Connect to Grafana Cloud",
+      "title": "Connect instances",
       "blocks": [
         {
           "type": "markdown",
-          "content": "You'll connect this self-managed instance to your Grafana Cloud stack using the migration token generated in the Cloud guide."
+          "content": "Connecting your self-managed instance to Grafana Cloud establishes a secure link between the two environments, enabling resource migration. The migration token authenticates this connection and verifies that both instances can communicate. This connection is read-only from the self-managed instance and won't modify your existing resources."
+        },
+        {
+          "type": "markdown",
+          "content": "Sign in to your self-managed Grafana instance as a server administrator."
         },
         {
           "type": "interactive",
           "action": "highlight",
           "reftarget": "a[data-testid='data-testid Nav menu item'][href='/admin/migrate-to-cloud']",
-          "content": "Open the navigation menu and select **Administration** > **General** > **Migrate to Grafana Cloud**.",
+          "content": "Navigate to **Home** > **Administration** > **General** > **Migrate to Grafana Cloud**.",
           "requirements": [
             "navmenu-open"
-          ]
+          ],
+          "doIt": false
+        },
+        {
+          "type": "markdown",
+          "content": "Next, you'll click **Migrate this instance to Cloud**. A modal will appear where you need to:\n\n1. Paste your migration token into the **Migration token** field\n2. Click **Connect to this Stack**"
         },
         {
           "type": "interactive",
           "action": "highlight",
           "reftarget": "[data-testid='migrate-to-cloud-connect-session-modal-button']",
-          "content": "Click **Migrate this instance to Cloud**.",
+          "content": "Click **Migrate this instance to Cloud**, then paste your token and click **Connect to this Stack** in the modal that appears.",
           "requirements": [
             "on-page:/admin/migrate-to-cloud"
           ],
@@ -61,34 +78,31 @@
         },
         {
           "type": "markdown",
-          "content": "Paste the migration token from your Cloud instance into the **Migration token** field and click **Connect to this Stack**."
-        },
-        {
-          "type": "markdown",
-          "content": "You connected your self-managed instance to Grafana Cloud and can now build a migration snapshot."
+          "content": "The connection is established and you see the migration assistant interface with options to build a snapshot."
         }
       ]
     },
     {
       "type": "section",
-      "title": "Build a migration snapshot",
+      "title": "Build snapshot",
       "blocks": [
         {
           "type": "markdown",
-          "content": "You'll select which resources to migrate and create a snapshot of their current state."
+          "content": "A snapshot captures the current state of your selected resources and stores them locally on your instance, ready for upload to Grafana Cloud. The snapshot includes all resource metadata, configurations, and dependencies. When you select a resource that requires other resources, the Migration Assistant automatically includes those dependencies in the snapshot."
         },
         {
           "type": "interactive",
           "action": "highlight",
           "reftarget": "div:has(> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-'])",
-          "content": "Review the available resource types: dashboards, folders, data sources, app plugins, panel plugins, library panels, and alerting resources.",
+          "content": "Review the available resources for migration displayed in the migration assistant interface.",
           "requirements": [
             "on-page:/admin/migrate-to-cloud"
-          ]
+          ],
+          "doIt": false
         },
         {
           "type": "markdown",
-          "content": "Select the checkbox next to each resource type you want to migrate. Dependencies are automatically included when you select a resource that requires them."
+          "content": "Select the checkbox next to each resource type you want to migrate: **Dashboards**, **Folders**, **Data sources**, **App Plugins**, **Panel Plugins**, **Library Panels**, and **Grafana Alerting resources**. When you select a resource that depends on other resources, those dependencies are automatically included."
         },
         {
           "type": "interactive",
@@ -102,27 +116,37 @@
         },
         {
           "type": "markdown",
-          "content": "Wait for the snapshot to complete. The interface displays progress as resources are captured."
+          "content": "Wait for the snapshot creation to complete. The interface displays progress as resources are captured."
         },
         {
           "type": "markdown",
-          "content": "You created a snapshot of your selected resources, ready for upload to Grafana Cloud."
+          "content": "The snapshot is created and a list of resources appears with Type and Status columns showing 'Not yet uploaded' for each resource."
         }
       ]
     },
     {
       "type": "section",
-      "title": "Upload resources to Grafana Cloud",
+      "title": "Upload snapshot",
       "blocks": [
         {
           "type": "markdown",
-          "content": "You'll upload the snapshot to transfer your resources to Grafana Cloud with real-time progress tracking."
+          "content": "Uploading the snapshot securely transfers your resources to Grafana Cloud, where you can track progress in real-time and review any errors that need manual resolution. Resource UIDs are preserved during upload, allowing you to correlate local and cloud resources, and enabling you to re-run migrations to update resources if needed."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "div:has(> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button'])",
+          "content": "Review the snapshot summary showing the total number of resources ready for upload.",
+          "requirements": [
+            "on-page:/admin/migrate-to-cloud"
+          ],
+          "doIt": false
         },
         {
           "type": "interactive",
           "action": "highlight",
           "reftarget": "[data-testid='migrate-to-cloud-summary-upload-snapshot-button']",
-          "content": "Click **Upload snapshot** to begin the transfer.",
+          "content": "Click **Upload snapshot**.",
           "requirements": [
             "on-page:/admin/migrate-to-cloud"
           ],
@@ -130,7 +154,27 @@
         },
         {
           "type": "markdown",
-          "content": "Monitor the real-time progress as the **Status** column updates for each resource. Successfully migrated resources show **Uploaded to cloud**."
+          "content": "Monitor the real-time progress tracking as resources are migrated. The Status column updates to show resources being uploaded, successfully uploaded resources ('Uploaded to cloud'), and any resources with errors."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "tr:has(th)",
+          "content": "Use the column headers to organize the view. Click **Name** to sort alphabetically, **Type** to group by resource type, or **Status** to group by upload status.",
+          "requirements": [
+            "on-page:/admin/migrate-to-cloud"
+          ],
+          "doIt": false
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "div:has(> div > div > span [data-testid='migrate-to-cloud-summary-disconnect-button'])",
+          "content": "Review the updated snapshot information showing total resources, successful migrations, and any errors.",
+          "requirements": [
+            "on-page:/admin/migrate-to-cloud"
+          ],
+          "doIt": false
         },
         {
           "type": "markdown",
@@ -138,21 +182,39 @@
         },
         {
           "type": "markdown",
-          "content": "You uploaded your resources to Grafana Cloud and can now verify them in your Cloud instance using the Cloud guide."
+          "content": "The upload completes and you see resources marked as 'Uploaded to cloud' with the snapshot summary showing the number of successfully migrated resources."
         }
       ]
     },
     {
       "type": "section",
-      "title": "Re-migrate alert rules as active (optional)",
+      "title": "Verify and activate in Cloud",
       "blocks": [
         {
           "type": "markdown",
-          "content": "You'll optionally re-migrate alert rules in their original active state instead of manually resuming them in Cloud."
+          "content": "You'll verify your migrated resources and activate alert rules on your Grafana Cloud instance."
         },
         {
           "type": "markdown",
-          "content": "Edit your Grafana configuration file (`grafana.ini` or `custom.ini`) and add:\n\n```ini\n[cloud_migration]\nalert_rules_state = unchanged\n```"
+          "content": "Complete the remaining steps in your **Grafana Cloud stack** to verify migrated resources and activate alert rules. Open the Cloud guide in your interactive learning when you're in your Cloud environment."
+        },
+        {
+          "type": "markdown",
+          "content": "Once verification is complete, return here if you want to re-migrate alert rules in an active state."
+        }
+      ]
+    },
+    {
+      "type": "section",
+      "title": "Re-migrate alert rules in an active state",
+      "blocks": [
+        {
+          "type": "markdown",
+          "content": "After completing the initial migration and verifying your resources in Grafana Cloud, you may want to re-migrate alert rules in their original active state instead of manually resuming them. To do this, change a configuration setting on your self-managed instance and re-upload the snapshot. When you re-upload, resources with matching UIDs are updated rather than duplicated."
+        },
+        {
+          "type": "markdown",
+          "content": "Locate your Grafana configuration file (`grafana.ini` or `custom.ini`) and add or modify the following setting:\n\n```ini\n[cloud_migration]\nalert_rules_state = unchanged\n```"
         },
         {
           "type": "markdown",
@@ -166,7 +228,7 @@
           "requirements": [
             "navmenu-open"
           ],
-          "skippable": true
+          "doIt": false
         },
         {
           "type": "interactive",
@@ -176,7 +238,7 @@
           "requirements": [
             "on-page:/admin/migrate-to-cloud"
           ],
-          "skippable": true
+          "doIt": false
         },
         {
           "type": "interactive",
@@ -186,29 +248,23 @@
           "requirements": [
             "on-page:/admin/migrate-to-cloud"
           ],
-          "doIt": false,
-          "skippable": true
+          "doIt": false
         },
         {
           "type": "interactive",
           "action": "highlight",
           "reftarget": "[data-testid='migrate-to-cloud-summary-upload-snapshot-button']",
-          "content": "Click **Upload snapshot** to re-upload your resources. Alert rules are migrated in their original state without creating duplicates.",
+          "content": "Click **Upload snapshot** to re-upload your resources. Alert rules will be updated to reflect their original state without creating duplicates.",
           "requirements": [
             "on-page:/admin/migrate-to-cloud"
           ],
-          "doIt": false,
-          "skippable": true
+          "doIt": false
         },
         {
           "type": "markdown",
-          "content": "You re-migrated alert rules in their original active state, avoiding the need to manually resume them in Cloud."
+          "content": "In your Grafana Cloud instance, navigate to **Alerts & IRM** > **Alerting** > **Alert rules** and verify that alert rules now reflect their original state from your self-managed instance."
         }
       ]
-    },
-    {
-      "type": "markdown",
-      "content": "You completed the self-managed migration steps. Switch to the Cloud guide to verify your resources and activate alert rules in Grafana Cloud."
     }
   ]
 }

--- a/cloud-migration-assistant-lj/oss/content.json
+++ b/cloud-migration-assistant-lj/oss/content.json
@@ -1,6 +1,6 @@
 {
   "id": "cloud-migration-assistant-oss",
-  "title": "Migrate to Grafana Cloud — Self-managed steps",
+  "title": "Migrate to Grafana Cloud \u2014 Self-managed steps",
   "blocks": [
     {
       "type": "markdown",
@@ -15,18 +15,15 @@
           "content": "You'll confirm your environment meets the requirements for a successful migration."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Verify you have Grafana server administrator access on this self-managed instance and Admin role access on your target Grafana Cloud stack."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Confirm this instance has internet access. If you use a highly available setup, scale down to a single replica before migrating."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "If your network uses an allowlist, add the required Grafana Cloud IPs and URLs. Refer to the [Grafana Cloud Migration Assistant documentation](https://grafana.com/docs/grafana/latest/administration/migrate-to-grafana-cloud/) for the current list."
         },
         {
@@ -48,19 +45,22 @@
           "action": "highlight",
           "reftarget": "a[data-testid='data-testid Nav menu item'][href='/admin/migrate-to-cloud']",
           "content": "Open the navigation menu and select **Administration** > **General** > **Migrate to Grafana Cloud**.",
-          "requirements": ["navmenu-open"]
+          "requirements": [
+            "navmenu-open"
+          ]
         },
         {
           "type": "interactive",
           "action": "highlight",
           "reftarget": "[data-testid='migrate-to-cloud-connect-session-modal-button']",
           "content": "Click **Migrate this instance to Cloud**.",
-          "requirements": ["on-page:/admin/migrate-to-cloud"],
+          "requirements": [
+            "on-page:/admin/migrate-to-cloud"
+          ],
           "doIt": false
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Paste the migration token from your Cloud instance into the **Migration token** field and click **Connect to this Stack**."
         },
         {
@@ -82,11 +82,12 @@
           "action": "highlight",
           "reftarget": "div:has(> div > label [data-testid^='migrate-to-cloud-configure-snapshot-checkbox-resource-'])",
           "content": "Review the available resource types: dashboards, folders, data sources, app plugins, panel plugins, library panels, and alerting resources.",
-          "requirements": ["on-page:/admin/migrate-to-cloud"]
+          "requirements": [
+            "on-page:/admin/migrate-to-cloud"
+          ]
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Select the checkbox next to each resource type you want to migrate. Dependencies are automatically included when you select a resource that requires them."
         },
         {
@@ -94,12 +95,13 @@
           "action": "highlight",
           "reftarget": "[data-testid='migrate-to-cloud-configure-snapshot-build-snapshot-button']",
           "content": "Click **Build snapshot**.",
-          "requirements": ["on-page:/admin/migrate-to-cloud"],
+          "requirements": [
+            "on-page:/admin/migrate-to-cloud"
+          ],
           "doIt": false
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Wait for the snapshot to complete. The interface displays progress as resources are captured."
         },
         {
@@ -121,17 +123,17 @@
           "action": "highlight",
           "reftarget": "[data-testid='migrate-to-cloud-summary-upload-snapshot-button']",
           "content": "Click **Upload snapshot** to begin the transfer.",
-          "requirements": ["on-page:/admin/migrate-to-cloud"],
+          "requirements": [
+            "on-page:/admin/migrate-to-cloud"
+          ],
           "doIt": false
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Monitor the real-time progress as the **Status** column updates for each resource. Successfully migrated resources show **Uploaded to cloud**."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "For any resources with errors, expand the error details to understand what requires manual resolution."
         },
         {
@@ -149,23 +151,21 @@
           "content": "You'll optionally re-migrate alert rules in their original active state instead of manually resuming them in Cloud."
         },
         {
-          "type": "interactive",
-          "action": "noop",
-          "content": "Edit your Grafana configuration file (`grafana.ini` or `custom.ini`) and add:\n\n```ini\n[cloud_migration]\nalert_rules_state = unchanged\n```",
-          "skippable": true
+          "type": "markdown",
+          "content": "Edit your Grafana configuration file (`grafana.ini` or `custom.ini`) and add:\n\n```ini\n[cloud_migration]\nalert_rules_state = unchanged\n```"
         },
         {
-          "type": "interactive",
-          "action": "noop",
-          "content": "Save the configuration file and restart your Grafana instance.",
-          "skippable": true
+          "type": "markdown",
+          "content": "Save the configuration file and restart your Grafana instance."
         },
         {
           "type": "interactive",
           "action": "highlight",
           "reftarget": "a[data-testid='data-testid Nav menu item'][href='/admin/migrate-to-cloud']",
           "content": "Navigate back to **Administration** > **General** > **Migrate to Grafana Cloud**.",
-          "requirements": ["navmenu-open"],
+          "requirements": [
+            "navmenu-open"
+          ],
           "skippable": true
         },
         {
@@ -173,7 +173,9 @@
           "action": "highlight",
           "reftarget": "[data-testid='migrate-to-cloud-summary-reconfigure-snapshot-button']",
           "content": "Click **Reconfigure snapshot** to return to the resource selection screen.",
-          "requirements": ["on-page:/admin/migrate-to-cloud"],
+          "requirements": [
+            "on-page:/admin/migrate-to-cloud"
+          ],
           "skippable": true
         },
         {
@@ -181,7 +183,9 @@
           "action": "highlight",
           "reftarget": "[data-testid='migrate-to-cloud-configure-snapshot-build-snapshot-button']",
           "content": "Select your resources and click **Build snapshot** to create a new snapshot with the updated alert rule state.",
-          "requirements": ["on-page:/admin/migrate-to-cloud"],
+          "requirements": [
+            "on-page:/admin/migrate-to-cloud"
+          ],
           "doIt": false,
           "skippable": true
         },
@@ -190,7 +194,9 @@
           "action": "highlight",
           "reftarget": "[data-testid='migrate-to-cloud-summary-upload-snapshot-button']",
           "content": "Click **Upload snapshot** to re-upload your resources. Alert rules are migrated in their original state without creating duplicates.",
-          "requirements": ["on-page:/admin/migrate-to-cloud"],
+          "requirements": [
+            "on-page:/admin/migrate-to-cloud"
+          ],
           "doIt": false,
           "skippable": true
         },

--- a/cloud-migration-assistant-lj/oss/manifest.json
+++ b/cloud-migration-assistant-lj/oss/manifest.json
@@ -1,0 +1,12 @@
+{
+  "id": "cloud-migration-assistant-oss",
+  "type": "guide",
+  "description": "Connect your self-managed Grafana instance to Grafana Cloud, build a migration snapshot, and upload your resources.",
+  "category": "cloud-migration",
+  "author": { "team": "Grafana Documentation", "name": "jvaldez" },
+  "testEnvironment": { "tier": "local" },
+  "depends": ["cloud-migration-assistant-cloud"],
+  "recommends": [],
+  "suggests": [],
+  "provides": []
+}


### PR DESCRIPTION
Add a new learning journey that walks users through migrating resources from a self-managed Grafana instance to Grafana Cloud using the Migration Assistant.

The journey has two step guides — a Cloud guide (token generation, verification, alert activation) and a Self-managed guide (connecting, snapshot building, uploading). They're separate guides because the user switches between instances during the migration flow.

Replaces https://github.com/grafana/interactive-tutorials/pull/179