### PR TITLE
Migrate infrastructure alerting numbered steps

### DIFF
--- a/infrastructure-alerting-lj/build-your-query/content.json
+++ b/infrastructure-alerting-lj/build-your-query/content.json
@@ -42,18 +42,15 @@
           "requirements": ["exists-reftarget", "on-page:/alerting/list"]
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "In the **Define query and alert condition** section, locate the query editor.\n\nThe default data source is pre-selected. Change it if needed to match where your data is stored (Prometheus/Mimir for metrics, Loki for logs)."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Select the data source for your alert:\n\n| If you're alerting on | Select |\n|-----------------------|--------|\n| Infrastructure metrics | Your Prometheus or Mimir data source |\n| Logs | Your Loki data source |"
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Build your query using the query builder:\n\n**For metrics (Prometheus/Mimir):**\n\n- Click **Metric** and select or search for your metric name.\n\n  For example, select `node_cpu_seconds_total` for CPU monitoring.\n\n- Add label filters to narrow the scope.\n\n  For example, add `mode != \"idle\"` to exclude idle CPU time.\n\n- Apply functions as needed.\n\n  For example, wrap with `rate()` and `avg by (instance)()` to get average CPU usage per host.\n\n**For logs (Loki):**\n\n- Enter a log query using LogQL.\n\n  For example, `{job=\"myapp\"} |= \"error\"` to find error logs.\n\n- Use metric queries for rate-based alerts.\n\n  For example, `rate({job=\"myapp\"} |= \"error\" [5m])` for error rate."
         },
         {
@@ -64,8 +61,7 @@
           "requirements": ["exists-reftarget"]
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "If your query returns multiple time series (multi-dimensional), verify that each series is labeled distinctly.\n\n| If alerting on | Multi-dimensional example |\n|----------------|---------------------------|\n| Metrics | CPU across 5 hosts → 5 series, each with unique `instance` label |\n| Logs | Errors across 3 services → 3 series, each with unique `job` or `service` label |"
         }
       ]

--- a/infrastructure-alerting-lj/evaluation-and-labels/content.json
+++ b/infrastructure-alerting-lj/evaluation-and-labels/content.json
@@ -24,18 +24,15 @@
           "requirements": ["exists-reftarget"]
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Select or create an **Evaluation group**.\n\nEvaluation groups batch rules that share the same evaluation interval.\n\n| If alerting on | Example group name |\n|----------------|-------------------|\n| Metrics | `CPU and memory alerts` |\n| Logs | `Error rate alerts` |"
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Set the **Evaluation interval**—how often Grafana runs your query and checks the condition.\n\nFor example, enter `1m` for critical alerts or `5m` for less urgent monitoring."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Set the **Pending period** (also called \"for\" duration)—how long the condition must be true before the alert fires.\n\n| Alert type | Pending period | Why |\n|------------|----------------|-----|\n| Metrics (CPU spike) | `5m` | Filter brief spikes during deployments |\n| Logs (error burst) | `2m` | Catch sustained error patterns, not single errors |\n\n> **Tip:** A 5-minute pending period with a 1-minute evaluation means the condition must be true for 5 consecutive checks before firing."
         },
         {
@@ -46,8 +43,7 @@
           "requirements": ["exists-reftarget"]
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "In the **Add annotations** section, optionally add context for responders:\n\n- **Summary**: Brief description of what's wrong.\n\n  | If alerting on | Example summary |\n  |----------------|------------------|\n  | Metrics | `CPU usage is high on {{ $labels.instance }}` |\n  | Logs | `Error rate elevated for {{ $labels.job }}` |\n\n- **Description**: Detailed context or troubleshooting steps.\n\n- **Runbook URL**: Link to documentation for responding to this alert."
         }
       ]

