### PR TITLE
Migrate Grafana Cloud tour numbered steps

### DIFF
--- a/grafana-cloud-tour-lj/explore-connect-data/content.json
+++ b/grafana-cloud-tour-lj/explore-connect-data/content.json
@@ -16,8 +16,7 @@
       "autoCollapse": false,
       "blocks": [
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "If you have not signed in to your Grafana Cloud environment, do so now."
         },
         {
@@ -65,8 +64,7 @@
           "content": "You can use these settings to configure the connection to your external MySQL server. After that, you can create dashboards and queries for your data."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Notice the tabs at the top lead to additional settings and information."
         }
       ]

--- a/grafana-cloud-tour-lj/explore-platform-components/content.json
+++ b/grafana-cloud-tour-lj/explore-platform-components/content.json
@@ -12,8 +12,7 @@
       "autoCollapse": false,
       "blocks": [
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Open the main menu on the left side of the screen."
         },
         {

--- a/grafana-cloud-tour-lj/explore-send-data/content.json
+++ b/grafana-cloud-tour-lj/explore-send-data/content.json
@@ -16,8 +16,7 @@
       "autoCollapse": false,
       "blocks": [
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "If you have not signed in to your Grafana Cloud environment, do so now."
         },
         {
@@ -54,8 +53,7 @@
           "content": "This opens a set of steps for sending metrics to your Grafana Cloud Prometheus endpoint. The alternative is connecting an external Prometheus data source, which you'll explore in the next milestone."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Review the two installation options: **Standard** (for regular hosts) and **Kubernetes** (for cluster workloads)."
         }
       ]


### PR DESCRIPTION
Migrates the Grafana Cloud tour learning path from noop workaround steps to markdown content blocks so Pathfinder can render them as sequentially numbered section steps. Part of https://github.com/grafana/interactive-tutorials/issues/314.

Made with [Cursor](https://cursor.com)