### PR TITLE
Migrate adaptive metrics numbered steps

### DIFF
--- a/adaptive-metrics-lj/auto-apply/content.json
+++ b/adaptive-metrics-lj/auto-apply/content.json
@@ -23,8 +23,7 @@
             ]
         },
         {
-            "type": "interactive",
-            "action": "noop",
+            "type": "markdown",
             "content": "Find the segment you want to enable auto-apply for (the **default** segment, or a team segment you created earlier), then click its **Edit segment** action.",
             "requirements": ["on-page:/a/grafana-adaptive-metrics-app/segments"]
         },

--- a/adaptive-metrics-lj/auto-apply/content.json
+++ b/adaptive-metrics-lj/auto-apply/content.json
@@ -24,8 +24,7 @@
         },
         {
             "type": "markdown",
-            "content": "Find the segment you want to enable auto-apply for (the **default** segment, or a team segment you created earlier), then click its **Edit segment** action.",
-            "requirements": ["on-page:/a/grafana-adaptive-metrics-app/segments"]
+            "content": "Find the segment you want to enable auto-apply for (the **default** segment, or a team segment you created earlier), then click its **Edit segment** action."
         },
         {
             "type": "markdown",

--- a/adaptive-metrics-lj/review-apply/content.json
+++ b/adaptive-metrics-lj/review-apply/content.json
@@ -49,14 +49,12 @@
             "content": "Expand a rule from the rules list to review the details, including **Recommended rule information** and **Metric usage stats**."
         },
         {
-            "type": "interactive",
-            "action": "noop",
+            "type": "markdown",
             "content": "Find the recommendation row you want to apply, then use the per-row **Apply recommendation** action on that row. The current UI applies recommendations one at a time — there is no bulk \"apply all\" button.",
             "requirements": ["on-page:/a/grafana-adaptive-metrics-app/rule-management"]
         },
         {
-            "type": "interactive",
-            "action": "noop",
+            "type": "markdown",
             "content": "Confirm the change in the **Apply recommendation** dialog. The rule is queued and takes effect after the aggregation delay."
         }
     ]

--- a/adaptive-metrics-lj/review-apply/content.json
+++ b/adaptive-metrics-lj/review-apply/content.json
@@ -50,8 +50,7 @@
         },
         {
             "type": "markdown",
-            "content": "Find the recommendation row you want to apply, then use the per-row **Apply recommendation** action on that row. The current UI applies recommendations one at a time — there is no bulk \"apply all\" button.",
-            "requirements": ["on-page:/a/grafana-adaptive-metrics-app/rule-management"]
+            "content": "Find the recommendation row you want to apply, then use the per-row **Apply recommendation** action on that row. The current UI applies recommendations one at a time — there is no bulk \"apply all\" button."
         },
         {
             "type": "markdown",

--- a/adaptive-metrics-lj/rules-exemptions/content.json
+++ b/adaptive-metrics-lj/rules-exemptions/content.json
@@ -23,8 +23,7 @@
             ]
         },
         {
-            "type": "interactive",
-            "action": "noop",
+            "type": "markdown",
             "content": "On the **Metrics** tab, select a segment from the dropdown menu that does not have **Auto-apply** enabled.",
             "requirements": ["on-page:/a/grafana-adaptive-metrics-app/rule-management"]
         },

--- a/adaptive-metrics-lj/rules-exemptions/content.json
+++ b/adaptive-metrics-lj/rules-exemptions/content.json
@@ -24,8 +24,7 @@
         },
         {
             "type": "markdown",
-            "content": "On the **Metrics** tab, select a segment from the dropdown menu that does not have **Auto-apply** enabled.",
-            "requirements": ["on-page:/a/grafana-adaptive-metrics-app/rule-management"]
+            "content": "On the **Metrics** tab, select a segment from the dropdown menu that does not have **Auto-apply** enabled."
         },
         {
             "type": "interactive",


### PR DESCRIPTION
Migrates the Adaptive Metrics learning path from noop workaround steps to markdown content blocks so Pathfinder can render them as sequentially numbered section steps where applicable. Part of https://github.com/grafana/interactive-tutorials/issues/314.

Made with [Cursor](https://cursor.com)