### PR TITLE
Migrate MySQL data source numbered steps

### DIFF
--- a/mysql-data-source-lj/prepare-configuration/content.json
+++ b/mysql-data-source-lj/prepare-configuration/content.json
@@ -20,28 +20,23 @@
       "autoCollapse": false,
       "blocks": [
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Connect to your MySQL server as an administrative user:\n\n```bash\nmysql -u root -p\n```"
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Create a dedicated monitoring user for Grafana:\n\n```sql\nCREATE USER 'grafanaReader' IDENTIFIED BY 'password';\n```"
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Grant the necessary privileges for monitoring:\n\n```sql\nGRANT SELECT ON performance_schema.* TO 'grafanaReader';\n```"
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Exit the MySQL client:\n\n```sql\nEXIT;\n```"
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Test the monitoring user connection:\n\n```bash\nmysql -u grafanaReader -p -e \"SHOW STATUS LIKE 'Uptime';\"\n```"
         }
       ]


### PR DESCRIPTION
Migrates the MySQL data source learning path from noop workaround steps to markdown content blocks so Pathfinder can render them as sequentially numbered section steps. Part of https://github.com/grafana/interactive-tutorials/issues/314.

Made with [Cursor](https://cursor.com)