### PR TITLE
Migrate synthetic monitoring numbered steps

### DIFF
--- a/detect-outages-synthetic-monitoring-lj/initialize-plugin/content.json
+++ b/detect-outages-synthetic-monitoring-lj/initialize-plugin/content.json
@@ -22,8 +22,7 @@
           "skippable": true
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Wait for the initialization process to complete. This typically takes a few seconds."
         }
       ]

--- a/detect-outages-synthetic-monitoring-lj/select-probe-locations/content.json
+++ b/detect-outages-synthetic-monitoring-lj/select-probe-locations/content.json
@@ -22,8 +22,7 @@
           "content": "In the check creation stepper, click **Execution**."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "In the **Probe locations** section, select the locations from which to run your check. For example, select **North California**, **Singapore**, and **Frankfurt** to test from three continents."
         },
         {


### PR DESCRIPTION
Migrates the detect outages Synthetic Monitoring learning path from noop workaround steps to markdown content blocks so Pathfinder can render them as sequentially numbered section steps. Part of https://github.com/grafana/interactive-tutorials/issues/314.

Made with [Cursor](https://cursor.com)