### PR TITLE
fix(grafana-irm-configuration-lj): render images, callouts, and videos in Pathfinder

### DIFF
--- a/grafana-irm-configuration-lj/build-mental-model/content.json
+++ b/grafana-irm-configuration-lj/build-mental-model/content.json
@@ -9,15 +9,21 @@
     },
     {
       "type": "markdown",
-      "content": "The following diagram illustrates the different components of IRM and how they work together as alerts flow through the system:\n\n![Alert flow diagram showing alert source passing through Grafana IRM components](/media/docs/grafana-cloud/alerting-and-irm/screenshot-grafana-irm-alert-flow-diagram-lj.png)"
+      "content": "The following diagram illustrates the different components of IRM and how they work together as alerts flow through the system:\n\n![Alert flow diagram showing alert source passing through Grafana IRM components](https://grafana.com/media/docs/grafana-cloud/alerting-and-irm/screenshot-grafana-irm-alert-flow-diagram-lj.png)"
     },
     {
       "type": "markdown",
       "content": "Familiarize yourself with these components before you configure them in the next milestones:\n\n- **Integrations** connect alert and event sources to IRM. Common types include Grafana Alerting, external monitoring tools, ticketing systems, custom webhooks, and API based connections.\n- **Routes** apply conditional rules to direct alerts from an integration to specific escalation chains. Every integration has a default route that processes all alerts; add more routes for conditional logic (labels, severity, service, or content).\n- **Escalation chains** define a sequence of notification steps: who is notified, when, and with what importance. They set initial targets, wait intervals, escalation steps, and notification importance.\n- **Schedules** manage on-call rotations and determine who is currently responsible. Use them in escalation chains to notify the current on-call responder automatically.\n- **Notification rules** define user-specific notification methods (SMS, phone call, mobile push, email) with timing and escalation behavior."
     },
     {
+      "type": "video",
+      "src": "https://www.youtube.com/embed/Eu0iLDFVdy0",
+      "provider": "youtube",
+      "title": "Configuring Grafana IRM walkthrough"
+    },
+    {
       "type": "markdown",
-      "content": "{{< docs/video id=\"Eu0iLDFVdy0\" >}}\nThis video provides a high-level walkthrough of configuring Grafana IRM, including connecting integrations, defining escalation chains and conditional routes, setting up on-call coverage, and creating notification rules.\n{{< /docs/video >}}\n\nIn the next milestone, you create an on-call schedule for your team."
+      "content": "This video provides a high-level walkthrough of configuring Grafana IRM, including connecting integrations, defining escalation chains and conditional routes, setting up on-call coverage, and creating notification rules.\n\nIn the next milestone, you create an on-call schedule for your team."
     }
   ]
 }

--- a/grafana-irm-configuration-lj/content.json
+++ b/grafana-irm-configuration-lj/content.json
@@ -9,7 +9,7 @@
     },
     {
       "type": "markdown",
-      "content": "The following diagram represents how Grafana IRM helps you detect, respond to, and learn from incidents:\n\n![Grafana IRM detect, respond, learn framework](/media/docs/grafana-cloud/alerting-and-irm/irm-lj-diagram-small.png)\n\n- **Detect:** Identify a problem within your system.\n- **Respond:** Get the right people and processes in place to respond to the issue.\n- **Learn:** Solve, communicate, and grow from resolving the issue."
+      "content": "The following diagram represents how Grafana IRM helps you detect, respond to, and learn from incidents:\n\n![Grafana IRM detect, respond, learn framework](https://grafana.com/media/docs/grafana-cloud/alerting-and-irm/irm-lj-diagram-small.png)\n\n- **Detect:** Identify a problem within your system.\n- **Respond:** Get the right people and processes in place to respond to the issue.\n- **Learn:** Solve, communicate, and grow from resolving the issue."
     },
     {
       "type": "markdown",

--- a/grafana-irm-configuration-lj/create-escalation-chain/content.json
+++ b/grafana-irm-configuration-lj/create-escalation-chain/content.json
@@ -9,7 +9,7 @@
     },
     {
       "type": "markdown",
-      "content": "For this example, you configure an escalation chain that notifies the current on-call user, then escalates to the broader team after 5 minutes if the alert remains unacknowledged:\n\n![Escalation chain that notifies the current on-call user from the selected schedule and then escalates to the rest of the team if unacknowledged after 5 minutes](/media/docs/grafana-cloud/alerting-and-irm/screenshot-grafana-irm-escalatino-chain-with-schedule-lj.png)\n\nTo create the escalation chain, complete the following steps:"
+      "content": "For this example, you configure an escalation chain that notifies the current on-call user, then escalates to the broader team after 5 minutes if the alert remains unacknowledged:\n\n![Escalation chain that notifies the current on-call user from the selected schedule and then escalates to the rest of the team if unacknowledged after 5 minutes](https://grafana.com/media/docs/grafana-cloud/alerting-and-irm/screenshot-grafana-irm-escalatino-chain-with-schedule-lj.png)\n\nTo create the escalation chain, complete the following steps:"
     },
     {
       "type": "guided",
@@ -89,7 +89,7 @@
     },
     {
       "type": "markdown",
-      "content": "{{< admonition type=\"note\" >}}\nFor each notification step, you can choose **Default** or **Important** notification rules. **Important** is for critical, time-sensitive alerts. If you're not sure which to pick, set **Default** for now and update later. Make sure team members configure their [personal notification rules](/docs/grafana-cloud/alerting-and-irm/irm/notify-responders/personal-notification-rules/) for both rule sets.\n{{< /admonition >}}\n\nYour escalation chain now routes Alert groups to the current on-call responder from your schedule, waits 5 minutes, then escalates to the broader team if unacknowledged.\n\nIn the next milestone, you connect Grafana Alerting as the alert source that feeds this escalation chain."
+      "content": "> **Note:** For each notification step, you can choose **Default** or **Important** notification rules. **Important** is for critical, time-sensitive alerts. If you're not sure which to pick, set **Default** for now and update later. Make sure team members configure their [personal notification rules](/docs/grafana-cloud/alerting-and-irm/irm/notify-responders/personal-notification-rules/) for both rule sets.\n\nYour escalation chain now routes Alert groups to the current on-call responder from your schedule, waits 5 minutes, then escalates to the broader team if unacknowledged.\n\nIn the next milestone, you connect Grafana Alerting as the alert source that feeds this escalation chain."
     }
   ]
 }

