### PR TITLE
Migrate collector fleet numbered steps

### DIFF
--- a/categorize-collector-fleet-lj/navigate-to-fleet/content.json
+++ b/categorize-collector-fleet-lj/navigate-to-fleet/content.json
@@ -11,8 +11,7 @@
       "type": "section",
       "blocks": [
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Sign in to your Grafana Cloud instance."
         },
         {

--- a/categorize-collector-fleet-lj/select-collector/content.json
+++ b/categorize-collector-fleet-lj/select-collector/content.json
@@ -11,13 +11,11 @@
       "type": "section",
       "blocks": [
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "In your Fleet Management **Inventory**, identify the collectors you want to categorize."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Select the checkboxes next to each collector ID."
         }
       ]


### PR DESCRIPTION
Migrates the categorize collector fleet learning path from noop workaround steps to markdown content blocks so Pathfinder can render them as sequentially numbered section steps. Part of https://github.com/grafana/interactive-tutorials/issues/314.

Made with [Cursor](https://cursor.com)