### PR TITLE
Migrate Linux server numbered steps

### DIFF
--- a/linux-server-integration-lj/configure-alloy/content.json
+++ b/linux-server-integration-lj/configure-alloy/content.json
@@ -32,18 +32,15 @@
           "alt": "Shows the snippet to copy from Grafana Cloud to the Alloy configuration file"
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "On your Linux machine, run the following command to open the Alloy configuration file:\n\n```\nsudo nano /etc/alloy/config.alloy\n```"
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Scroll to the end of the configuration file and paste the code snippet you copied from Grafana Cloud."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Press `Ctrl+O` to write the changes to the file, then press **Enter** to save. Press `Ctrl+X` to exit the editor.\n\nIn the next step of your journey, you'll restart Alloy and test the configuration."
         }
       ]

--- a/linux-server-integration-lj/install-alloy/content.json
+++ b/linux-server-integration-lj/install-alloy/content.json
@@ -27,33 +27,27 @@
           "content": "In the **Install Alloy** section, click **Run Grafana Alloy**."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Perform one of the following:\n\n| If you want to | Then |\n| --- | --- |\n| Create a new token | Click **Create new token**, enter a meaningful token name (e.g., `prodUS`), then click **Create token**. |\n| Use an existing token | Click **Use an existing token** and enter a token you have created in the past. |\n\n**Tip:** You don't need to copy the token. The token is added to the install Grafana Alloy script that you copy in the next step."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Verify that the **Enable Remote Configuration** toggle is set to on."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "In the **Install and run Grafana Alloy** section, click **Copy to Clipboard**."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Log in to the Linux machine and open the Terminal. Paste the contents of the clipboard into the terminal and press **Enter**.\n\nThis command installs Grafana Alloy on the Linux machine. When the installation is complete, you'll see `Alloy is now running!`"
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "To verify that Grafana Alloy is installed correctly, click **Test Alloy connection**.\n\nIf Grafana Alloy is installed correctly, you'll see `Awesome! Grafana Alloy is good to go`."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "If Alloy is successfully installed, click **Proceed to install integration**."
         }
       ]

--- a/linux-server-integration-lj/install-dashboards-alerts/content.json
+++ b/linux-server-integration-lj/install-dashboards-alerts/content.json
@@ -34,8 +34,7 @@
           "content": "To view dashboards, click **View Dashboards**.\n\nA folder containing the integration dashboards appears."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "To see the installed alerts, navigate to **Alerts & IRM > Alerting > Alert rules**.\n\nThe Alert rules page shows all active alerts. Linux integration alerts begin with `integrations-linux-node`."
         }
       ]

--- a/linux-server-integration-lj/restart-test-connection/content.json
+++ b/linux-server-integration-lj/restart-test-connection/content.json
@@ -20,8 +20,7 @@
       "autoCollapse": false,
       "blocks": [
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "In the Linux machine Terminal, enter the following command and press **Enter**:\n\n```\nsudo systemctl restart alloy.service\n```\n\n**Tip:** You see the Terminal prompt after you run the Alloy restart command. You don't receive feedback from Linux that the restart is running or is complete."
         },
         {

--- a/linux-server-integration-lj/select-platform/content.json
+++ b/linux-server-integration-lj/select-platform/content.json
@@ -40,8 +40,7 @@
           "content": "Click the **Linux Server** tile."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Use the following table to select the operating system:\n\n| If you are running | Select |\n| --- | --- |\n| Debian | Debian |\n| Ubuntu | Debian |\n| Red Hat Enterprise Linux (RHEL) | RedHat |\n| Fedora | RedHat |\n| CentOS | RedHat |"
         },
         {
@@ -61,8 +60,7 @@
           "doIt": false
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "If you are unsure of the architecture, run `uname -m` in your Linux terminal. If it returns `x86_64`, select **Amd64**. If it returns `aarch64`, select **Arm64**. If the command returns anything else, your system isn't supported by Grafana Alloy."
         }
       ]


### PR DESCRIPTION
Migrates the Linux server integration learning path from noop workaround steps to markdown content blocks so Pathfinder can render them as sequentially numbered section steps. Part of https://github.com/grafana/interactive-tutorials/issues/314.

Made with [Cursor](https://cursor.com)