### PR TITLE
Migrate metrics drilldown numbered steps

### DIFF
--- a/drilldown-metrics-lj/add-metric-dashboard/content.json
+++ b/drilldown-metrics-lj/add-metric-dashboard/content.json
@@ -31,8 +31,7 @@
           "requirements": ["exists-reftarget"]
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "On the **Add panel to dashboard** dialog box, perform one of the following:\n\n- To add the visualization to a new dashboard, click **New dashboard**.\n- To add the visualization to an existing dashboard, click **Existing dashboard** and select a dashboard from the list.\n\nThe visualization appears in a dashboard."
         },
         {
@@ -43,8 +42,7 @@
           "requirements": ["exists-reftarget"]
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Enter a title and description for your dashboard, select a folder if applicable, and click **Save**."
         }
       ]

--- a/drilldown-metrics-lj/analyze-data/content.json
+++ b/drilldown-metrics-lj/analyze-data/content.json
@@ -12,8 +12,7 @@
       "autoCollapse": false,
       "blocks": [
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Review the panels and identify a metric of interest.\n\nIn the following example, the `node_cpu_online` and `node_cpu_guest_seconds` metrics show little variation, making them less interesting to analyze. The `node_cpu_seconds_total` and `node_cpu_usage_seconds_total` metrics, which exhibit more change, are more valuable to explore."
         },
         {
@@ -38,8 +37,7 @@
           "doIt": false
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Continue your investigation by reviewing the **Breakdown** tab and the **Related metrics** tab."
         },
         {

--- a/drilldown-metrics-lj/open-metrics-explore/content.json
+++ b/drilldown-metrics-lj/open-metrics-explore/content.json
@@ -12,8 +12,7 @@
       "autoCollapse": false,
       "blocks": [
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Hover your cursor over the metric you want to open in Explore."
         },
         {
@@ -37,8 +36,7 @@
           "requirements": ["exists-reftarget"]
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "When the metrics visualization opens, you'll see the query view. If needed, you can edit the query."
         },
         {

--- a/drilldown-metrics-lj/search-metrics/content.json
+++ b/drilldown-metrics-lj/search-metrics/content.json
@@ -19,8 +19,7 @@
           "content": "On the Grafana Cloud home page, open the navigation menu and click **Drilldown > Metrics**."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "If you see a **Let's start** button, click it."
         },
         {


### PR DESCRIPTION
Migrates the Metrics Drilldown learning path from noop workaround steps to markdown content blocks so Pathfinder can render them as sequentially numbered section steps. Part of https://github.com/grafana/interactive-tutorials/issues/314.

Made with [Cursor](https://cursor.com)