--- a/infrastructure-alerting-lj/find-data-to-alert/content.json
+++ b/infrastructure-alerting-lj/find-data-to-alert/content.json
@@ -20,8 +20,7 @@
       "autoCollapse": false,
       "blocks": [
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Sign in to your [Grafana Cloud account](https://grafana.com/auth/sign-in)."
         },
         {
@@ -32,23 +31,19 @@
           "reftarget": "a[data-testid='data-testid Nav menu item'][href='/drilldown']"
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Choose the appropriate Drilldown app based on what you want to alert on:\n\n| If you want to alert on | Select |\n|-------------------------|--------|\n| Infrastructure metrics (CPU, memory, disk) | **Metrics Drilldown** |\n| Application or system logs | **Logs Drilldown** |"
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "In the Drilldown app, explore the available data:\n\n- For **Metrics Drilldown**: Browse metric names, filter by labels (like `job` or `instance`), and view current values.\n- For **Logs Drilldown**: Search log content, filter by labels, and identify patterns worth alerting on."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Identify a specific metric or log pattern you want to alert on.\n\n**Metrics examples:**\n| Metric | Use case |\n|--------|----------|\n| `node_cpu_seconds_total` | CPU usage per host |\n| `node_memory_MemAvailable_bytes` | Available memory |\n| `node_filesystem_avail_bytes` | Disk space |\n\n**Logs examples:**\n| Log query | Use case |\n|-----------|-----------|\n| `{job=\"myapp\"} \\|= \"error\"` | Application errors |\n| `{job=\"nginx\"} \\| json \\| status >= 500` | HTTP 5xx errors |\n| `{job=\"syslog\"} \\|= \"OOM\"` | Out-of-memory events |"
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Note the metric name or log query—you'll use this in your alert rule.\n\n> **Tip:** You can also copy the query directly from the Drilldown app to paste into your alert rule later."
         }
       ]

--- a/infrastructure-alerting-lj/monitor-your-rule/content.json
+++ b/infrastructure-alerting-lj/monitor-your-rule/content.json
@@ -35,28 +35,23 @@
           "requirements": ["navmenu-open"]
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Locate your alert rule and observe its current state:\n\n| State | Meaning | What to expect |\n|-------|---------|----------------|\n| **Normal** | Condition not met | Your metric is below the threshold—this is good! |\n| **Pending** | Condition met, waiting | Threshold crossed, but pending period not elapsed |\n| **Firing** | Condition confirmed | Alert is active, notifications sent |\n| **Error** | Evaluation failed | Query or configuration issue |\n| **No Data** | No data returned | Data source issue or query problem |"
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Click on your alert rule to view its details.\n\nThe detail view shows:\n- Current state and state history\n- When the rule was last evaluated\n- The query results and which instances (if multi-dimensional) are affected"
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "View the **State history** tab to see how your alert has behaved over time.\n\nThis helps you understand if the alert fires too frequently (threshold too sensitive) or never fires (threshold too high)."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "To test that notifications work, you can temporarily lower your threshold to trigger a firing state, then restore it.\n\n> **Important:** If testing in production, set a very short pending period and restore your original settings immediately after confirming notifications work."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Check your contact point (Slack, email, etc.) to verify notifications are delivered when the alert fires."
         }
       ]

--- a/infrastructure-alerting-lj/notification-settings/content.json
+++ b/infrastructure-alerting-lj/notification-settings/content.json
@@ -16,13 +16,11 @@
       "autoCollapse": false,
       "blocks": [
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "In the **Configure notifications** section, leave **Use default policy** selected.\n\nThe default policy sends all alerts to the default contact point. This is perfect for getting started."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Verify or create a contact point:\n\n- If a default contact point exists (like a default email), you're ready to proceed.\n\n- If no contact point exists, you'll see a prompt to create one."
         },
         {
@@ -34,13 +32,11 @@
           "requirements": ["exists-reftarget"]
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "**If creating a contact point:**\n\n| Option | Best for your first alert |\n|--------|---------------------------|\n| **Email** | Quick setup—enter your email address |\n| **Slack** | If you have a webhook URL ready |\n\nFor email:\n- Enter a **Name** (e.g., `My alerts`)\n- Select **Email** as the integration\n- Enter your email address\n- Click **Save contact point**\n- Return to your alert rule and select this contact point"
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Skip the advanced options for now:\n\n- **Override grouping** — Keep defaults\n- **Override timings** — Keep defaults\n\n> **Note:** You'll learn to configure advanced routing (by severity, team, channel) in the **Configure alert routing** learning path."
         }
       ]

