### PR TITLE
refactor(grafana-irm-configuration-lj): wrap milestones in sections, convert input steps to formfill

### DIFF
--- a/grafana-irm-configuration-lj/connect-alert-rule/content.json
+++ b/grafana-irm-configuration-lj/connect-alert-rule/content.json
@@ -8,28 +8,35 @@
       "content": "In this milestone, you update an existing alert rule so IRM can receive alerts from Grafana Alerting. For firing alerts to create IRM Alert groups, the alert rule must include the IRM contact point you created in the previous milestone.\n\nTo open the alert rules list in Grafana Alerting, complete the following steps:"
     },
     {
-      "type": "guided",
-      "content": "Open the alert rules list and find your rule.",
-      "requirements": ["navmenu-open"],
-      "stepTimeout": 45000,
-      "steps": [
+      "type": "section",
+      "id": "open-alert-rules-list",
+      "title": "Open the alert rules list",
+      "blocks": [
         {
-          "action": "highlight",
-          "reftarget": "a[data-testid=\"data-testid Nav menu item\"][href=\"/alerting\"]",
+          "type": "guided",
+          "content": "Open the alert rules list and find your rule.",
           "requirements": ["navmenu-open"],
-          "tooltip": "Expand the alerting section in the navigation menu."
-        },
-        {
-          "action": "highlight",
-          "reftarget": "a[data-testid=\"data-testid Nav menu item\"][href=\"/alerting/list\"]",
-          "requirements": ["navmenu-open"],
-          "tooltip": "Open the alert rules list."
-        },
-        {
-          "action": "highlight",
-          "reftarget": "input[data-testid=\"search-query-input\"]",
-          "skippable": true,
-          "tooltip": "Search by name, label, or folder to find the rule you want to connect to IRM."
+          "stepTimeout": 45000,
+          "steps": [
+            {
+              "action": "highlight",
+              "reftarget": "a[data-testid=\"data-testid Nav menu item\"][href=\"/alerting\"]",
+              "requirements": ["navmenu-open"],
+              "tooltip": "Expand the alerting section in the navigation menu."
+            },
+            {
+              "action": "highlight",
+              "reftarget": "a[data-testid=\"data-testid Nav menu item\"][href=\"/alerting/list\"]",
+              "requirements": ["navmenu-open"],
+              "tooltip": "Open the alert rules list."
+            },
+            {
+              "action": "highlight",
+              "reftarget": "input[data-testid=\"search-query-input\"]",
+              "skippable": true,
+              "tooltip": "Search by name, label, or folder to find the rule you want to connect to IRM."
+            }
+          ]
         }
       ]
     },
@@ -38,25 +45,32 @@
       "content": "Click the rule name or **Edit** on the rule row to open the rule edit view, then follow the steps below to add the IRM contact point:"
     },
     {
-      "type": "guided",
-      "content": "Add the IRM contact point to the alert rule.",
-      "stepTimeout": 45000,
-      "steps": [
+      "type": "section",
+      "id": "add-irm-contact-point",
+      "title": "Add the IRM contact point to the rule",
+      "blocks": [
         {
-          "action": "highlight",
-          "reftarget": "[data-testid=\"routing-options-contact-point\"]",
-          "skippable": true,
-          "tooltip": "In the notifications step, select Contact point routing. Skip this step if the rule already uses contact point routing."
-        },
-        {
-          "action": "highlight",
-          "reftarget": "[data-testid=\"contact-point-picker\"]",
-          "tooltip": "Open the contact point picker and choose the IRM contact point you created in the previous milestone."
-        },
-        {
-          "action": "button",
-          "reftarget": "button[data-testid=\"save-rule\"]",
-          "tooltip": "Save the rule. The IRM contact point is now wired to this alert rule."
+          "type": "guided",
+          "content": "Add the IRM contact point to the alert rule.",
+          "stepTimeout": 45000,
+          "steps": [
+            {
+              "action": "highlight",
+              "reftarget": "[data-testid=\"routing-options-contact-point\"]",
+              "skippable": true,
+              "tooltip": "In the notifications step, select Contact point routing. Skip this step if the rule already uses contact point routing."
+            },
+            {
+              "action": "highlight",
+              "reftarget": "[data-testid=\"contact-point-picker\"]",
+              "tooltip": "Open the contact point picker and choose the IRM contact point you created in the previous milestone."
+            },
+            {
+              "action": "button",
+              "reftarget": "button[data-testid=\"save-rule\"]",
+              "tooltip": "Save the rule. The IRM contact point is now wired to this alert rule."
+            }
+          ]
         }
       ]
     },

--- a/grafana-irm-configuration-lj/connect-grafana-alerting/content.json
+++ b/grafana-irm-configuration-lj/connect-grafana-alerting/content.json
@@ -8,46 +8,55 @@
       "content": "In this milestone, you connect Grafana Alerting as the alert source that feeds the schedule and escalation chain you already built. The integration sends Grafana Cloud alert rules to IRM for automatic grouping, routing, escalation, and notification.\n\nTo add Grafana Alerting as an integration and associate it with your escalation chain, complete the following steps:"
     },
     {
-      "type": "guided",
-      "content": "Add Grafana Alerting as an integration.",
-      "requirements": ["navmenu-open"],
-      "stepTimeout": 45000,
-      "steps": [
+      "type": "section",
+      "id": "add-grafana-alerting-integration",
+      "title": "Add Grafana Alerting as an integration",
+      "blocks": [
         {
-          "action": "highlight",
-          "reftarget": "a[data-testid=\"data-testid Nav menu item\"][href=\"/a/grafana-irm-app/integrations\"]",
+          "type": "guided",
+          "content": "Add Grafana Alerting as an integration.",
           "requirements": ["navmenu-open"],
-          "tooltip": "Open the integrations list from the IRM navigation menu."
-        },
-        {
-          "action": "button",
-          "reftarget": "[data-pathfinder=\"add-integration-button\"]",
-          "tooltip": "Start adding a new integration."
-        },
-        {
-          "action": "highlight",
-          "reftarget": "[data-pathfinder=\"integration-grafanaalerting\"]",
-          "tooltip": "Choose Grafana Alerting as the integration type."
-        },
-        {
-          "action": "highlight",
-          "reftarget": "[data-pathfinder=\"integration-name-input\"]",
-          "tooltip": "Enter a descriptive name (for example, `Production SRE alerts`)."
-        },
-        {
-          "action": "highlight",
-          "reftarget": "div[data-testid=\"data-testid radio-button\"]:nth-match(2)",
-          "tooltip": "Choose to create a new contact point alongside this integration."
-        },
-        {
-          "action": "highlight",
-          "reftarget": "[data-pathfinder=\"new-contact-point-input\"]",
-          "tooltip": "Name the new contact point (for example, `Production IRM`)."
-        },
-        {
-          "action": "button",
-          "reftarget": "[data-pathfinder=\"save-integration-button\"]",
-          "tooltip": "Save the integration. The contact point is auto-created in Grafana Alerting."
+          "stepTimeout": 45000,
+          "steps": [
+            {
+              "action": "highlight",
+              "reftarget": "a[data-testid=\"data-testid Nav menu item\"][href=\"/a/grafana-irm-app/integrations\"]",
+              "requirements": ["navmenu-open"],
+              "tooltip": "Open the integrations list from the IRM navigation menu."
+            },
+            {
+              "action": "button",
+              "reftarget": "[data-pathfinder=\"add-integration-button\"]",
+              "tooltip": "Start adding a new integration."
+            },
+            {
+              "action": "highlight",
+              "reftarget": "[data-pathfinder=\"integration-grafanaalerting\"]",
+              "tooltip": "Choose Grafana Alerting as the integration type."
+            },
+            {
+              "action": "formfill",
+              "reftarget": "[data-pathfinder=\"integration-name-input\"]",
+              "targetvalue": "Production SRE alerts",
+              "tooltip": "Enter a descriptive name (for example, `Production SRE alerts`)."
+            },
+            {
+              "action": "highlight",
+              "reftarget": "div[data-testid=\"data-testid radio-button\"]:nth-match(2)",
+              "tooltip": "Choose to create a new contact point alongside this integration."
+            },
+            {
+              "action": "formfill",
+              "reftarget": "[data-pathfinder=\"new-contact-point-input\"]",
+              "targetvalue": "Production IRM",
+              "tooltip": "Name the new contact point (for example, `Production IRM`)."
+            },
+            {
+              "action": "button",
+              "reftarget": "[data-pathfinder=\"save-integration-button\"]",
+              "tooltip": "Save the integration. The contact point is auto-created in Grafana Alerting."
+            }
+          ]
         }
       ]
     },
@@ -56,24 +65,31 @@
       "content": "The integration is now created in IRM, but alert rules won't create Alert groups until you assign the IRM contact point to those rules in the next milestone. First, route alerts from this integration to the escalation chain you built earlier."
     },
     {
-      "type": "guided",
-      "content": "Route alerts from the integration to your escalation chain.",
-      "stepTimeout": 45000,
-      "steps": [
+      "type": "section",
+      "id": "route-alerts-to-escalation-chain",
+      "title": "Route alerts to your escalation chain",
+      "blocks": [
         {
-          "action": "highlight",
-          "reftarget": "[data-pathfinder=\"route-heading-0\"]",
-          "tooltip": "Expand the default route."
-        },
-        {
-          "action": "highlight",
-          "reftarget": "[data-testid=\"escalation-chain-select\"]",
-          "tooltip": "Open the escalation chain selector for this route."
-        },
-        {
-          "action": "highlight",
-          "reftarget": "[data-pathfinder=\"escalation-chain-option-0\"]",
-          "tooltip": "Select the chain you created in the previous milestone."
+          "type": "guided",
+          "content": "Route alerts from the integration to your escalation chain.",
+          "stepTimeout": 45000,
+          "steps": [
+            {
+              "action": "highlight",
+              "reftarget": "[data-pathfinder=\"route-heading-0\"]",
+              "tooltip": "Expand the default route."
+            },
+            {
+              "action": "highlight",
+              "reftarget": "[data-testid=\"escalation-chain-select\"]",
+              "tooltip": "Open the escalation chain selector for this route."
+            },
+            {
+              "action": "highlight",
+              "reftarget": "[data-pathfinder=\"escalation-chain-option-0\"]",
+              "tooltip": "Select the chain you created in the previous milestone."
+            }
+          ]
         }
       ]
     },

--- a/grafana-irm-configuration-lj/create-escalation-chain/content.json
+++ b/grafana-irm-configuration-lj/create-escalation-chain/content.json
@@ -12,31 +12,39 @@
       "content": "For this example, you configure an escalation chain that notifies the current on-call user, then escalates to the broader team after 5 minutes if the alert remains unacknowledged:\n\n![Escalation chain that notifies the current on-call user from the selected schedule and then escalates to the rest of the team if unacknowledged after 5 minutes](https://grafana.com/media/docs/grafana-cloud/alerting-and-irm/screenshot-grafana-irm-escalatino-chain-with-schedule-lj.png)\n\nTo create the escalation chain, complete the following steps:"
     },
     {
-      "type": "guided",
-      "content": "Create a new escalation chain.",
-      "requirements": ["navmenu-open"],
-      "stepTimeout": 45000,
-      "steps": [
+      "type": "section",
+      "id": "create-new-escalation-chain",
+      "title": "Create a new escalation chain",
+      "blocks": [
         {
-          "action": "highlight",
-          "reftarget": "a[data-testid=\"data-testid Nav menu item\"][href=\"/a/grafana-irm-app/escalations\"]",
+          "type": "guided",
+          "content": "Create a new escalation chain.",
           "requirements": ["navmenu-open"],
-          "tooltip": "Open the escalation chains list from the IRM navigation menu."
-        },
-        {
-          "action": "button",
-          "reftarget": "[data-pathfinder=\"new-escalation-chain-button\"]",
-          "tooltip": "Start creating a new chain."
-        },
-        {
-          "action": "highlight",
-          "reftarget": "[data-pathfinder=\"escalation-chain-name-input\"]",
-          "tooltip": "Enter a descriptive name (for example, `Production - Default`)."
-        },
-        {
-          "action": "button",
-          "reftarget": "[data-pathfinder=\"save-escalation-chain-button\"]",
-          "tooltip": "Save the chain so you can add steps to it."
+          "stepTimeout": 45000,
+          "steps": [
+            {
+              "action": "highlight",
+              "reftarget": "a[data-testid=\"data-testid Nav menu item\"][href=\"/a/grafana-irm-app/escalations\"]",
+              "requirements": ["navmenu-open"],
+              "tooltip": "Open the escalation chains list from the IRM navigation menu."
+            },
+            {
+              "action": "button",
+              "reftarget": "[data-pathfinder=\"new-escalation-chain-button\"]",
+              "tooltip": "Start creating a new chain."
+            },
+            {
+              "action": "formfill",
+              "reftarget": "[data-pathfinder=\"escalation-chain-name-input\"]",
+              "targetvalue": "Production - Default",
+              "tooltip": "Enter a descriptive name (for example, `Production - Default`)."
+            },
+            {
+              "action": "button",
+              "reftarget": "[data-pathfinder=\"save-escalation-chain-button\"]",
+              "tooltip": "Save the chain so you can add steps to it."
+            }
+          ]
         }
       ]
     },
@@ -45,45 +53,52 @@
       "content": "Now add the notification, wait, and escalation steps. The first step pages the on-call user from your schedule, the second waits 5 minutes, and the third escalates to the broader team."
     },
     {
-      "type": "guided",
-      "content": "Add steps to your escalation chain.",
-      "stepTimeout": 45000,
-      "skippable": true,
-      "steps": [
+      "type": "section",
+      "id": "add-escalation-chain-steps",
+      "title": "Add steps to your escalation chain",
+      "blocks": [
         {
-          "action": "highlight",
-          "reftarget": "[data-pathfinder=\"timeline-item-1\"]",
-          "tooltip": "Add the first escalation step."
-        },
-        {
-          "action": "highlight",
-          "reftarget": "div:text(\"Notify users from on-call schedule\")",
-          "tooltip": "Choose to notify users from an on-call schedule."
-        },
-        {
-          "action": "highlight",
-          "reftarget": "div[data-testid=\"input-wrapper\"] input[placeholder=\"Select Schedule\"]",
-          "tooltip": "Select the schedule you created in the previous milestone."
-        },
-        {
-          "action": "highlight",
-          "reftarget": "[data-pathfinder=\"timeline-item-2\"]",
-          "tooltip": "Add a second step to introduce a wait."
-        },
-        {
-          "action": "highlight",
-          "reftarget": "div:text(\"Wait\")",
-          "tooltip": "Choose Wait, then set the wait time to `5 minutes`."
-        },
-        {
-          "action": "highlight",
-          "reftarget": "[data-pathfinder=\"timeline-item-3\"]",
-          "tooltip": "Add a third step to escalate when no one acknowledges."
-        },
-        {
-          "action": "highlight",
-          "reftarget": "div:text(\"Notify users\")",
-          "tooltip": "Choose Notify users, then select the broader team to escalate to."
+          "type": "guided",
+          "content": "Add steps to your escalation chain.",
+          "stepTimeout": 45000,
+          "skippable": true,
+          "steps": [
+            {
+              "action": "highlight",
+              "reftarget": "[data-pathfinder=\"timeline-item-1\"]",
+              "tooltip": "Add the first escalation step."
+            },
+            {
+              "action": "highlight",
+              "reftarget": "div:text(\"Notify users from on-call schedule\")",
+              "tooltip": "Choose to notify users from an on-call schedule."
+            },
+            {
+              "action": "highlight",
+              "reftarget": "div[data-testid=\"input-wrapper\"] input[placeholder=\"Select Schedule\"]",
+              "tooltip": "Select the schedule you created in the previous milestone."
+            },
+            {
+              "action": "highlight",
+              "reftarget": "[data-pathfinder=\"timeline-item-2\"]",
+              "tooltip": "Add a second step to introduce a wait."
+            },
+            {
+              "action": "highlight",
+              "reftarget": "div:text(\"Wait\")",
+              "tooltip": "Choose Wait, then set the wait time to `5 minutes`."
+            },
+            {
+              "action": "highlight",
+              "reftarget": "[data-pathfinder=\"timeline-item-3\"]",
+              "tooltip": "Add a third step to escalate when no one acknowledges."
+            },
+            {
+              "action": "highlight",
+              "reftarget": "div:text(\"Notify users\")",
+              "tooltip": "Choose Notify users, then select the broader team to escalate to."
+            }
+          ]
         }
       ]
     },

--- a/grafana-irm-configuration-lj/create-on-call-schedule/content.json
+++ b/grafana-irm-configuration-lj/create-on-call-schedule/content.json
@@ -12,36 +12,44 @@
       "content": "For this example, you configure a 24-hour daily handoff rotation:\n\n![On-call schedule creation screen with three users rotating daily between a 24-hour shift](https://grafana.com/media/docs/grafana-cloud/alerting-and-irm/screenshot-grafana-irm-on-call-schedule-lj.png)\n\nTo create a new schedule, complete the following steps:"
     },
     {
-      "type": "guided",
-      "content": "Create a new on-call schedule.",
-      "requirements": ["navmenu-open"],
-      "stepTimeout": 45000,
-      "steps": [
+      "type": "section",
+      "id": "create-new-schedule",
+      "title": "Create a new on-call schedule",
+      "blocks": [
         {
-          "action": "highlight",
-          "reftarget": "a[data-testid=\"data-testid Nav menu item\"][href=\"/a/grafana-irm-app/schedules\"]",
+          "type": "guided",
+          "content": "Create a new on-call schedule.",
           "requirements": ["navmenu-open"],
-          "tooltip": "Open the schedule list from the IRM navigation menu."
-        },
-        {
-          "action": "button",
-          "reftarget": "[data-pathfinder=\"new-schedule-button\"]",
-          "tooltip": "Start creating a new schedule."
-        },
-        {
-          "action": "button",
-          "reftarget": "[data-pathfinder=\"create-web-schedule-button\"]",
-          "tooltip": "Choose a guided on-call rotation setup."
-        },
-        {
-          "action": "highlight",
-          "reftarget": "[data-pathfinder=\"schedule-name\"]",
-          "tooltip": "Enter a descriptive name for the schedule (for example, `Production SRE`)."
-        },
-        {
-          "action": "button",
-          "reftarget": "[data-pathfinder=\"save-schedule-button\"]",
-          "tooltip": "Save the schedule. The rotation configuration modal opens automatically."
+          "stepTimeout": 45000,
+          "steps": [
+            {
+              "action": "highlight",
+              "reftarget": "a[data-testid=\"data-testid Nav menu item\"][href=\"/a/grafana-irm-app/schedules\"]",
+              "requirements": ["navmenu-open"],
+              "tooltip": "Open the schedule list from the IRM navigation menu."
+            },
+            {
+              "action": "button",
+              "reftarget": "[data-pathfinder=\"new-schedule-button\"]",
+              "tooltip": "Start creating a new schedule."
+            },
+            {
+              "action": "button",
+              "reftarget": "[data-pathfinder=\"create-web-schedule-button\"]",
+              "tooltip": "Choose a guided on-call rotation setup."
+            },
+            {
+              "action": "formfill",
+              "reftarget": "[data-pathfinder=\"schedule-name\"]",
+              "targetvalue": "Production SRE",
+              "tooltip": "Enter a descriptive name for the schedule (for example, `Production SRE`)."
+            },
+            {
+              "action": "button",
+              "reftarget": "[data-pathfinder=\"save-schedule-button\"]",
+              "tooltip": "Save the schedule. The rotation configuration modal opens automatically."
+            }
+          ]
         }
       ]
     },
@@ -50,25 +58,32 @@
       "content": "Now configure a single rotation layer. The first user in the rotation is on call when the schedule starts."
     },
     {
-      "type": "guided",
-      "content": "Add a rotation layer to your schedule.",
-      "stepTimeout": 45000,
-      "steps": [
+      "type": "section",
+      "id": "add-rotation-layer",
+      "title": "Add a rotation layer",
+      "blocks": [
         {
-          "action": "highlight",
-          "reftarget": "div[data-testid=\"schedule-rotations\"] button:first-of-type",
-          "skippable": true,
-          "tooltip": "Add a new rotation. Skip this step if the rotation editor is already open."
-        },
-        {
-          "action": "highlight",
-          "reftarget": "[data-pathfinder=\"add-user-select\"]",
-          "tooltip": "Select at least one responder. Drag to reorder; the top user is first on-call."
-        },
-        {
-          "action": "button",
-          "reftarget": "[data-pathfinder=\"save-rotation-button\"]",
-          "tooltip": "Save the rotation."
+          "type": "guided",
+          "content": "Add a rotation layer to your schedule.",
+          "stepTimeout": 45000,
+          "steps": [
+            {
+              "action": "highlight",
+              "reftarget": "div[data-testid=\"schedule-rotations\"] button:first-of-type",
+              "skippable": true,
+              "tooltip": "Add a new rotation. Skip this step if the rotation editor is already open."
+            },
+            {
+              "action": "highlight",
+              "reftarget": "[data-pathfinder=\"add-user-select\"]",
+              "tooltip": "Select at least one responder. Drag to reorder; the top user is first on-call."
+            },
+            {
+              "action": "button",
+              "reftarget": "[data-pathfinder=\"save-rotation-button\"]",
+              "tooltip": "Save the rotation."
+            }
+          ]
         }
       ]
     },

--- a/grafana-irm-configuration-lj/run-end-to-end-test/content.json
+++ b/grafana-irm-configuration-lj/run-end-to-end-test/content.json
@@ -20,26 +20,33 @@
       "content": "After the rule fires, verify the resulting Alert group in IRM and acknowledge it:"
     },
     {
-      "type": "guided",
-      "content": "Verify and acknowledge the new Alert group.",
-      "requirements": ["navmenu-open"],
-      "stepTimeout": 45000,
-      "steps": [
+      "type": "section",
+      "id": "verify-alert-group",
+      "title": "Verify and acknowledge the Alert group",
+      "blocks": [
         {
-          "action": "highlight",
-          "reftarget": "a[data-testid=\"data-testid Nav menu item\"][href=\"/a/grafana-irm-app/alert-groups\"]",
+          "type": "guided",
+          "content": "Verify and acknowledge the new Alert group.",
           "requirements": ["navmenu-open"],
-          "tooltip": "Open the Alert groups list in IRM."
-        },
-        {
-          "action": "highlight",
-          "reftarget": "[data-testid=\"integration-url\"]:nth-match(1) a",
-          "tooltip": "Open the most recent Alert group to view its details and timeline."
-        },
-        {
-          "action": "highlight",
-          "reftarget": "button:text(\"Acknowledge\")",
-          "tooltip": "Acknowledge the Alert group to stop further escalation and notifications."
+          "stepTimeout": 45000,
+          "steps": [
+            {
+              "action": "highlight",
+              "reftarget": "a[data-testid=\"data-testid Nav menu item\"][href=\"/a/grafana-irm-app/alert-groups\"]",
+              "requirements": ["navmenu-open"],
+              "tooltip": "Open the Alert groups list in IRM."
+            },
+            {
+              "action": "highlight",
+              "reftarget": "[data-testid=\"integration-url\"]:nth-match(1) a",
+              "tooltip": "Open the most recent Alert group to view its details and timeline."
+            },
+            {
+              "action": "highlight",
+              "reftarget": "button:text(\"Acknowledge\")",
+              "tooltip": "Acknowledge the Alert group to stop further escalation and notifications."
+            }
+          ]
         }
       ]
     },
@@ -48,33 +55,40 @@
       "content": "On the Alert group details page, review the timeline to verify escalation chain selection, on-call user identification, notification attempts, and any wait and escalation steps you configured. After acknowledging, restore the alert rule conditions and confirm the rule returns to a non-firing (OK) state after the next evaluation.\n\nIf you don't have an alert rule connected to IRM, you can run a partial test by sending a demo alert from the integration page:"
     },
     {
-      "type": "guided",
-      "content": "Send a demo alert and view the resulting Alert group.",
-      "requirements": ["navmenu-open"],
-      "stepTimeout": 45000,
-      "skippable": true,
-      "steps": [
+      "type": "section",
+      "id": "send-demo-alert",
+      "title": "Send a demo alert",
+      "blocks": [
         {
-          "action": "highlight",
-          "reftarget": "a[data-testid=\"data-testid Nav menu item\"][href=\"/a/grafana-irm-app/integrations\"]",
+          "type": "guided",
+          "content": "Send a demo alert and view the resulting Alert group.",
           "requirements": ["navmenu-open"],
-          "tooltip": "Open the integrations list and select your Grafana Alerting integration."
-        },
-        {
-          "action": "button",
-          "reftarget": "[data-pathfinder=\"send-demo-alert-button\"]",
-          "tooltip": "Trigger a demo alert. Review and optionally customize the payload."
-        },
-        {
-          "action": "button",
-          "reftarget": "[data-pathfinder=\"submit-send-alert-button\"]",
-          "tooltip": "Confirm and send the demo alert."
-        },
-        {
-          "action": "highlight",
-          "reftarget": "a[data-testid=\"data-testid Nav menu item\"][href=\"/a/grafana-irm-app/alert-groups\"]",
-          "requirements": ["navmenu-open"],
-          "tooltip": "Open Alert groups to see the demo alert and its escalation timeline."
+          "stepTimeout": 45000,
+          "skippable": true,
+          "steps": [
+            {
+              "action": "highlight",
+              "reftarget": "a[data-testid=\"data-testid Nav menu item\"][href=\"/a/grafana-irm-app/integrations\"]",
+              "requirements": ["navmenu-open"],
+              "tooltip": "Open the integrations list and select your Grafana Alerting integration."
+            },
+            {
+              "action": "button",
+              "reftarget": "[data-pathfinder=\"send-demo-alert-button\"]",
+              "tooltip": "Trigger a demo alert. Review and optionally customize the payload."
+            },
+            {
+              "action": "button",
+              "reftarget": "[data-pathfinder=\"submit-send-alert-button\"]",
+              "tooltip": "Confirm and send the demo alert."
+            },
+            {
+              "action": "highlight",
+              "reftarget": "a[data-testid=\"data-testid Nav menu item\"][href=\"/a/grafana-irm-app/alert-groups\"]",
+              "requirements": ["navmenu-open"],
+              "tooltip": "Open Alert groups to see the demo alert and its escalation timeline."
+            }
+          ]
         }
       ]
     },


### PR DESCRIPTION
## Summary

Applies the section-wrapping + formfill pattern landed in #327 to all 5 milestones in the `grafana-irm-configuration-lj` learning path that contain interactive (guided) blocks. The 3 pure-markdown milestones (`build-mental-model`, `end-journey`, `understand-value`) are unchanged — they have no guided blocks to wrap.

For each milestone the refactor is mechanical:
1. **Wrap each `guided` block in a `section` block** with a kebab-case `id` and a display `title`.
2. **Convert genuine text-input sub-steps to `formfill`** with sensible default `targetvalue`s — only steps whose tooltip says "Enter a descriptive name" (or equivalent). Dropdown picks, multi-select fields, and search inputs stay as `highlight`.
3. **Existing narrative markdown blocks stay at the top level** between sections (no inner section bookends, matching the convention from #327).

### Per-milestone changes

| Milestone | Sections added | Formfill conversions |
|---|---|---|
| `create-on-call-schedule` | 2 (`create-new-schedule`, `add-rotation-layer`) | 1 — `schedule-name` → `Production SRE` |
| `create-escalation-chain` | 2 (`create-new-escalation-chain`, `add-escalation-chain-steps`) | 1 — `escalation-chain-name-input` → `Production - Default` |
| `connect-grafana-alerting` | 2 (`add-grafana-alerting-integration`, `route-alerts-to-escalation-chain`) | 2 — `integration-name-input` → `Production SRE alerts`, `new-contact-point-input` → `Production IRM` |
| `connect-alert-rule` | 2 (`open-alert-rules-list`, `add-irm-contact-point`) | 0 — no text-input steps |
| `run-end-to-end-test` | 2 (`verify-alert-group`, `send-demo-alert`) | 0 — no text-input steps |

Totals: **10 new sections, 4 formfill conversions, 5 files changed.**

### What is NOT changed

- `schemaVersion`, `id`, `title` on any file
- All `requirements` arrays (preserved verbatim — including `navmenu-open`)
- `stepTimeout`, `skippable`, `content`, `tooltip` on every block and step
- All selectors
- All narrative markdown blocks
- The 3 pure-markdown milestones (`build-mental-model`, `end-journey`, `understand-value`)

## Test plan

For each of the 5 modified milestones, load it in a Pathfinder dev environment as part of the `grafana-irm-configuration-lj` learning path and confirm:

- [ ] Both section titles render in the section index
- [ ] The guided stepper inside each section runs through its original steps in order
- [ ] Formfill steps (where present) populate the right field with the default value
- [ ] Dropdown/select/multi-select steps still open and let the user pick manually
- [ ] Narrative markdown blocks render between sections as expected
- [ ] Existing requirements (`navmenu-open` on nav steps, `skippable` on skippable steps) still gate correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)