### PR TITLE
Migrate billing usage numbered steps

### DIFF
--- a/billing-usage-lj/create-billing-alert/content.json
+++ b/billing-usage-lj/create-billing-alert/content.json
@@ -97,14 +97,8 @@
           "doIt": false
         },
         {
-          "type": "interactive",
-          "action": "highlight",
-          "reftarget": "a[data-testid='data-testid Nav menu item'][href='/alerting/routes']",
-          "content": "Notification policies are configured separately from alert rules. If you need to route alerts to different teams based on labels, navigate to **Notification policies** in the sidebar. Refer to the [notification policies documentation](https://grafana.com/docs/grafana-cloud/alerting-and-irm/alerting/configure-notifications/create-notification-policy/) for details.",
-          "requirements": [
-            "navmenu-open"
-          ],
-          "doIt": false
+          "type": "markdown",
+          "content": "Notification policies are configured separately from alert rules. If you need to route alerts to different teams based on labels, use **Notification configuration** and open the **Notification policies** tab. Refer to the [notification policies documentation](https://grafana.com/docs/grafana-cloud/alerting-and-irm/alerting/configure-notifications/create-notification-policy/) for details."
         },
         {
           "type": "interactive",

--- a/billing-usage-lj/create-billing-alert/content.json
+++ b/billing-usage-lj/create-billing-alert/content.json
@@ -16,13 +16,11 @@
       "autoCollapse": false,
       "blocks": [
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "In the Billing/Usage dashboard, identify a panel for which you want to create an alert."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Click the panel menu (⋮) on the chosen panel, then select **More…** > **New alert rule**."
         },
         {

--- a/billing-usage-lj/identify-cost-sources/content.json
+++ b/billing-usage-lj/identify-cost-sources/content.json
@@ -28,18 +28,15 @@
           "alt": "Dashboard panel showing monthly cost per product"
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Compare the cost values to identify which products contribute most to your total bill. In the preceding example, with a projected monthly cost of $3,100, the `VUh (k6)` cost is the primary cost driver."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Scroll down on the Billing/Usage dashboard and expand the row for the product that contributes to the highest costs. For example, locate and expand the **k6 Virtual User Hours (VUh)** row."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Review the time series panels to understand usage trends."
         }
       ]

--- a/billing-usage-lj/navigate-to-billing-dashboard/content.json
+++ b/billing-usage-lj/navigate-to-billing-dashboard/content.json
@@ -12,8 +12,7 @@
       "autoCollapse": false,
       "blocks": [
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Sign in to your Grafana Cloud environment, for example `mystack.grafana.net`."
         },
         {


### PR DESCRIPTION
Migrates the billing usage learning path from noop workaround steps to markdown content blocks so Pathfinder can render them as sequentially numbered section steps. Part of https://github.com/grafana/interactive-tutorials/issues/314.

Made with [Cursor](https://cursor.com)