### PR TITLE
Migrate metrics visualization numbered steps

### DIFF
--- a/visualization-metrics-lj/add-visualization/content.json
+++ b/visualization-metrics-lj/add-visualization/content.json
@@ -12,8 +12,7 @@
       "autoCollapse": false,
       "blocks": [
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Sign in to your Grafana Cloud environment (for example, `mystack.grafana.net`)."
         },
         {
@@ -33,18 +32,15 @@
           ]
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "In the **Add** drawer, click the **Panel** card to add a new visualization to your dashboard.\n\nA new panel is added to your dashboard."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "On the new panel, click **Configure**.\n\nThe **Edit panel** view opens with the default Prometheus data source preselected."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "If you want to use a different data source, in the **Queries** tab, click the **Data source** drop-down list and select one of your existing data sources."
         }
       ]

--- a/visualization-metrics-lj/save-dashboard/content.json
+++ b/visualization-metrics-lj/save-dashboard/content.json
@@ -12,8 +12,7 @@
       "autoCollapse": false,
       "blocks": [
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "On the right of the **Edit panel** page, under **Panel options**, enter a panel **Title** and description.\n\nThe title appears at the top of the visualization."
         },
         {
@@ -24,18 +23,15 @@
           "requirements": ["exists-reftarget"]
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Enter a **title** and **description** for your dashboard."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Select a **folder**, if applicable."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Click **Save**."
         },
         {

--- a/visualization-metrics-lj/time-range-refresh/content.json
+++ b/visualization-metrics-lj/time-range-refresh/content.json
@@ -24,8 +24,7 @@
           "requirements": ["exists-reftarget"]
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Select a time range from the available options (for example, **Last 1 hour**, **Last 6 hours**, or **Last 24 hours**)."
         },
         {
@@ -37,8 +36,7 @@
           "requirements": ["exists-reftarget"]
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Select a refresh interval from the available options (for example, **1m**, **5m**, or **15m**)."
         }
       ]

--- a/visualization-metrics-lj/write-query/content.json
+++ b/visualization-metrics-lj/write-query/content.json
@@ -28,8 +28,7 @@
           "requirements": ["exists-reftarget"]
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "(Optional) In the **Label filters** fields, select a key-value pair and operator to filter your data. For example, select `node`, `=`, and your specific node ID."
         },
         {


### PR DESCRIPTION
Migrates the metrics visualization learning path from noop workaround steps to markdown content blocks so Pathfinder can render them as sequentially numbered section steps. Part of https://github.com/grafana/interactive-tutorials/issues/314.

Made with [Cursor](https://cursor.com)