### PR TITLE
Migrate Infinity CSV numbered steps

### DIFF
--- a/infinity-csv-lj/build-dashboard/content.json
+++ b/infinity-csv-lj/build-dashboard/content.json
@@ -31,13 +31,11 @@
           "content": "From the navigation menu, click **Dashboards**."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Click **New** and select **New dashboard**."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Open the panel editor by doing one of the following:\n\n- If you see an **Add visualization** button or placeholder, click it.\n- If you see a **+** icon in the top toolbar, click it and select **Visualization**.\n\nEither option opens the panel editor."
         },
         {
@@ -48,8 +46,7 @@
           "content": "In the query section at the bottom of the screen, click the **Data source** dropdown and search for your Infinity data source."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Select your Infinity data source from the list."
         },
         {
@@ -125,8 +122,7 @@
           "content": "In the toolbar, click **Save dashboard**."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Enter a name for your dashboard and click **Save**."
         }
       ]

--- a/infinity-csv-lj/check-health/content.json
+++ b/infinity-csv-lj/check-health/content.json
@@ -24,28 +24,23 @@
       "autoCollapse": false,
       "blocks": [
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "On the data source left navigation, click **Health check**."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Click the **Enable custom health check** toggle."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Enter the CSV endpoint URL.\n\nFor example, enter `https://thingspeak.com/channels/38629/feed.csv`. This CSV endpoint is available to the public and we'll use it in this journey, but you should use a URL that returns the data you want to use."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Click **Save & test**."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "You should receive a `Health check successful` message."
         }
       ]

--- a/infinity-csv-lj/config-authentication/content.json
+++ b/infinity-csv-lj/config-authentication/content.json
@@ -28,18 +28,15 @@
       "autoCollapse": false,
       "blocks": [
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "On the data source left navigation, click **Authentication**."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Select the authentication method you want to configure.\n\nFor example: **Basic authentication**."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "For basic authentication, enter the username and password."
         }
       ]

--- a/infinity-csv-lj/select-private-connection/content.json
+++ b/infinity-csv-lj/select-private-connection/content.json
@@ -41,8 +41,7 @@
           "content": "Click **Save & test**."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "When successful, you'll see a `Success` message."
         }
       ]


### PR DESCRIPTION
Migrates the Infinity CSV learning path from noop workaround steps to markdown content blocks so Pathfinder can render them as sequentially numbered section steps. Part of https://github.com/grafana/interactive-tutorials/issues/314.

Made with [Cursor](https://cursor.com)