--- a/grafana-irm-configuration-lj/create-on-call-schedule/content.json
+++ b/grafana-irm-configuration-lj/create-on-call-schedule/content.json
@@ -9,7 +9,7 @@
     },
     {
       "type": "markdown",
-      "content": "For this example, you configure a 24-hour daily handoff rotation:\n\n![On-call schedule creation screen with three users rotating daily between a 24-hour shift](/media/docs/grafana-cloud/alerting-and-irm/screenshot-grafana-irm-on-call-schedule-lj.png)\n\nTo create a new schedule, complete the following steps:"
+      "content": "For this example, you configure a 24-hour daily handoff rotation:\n\n![On-call schedule creation screen with three users rotating daily between a 24-hour shift](https://grafana.com/media/docs/grafana-cloud/alerting-and-irm/screenshot-grafana-irm-on-call-schedule-lj.png)\n\nTo create a new schedule, complete the following steps:"
     },
     {
       "type": "guided",
@@ -74,7 +74,7 @@
     },
     {
       "type": "markdown",
-      "content": "{{< admonition type=\"tip\" >}}\nAdd yourself as the current on-call user for initial testing to avoid sending notifications to teammates. Make sure your [personal notification rules](/docs/grafana-cloud/alerting-and-irm/irm/notify-responders/personal-notification-rules/) are configured so you actually receive the test notifications.\n{{< /admonition >}}\n\nTo verify the schedule, return to **Schedules** and locate the new schedule. View **Final schedule** to confirm rotation coverage and timing, and verify **On-call now** shows the expected user.\n\nIn the next milestone, you create an escalation chain that routes alerts to the current on-call responder from this schedule."
+      "content": "> **Tip:** Add yourself as the current on-call user for initial testing to avoid sending notifications to teammates. Make sure your [personal notification rules](/docs/grafana-cloud/alerting-and-irm/irm/notify-responders/personal-notification-rules/) are configured so you actually receive the test notifications.\n\nTo verify the schedule, return to **Schedules** and locate the new schedule. View **Final schedule** to confirm rotation coverage and timing, and verify **On-call now** shows the expected user.\n\nIn the next milestone, you create an escalation chain that routes alerts to the current on-call responder from this schedule."
     }
   ]
 }

