### PR TITLE
Migrate logs visualization numbered steps

### DIFF
--- a/visualization-logs/add-visualization/content.json
+++ b/visualization-logs/add-visualization/content.json
@@ -20,8 +20,7 @@
       "autoCollapse": false,
       "blocks": [
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "**Sign in to Grafana Cloud**\n\nSign in to your Grafana Cloud environment (for example, `mystack.grafana.net`)."
         },
         {
@@ -41,13 +40,11 @@
           ]
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "In the edit pane on the right, under **Add**, click **Panel** or drag it onto the dashboard canvas.\n\nA new panel is added to your dashboard."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "On the new panel, enter a panel title and description, and click **Configure** to open the Edit panel view."
         },
         {

--- a/visualization-logs/save-dashboard/content.json
+++ b/visualization-logs/save-dashboard/content.json
@@ -23,8 +23,7 @@
           "requirements": ["exists-reftarget"]
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "In the save dialog:\n\na. Enter a **title** and **description** for your dashboard.\n\n  b. Select a **folder** if applicable.\n\n  c. Click **Save**."
         },
         {

--- a/visualization-logs/time-range-refresh/content.json
+++ b/visualization-logs/time-range-refresh/content.json
@@ -36,8 +36,7 @@
           "requirements": ["exists-reftarget"]
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "You are now ready to save the dashboard so that other users can view it."
         }
       ]

--- a/visualization-logs/write-query/content.json
+++ b/visualization-logs/write-query/content.json
@@ -62,8 +62,7 @@
       "autoCollapse": false,
       "blocks": [
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "To define a log pipeline expression, select a line filter operator.\n\nFor example, select **Line contains** and enter `error`. The system returns all error logs. All other log types (warning, info) aren't included in the Logs panel."
         },
         {


### PR DESCRIPTION
Migrates the logs visualization learning path from noop workaround steps to markdown content blocks so Pathfinder can render them as sequentially numbered section steps. Part of https://github.com/grafana/interactive-tutorials/issues/314.

Made with [Cursor](https://cursor.com)