### PR TITLE
Migrate logs drilldown numbered steps

### DIFF
--- a/drilldown-logs-lj/add-log-dashboard/content.json
+++ b/drilldown-logs-lj/add-log-dashboard/content.json
@@ -39,8 +39,7 @@
           ]
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Enter a title and description for your dashboard, select a folder if applicable, and click **Save**."
         }
       ]

--- a/drilldown-logs-lj/log-patterns/content.json
+++ b/drilldown-logs-lj/log-patterns/content.json
@@ -12,8 +12,7 @@
       "autoCollapse": false,
       "blocks": [
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "To start your filters from scratch, remove all filter selections above the **Logs** tab."
         },
         {
@@ -24,13 +23,11 @@
           "requirements": ["exists-reftarget"]
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Identify a pattern that matches the type of logs you're interested in viewing."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Click the **Include** button for the pattern.\n\nUsing the example from the previous milestone, the pattern `The flag is <_>` is selected."
         },
         {

--- a/drilldown-logs-lj/open-logs-explore/content.json
+++ b/drilldown-logs-lj/open-logs-explore/content.json
@@ -12,8 +12,7 @@
       "autoCollapse": false,
       "blocks": [
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Hover your cursor over the log you want to open in Explore."
         },
         {
@@ -41,8 +40,7 @@
           "alt": "Image shows log metric open in Explore"
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "To better understand the query, click the **Explain query** toggle."
         }
       ]

--- a/drilldown-logs-lj/search-logs/content.json
+++ b/drilldown-logs-lj/search-logs/content.json
@@ -12,8 +12,7 @@
       "autoCollapse": false,
       "blocks": [
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "On the **Logs** tab, review the **Log volume** dashboard and click the log legend to filter it by log level.\n\nThe following example shows the `error` log level selected and all error logs listed."
         },
         {


### PR DESCRIPTION
Migrates the Logs Drilldown learning path from noop workaround steps to markdown content blocks so Pathfinder can render them as sequentially numbered section steps. Part of https://github.com/grafana/interactive-tutorials/issues/314.

Made with [Cursor](https://cursor.com)