### PR TITLE
Migrate Prometheus numbered steps

### DIFF
--- a/prometheus-lj/config-authentication/content.json
+++ b/prometheus-lj/config-authentication/content.json
@@ -40,8 +40,7 @@
           "content": "In the **Authentication method** dropdown, select a method of authentication.\n\nFor example: **Basic authentication**."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "For basic authentication, enter the username and password."
         }
       ]

--- a/prometheus-lj/verify-ds-connection/content.json
+++ b/prometheus-lj/verify-ds-connection/content.json
@@ -26,8 +26,7 @@
           "content": "In the Grafana side menu, click **Drilldown > Metrics**."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "If you see a **Let's start!** button, click it."
         }
       ]

--- a/prometheus-lj/verify-prom-data/content.json
+++ b/prometheus-lj/verify-prom-data/content.json
@@ -24,23 +24,19 @@
       "autoCollapse": false,
       "blocks": [
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Log into the machine on which Prometheus is installed."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "If required, switch to a user that has administrative privileges."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "To check the Prometheus service status, run one of the following commands:\n\nFor Linux:\n\n```\nsystemctl status prometheus.service\n```\n\nFor Windows:\n\n```\nsc query prometheus\n```\n\nYou should see something similar to the following:"
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "To ensure that Prometheus is capturing the metrics, open a browser tab and navigate to the metrics endpoint URL.\n\nFor example, navigate to `http://localhost:9090/metrics`\n\nYou should see something similar to the following:"
         }
       ]


### PR DESCRIPTION
Migrates the Prometheus learning path from noop workaround steps to markdown content blocks so Pathfinder can render them as sequentially numbered section steps. Part of https://github.com/grafana/interactive-tutorials/issues/314.

Made with [Cursor](https://cursor.com)