--- a/grafana-irm-configuration-lj/run-end-to-end-test/content.json
+++ b/grafana-irm-configuration-lj/run-end-to-end-test/content.json
@@ -9,7 +9,7 @@
     },
     {
       "type": "markdown",
-      "content": "{{< admonition type=\"note\" >}}\nBefore you test, configure your [personal notification rules](/docs/grafana-cloud/alerting-and-irm/irm/notify-responders/personal-notification-rules/) so you receive notifications through your preferred channels. The default notification method is your Grafana Cloud account email. If you're testing against a production alert rule, duplicate the rule first or revert any changes immediately after testing using the **Versions** tab.\n{{< /admonition >}}\n\nTo trigger the alert rule from Grafana Alerting, complete the following steps:"
+      "content": "> **Note:** Before you test, configure your [personal notification rules](/docs/grafana-cloud/alerting-and-irm/irm/notify-responders/personal-notification-rules/) so you receive notifications through your preferred channels. The default notification method is your Grafana Cloud account email. If you're testing against a production alert rule, duplicate the rule first or revert any changes immediately after testing using the **Versions** tab.\n\nTo trigger the alert rule from Grafana Alerting, complete the following steps:"
     },
     {
       "type": "markdown",

--- a/grafana-irm-configuration-lj/understand-value/content.json
+++ b/grafana-irm-configuration-lj/understand-value/content.json
@@ -8,8 +8,14 @@
       "content": "Observability systems are complicated. There are nodes, pods, services, and system resources, sometimes thousands of them, all connected in a complex web of relationships. Behind all of that is the group of people who keep these systems healthy.\n\nWhen something goes wrong those people must identify the cause and restore service fast. Downtime is expensive and the response work itself is stressful and draining for the people involved. Grafana IRM is built for those people."
     },
     {
+      "type": "video",
+      "src": "https://www.youtube.com/embed/y_Ewv9azoE4",
+      "provider": "youtube",
+      "title": "Grafana IRM: observability-native incident response"
+    },
+    {
       "type": "markdown",
-      "content": "{{< docs/video id=\"y_Ewv9azoE4\" >}}\nGrafana IRM unifies alert routing, on-call scheduling, incident coordination, and post-incident learning in one observability-native workflow. Hear from experts on best practices and how historical incident data improves escalation, reduces MTTR, and strengthens reliability.\n{{< /docs/video >}}"
+      "content": "Grafana IRM unifies alert routing, on-call scheduling, incident coordination, and post-incident learning in one observability-native workflow. Hear from experts on best practices and how historical incident data improves escalation, reduces MTTR, and strengthens reliability."
     },
     {
       "type": "markdown",


### PR DESCRIPTION
## Summary

The `grafana-irm-configuration-lj` learning journey (merged in #317) ships three Pathfinder-incompatible patterns inherited from Hugo-rendered docs. This PR fixes all three so the LJ renders correctly inside Pathfinder.

### What was broken

- **Images don't render.** Four images used website-relative paths (`/media/docs/grafana-cloud/alerting-and-irm/...`) that only resolve on grafana.com. In Pathfinder, the browser resolves them against the Pathfinder host and 404s. Documented in [`.cursor/skills/migrate-guide/SKILL.md`](.cursor/skills/migrate-guide/SKILL.md) (lines around 455).
- **Admonitions display as literal text.** Three blocks wrapped content in Hugo shortcodes (`{{< admonition type=\"...\" >}}...{{< /admonition >}}`). The JSON guide schema has no admonition block type ([`docs/json-guide-reference.md`](docs/json-guide-reference.md)), so the tags pass through verbatim. No other LJ in the repo uses admonitions.
- **Video shortcodes display as literal text.** Two blocks used `{{< docs/video id=\"...\" >}}...{{< /docs/video >}}` — same bug class.

### What changed

| File | Change |
|------|--------|
| `content.json` | Image URL → absolute |
| `build-mental-model/content.json` | Image URL → absolute; video shortcode → `video` block + adjacent markdown |
| `create-on-call-schedule/content.json` | Image URL → absolute; admonition (tip) → `> **Tip:**` blockquote |
| `create-escalation-chain/content.json` | Image URL → absolute; admonition (note) → `> **Note:**` blockquote |
| `run-end-to-end-test/content.json` | Admonition (note) → `> **Note:**` blockquote |
| `understand-value/content.json` | Video shortcode → `video` block + adjacent markdown |

Blockquote callout style was chosen to match the existing convention in `infinity-csv-lj`, `infrastructure-alerting-lj`, and `create-availability-slo-lj`. Video block format matches `docs/json-guide-reference.md:135`.

### Known pre-existing typo (not fixed here)

The asset `screenshot-grafana-irm-escalatino-chain-with-schedule-lj.png` has `escalatino` (should be `escalation`) in the source filename on grafana.com. The reference is correct against the published asset (returns 200), so this PR leaves it alone. Recommend re-uploading the asset with the corrected name in a follow-up change, then updating the reference.

## Test plan

- [x] `jq empty` on every modified JSON file — all parse cleanly
- [x] `grep` for residual website-relative `/media/docs/grafana-cloud/...` refs — none remain
- [x] `grep` for residual `{{<` Hugo shortcodes — none remain
- [x] All four image URLs return `200 OK` at the new absolute path (verified with `curl` during planning)
- [ ] Load LJ in a Pathfinder dev instance and walk every milestone — confirm images render inline, callouts render as blockquotes, both videos embed and play
- [ ] Run Pathfinder CLI validation: `node {pathfinder-app}/dist/cli/cli/index.js validate --packages .`

🤖 Generated with [Claude Code](https://claude.com/claude-code)