### PR TITLE
Change CODEOWNERS to Eve for billing-usage-lj

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -27,7 +27,7 @@
 /adaptive-metrics-lj/                                     @brendamuir
 /adaptive-metrics-recommendations/                        @brendamuir
 /alerting-101/                                            @tomglenn
-/billing-usage-lj/                                        @jtvdez
+/billing-usage-lj/                                        @Eve832
 /categorize-collector-fleet-lj/                            @tiffany76
 /connect-prometheus-metrics/                              @tacole02
 /detect-outages-synthetic-monitoring-lj/                  @heitortsergent


### PR DESCRIPTION
I'm taking over pricing docs. Also, I will need to rework this interactive guide in anticipation of the deprecation of the cost management and billing dashboards in favor of the app. 