### PR TITLE
Migrate HAProxy numbered steps

### DIFF
--- a/haproxy-load-balancer-lj/configure-integration/content.json
+++ b/haproxy-load-balancer-lj/configure-integration/content.json
@@ -12,18 +12,15 @@
       "autoCollapse": false,
       "blocks": [
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "If you navigated away, return to the HAProxy integration page:\n\na. Click **Connections > Add new connection** in the left-side menu\n\nb. Search for `HAProxy` and click the tile\n\nc. Click **Proceed to install integration** if you completed the Alloy installation step"
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "In the **Configure your HAProxy integration** section, enter the address of your HAProxy Prometheus endpoint.\n\nIf you used the configuration from the previous step, enter:\n\n```\nhttp://localhost:8405/metrics\n```\n\nIf your HAProxy server and Alloy are on different machines, replace `localhost` with the HAProxy server's IP address or hostname."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Review the configuration and click **Test integration** to verify that Alloy can reach the HAProxy metrics endpoint.\n\nIf the test succeeds, click **Save and apply**."
         }
       ]

--- a/haproxy-load-balancer-lj/install-alloy/content.json
+++ b/haproxy-load-balancer-lj/install-alloy/content.json
@@ -18,28 +18,23 @@
           "content": "In the **Install Alloy** section, click **Run Grafana Alloy**."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Perform one of the following:\n\n| If you want to | Then |\n| --- | --- |\n| Create a new token | Click **Create new token**, enter a meaningful token name (for example, `haproxy-prod`), then click **Create token**. |\n| Use an existing token | Click **Use an existing token** and enter a token you have created in the past. |\n\n**Tip:** You don't need to copy the token. The token is added to the Alloy install script that you copy in the next step."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Verify that the **Enable Remote Configuration** toggle is set to on."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "In the **Install and run Grafana Alloy** section, click **Copy to Clipboard**."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Log in to your HAProxy server and open a terminal. Paste the contents of the clipboard into the terminal and press **Enter**.\n\nWhen the installation is complete, you'll see `Alloy is now running!`"
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "To verify that Grafana Alloy is installed correctly, click **Test Alloy connection**.\n\nIf Alloy is installed correctly, you'll see `Awesome! Grafana Alloy is good to go`."
         }
       ]

--- a/haproxy-load-balancer-lj/install-dashboards/content.json
+++ b/haproxy-load-balancer-lj/install-dashboards/content.json
@@ -62,8 +62,7 @@
           "requirements": ["navmenu-open"]
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Find and open the **HAProxy overview** dashboard from the integration folder.\n\nThis dashboard provides a high-level view of your HAProxy instance."
         }
       ]

--- a/haproxy-load-balancer-lj/select-platform/content.json
+++ b/haproxy-load-balancer-lj/select-platform/content.json
@@ -46,8 +46,7 @@
           "doIt": false
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "If you are unsure of the architecture, run `uname -m` in your terminal. If it returns `x86_64`, select **Amd64**. If it returns `aarch64`, select **Arm64**."
         }
       ]

--- a/haproxy-load-balancer-lj/verify-metrics/content.json
+++ b/haproxy-load-balancer-lj/verify-metrics/content.json
@@ -42,8 +42,7 @@
           "requirements": ["on-page:/explore"]
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "If no data appears, wait 2-3 minutes for the first scrape to complete, then try again.\n\nYou can also try `up{job=~\".*haproxy.*\"}` to confirm the scrape target is healthy. A value of `1` means the target is up and being scraped."
         }
       ]


### PR DESCRIPTION
Migrates the HAProxy learning path from noop workaround steps to markdown content blocks so Pathfinder can render them as sequentially numbered section steps. Part of https://github.com/grafana/interactive-tutorials/issues/314.

Made with [Cursor](https://cursor.com)