--- a/infrastructure-alerting-lj/planning-alerts/content.json
+++ b/infrastructure-alerting-lj/planning-alerts/content.json
@@ -20,28 +20,23 @@
       "autoCollapse": false,
       "blocks": [
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "**Choose what to monitor.** Start with metrics or logs that directly indicate user impact or system health.\n\n| Data type | What to monitor | Why it matters |\n|-----------|-----------------|----------------|\n| **Metrics** | CPU, memory, disk, network | Resource exhaustion affects all services |\n| **Logs** | Error patterns, exceptions, failed requests | Application health and user impact |"
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "**Define meaningful thresholds.** Base thresholds on what \"normal\" looks like in your environment, not arbitrary numbers.\n\n| Data type | Example threshold | Reasoning |\n|-----------|-------------------|-----------||\n| **Metrics** | CPU > 80% | Normal is 40-60%, gives time to respond |\n| **Logs** | Errors > 10/min | Normal is 1-2/min, catches real spikes |"
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "**Set appropriate urgency.** Not every alert needs to page someone at 3 AM.\n\n| Alert type | Metrics example | Logs example | Urgency |\n|------------|-----------------|--------------|---------||\n| **Critical** | Disk 95% full | `FATAL` or `panic` logs | Page immediately |\n| **Warning** | CPU elevated 15 min | Error rate 5x normal | Slack notification |\n| **Info** | Memory trending up | Unusual log pattern | Email digest |"
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "**Identify the responders.** Who should receive this alert? The platform team? Database team? On-call engineer?"
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "**Consider the \"for\" duration.** How long should the condition persist before firing? Brief spikes during deployments shouldn't page anyone."
         }
       ]

--- a/infrastructure-alerting-lj/save-and-activate/content.json
+++ b/infrastructure-alerting-lj/save-and-activate/content.json
@@ -16,8 +16,7 @@
       "autoCollapse": false,
       "blocks": [
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Review your alert rule configuration:\n\n- **Query**: Returns the data you want to monitor.\n- **Condition**: Fires when your threshold is crossed.\n- **Evaluation**: Checks at your specified interval with your pending period.\n- **Labels**: Organize and route your alert.\n- **Notifications**: Deliver to your contact point."
         },
         {

--- a/infrastructure-alerting-lj/set-conditions/content.json
+++ b/infrastructure-alerting-lj/set-conditions/content.json
@@ -16,18 +16,15 @@
       "autoCollapse": false,
       "blocks": [
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "In the **Define query and alert condition** section, scroll to the **Expressions** area.\n\nGrafana automatically adds a **Reduce** expression and a **Threshold** expression to process your query results."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Configure the **Reduce** expression:\n\n- **Function**: Select how to reduce the time series to a single value.\n\n  For example, select `Last` to use the most recent value, or `Mean` to use the average over the evaluation window.\n\n- **Input**: Should reference your query (typically `A`)."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Configure the **Threshold** expression:\n\n- **Input**: Should reference your Reduce expression (typically `B`).\n\n- **Condition**: Select the comparison operator.\n\n  | If alerting on | Condition | Example |\n  |----------------|-----------|--------|\n  | High CPU | `IS ABOVE` | Fire when CPU > 80% |\n  | Low disk space | `IS BELOW` | Fire when free space < 10GB |\n  | Error rate | `IS ABOVE` | Fire when errors/min > 10 |\n  | Log count | `IS ABOVE` | Fire when error logs > 50 in 5m |\n\n- **Value**: Enter your threshold value.\n\n  | Alert type | Example value | Notes |\n  |------------|---------------|-------|\n  | CPU percentage | `0.8` or `80` | Depends on query output format |\n  | Error rate | `10` | Errors per minute |\n  | Log count | `50` | Errors in evaluation window |"
         },
         {
@@ -38,8 +35,7 @@
           "requirements": ["exists-reftarget"]
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Adjust the threshold if needed based on the preview results.\n\n> **Tip:** A good threshold gives you time to respond before the situation becomes critical. For metrics, if your normal CPU is 40-60%, alerting at 80% gives you warning. For logs, if your app normally logs 1-2 errors per minute, alerting at 10 catches real problems."
         }
       ]


### PR DESCRIPTION
Migrates the infrastructure alerting learning path from noop workaround steps to markdown content blocks so Pathfinder can render them as sequentially numbered section steps. Part of https://github.com/grafana/interactive-tutorials/issues/314.