### PR TITLE
Migrate GitHub data source numbered steps

### DIFF
--- a/github-data-source-lj/config-github-datasource/content.json
+++ b/github-data-source-lj/config-github-datasource/content.json
@@ -36,18 +36,15 @@
           "content": "In the **Name** field, enter a descriptive name for your data source.\n\nFor example, enter `My GitHub Organization Data` or `GitHub Repository Data`.\n\n> **Did you know?** The name of the data source appears on the dashboard panels, so it's important to choose a meaningful name. If there are multiple data sources for a dashboard panel, the default toggle determines which data source appears by default."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Optionally, enable the **Default** toggle if you want this to be your default data source when creating new panels."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Scroll down to the **Authentication** section at the bottom of the page."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "For **Authentication Type**, **Personal Access Token** is selected by default. This is the recommended option for most users."
         },
         {
@@ -59,8 +56,7 @@
           "content": "Paste the GitHub Personal Access Token you created earlier.\n\n**Tip:** Ensure you paste the complete token without any extra spaces or characters."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Under **Connection**, select your **GitHub License Type**:\n\n- **Free, Pro & Team** (default) - For personal accounts and standard GitHub organizations\n- **Enterprise Cloud** - For GitHub Enterprise Cloud customers\n- **Enterprise Server** - For self-hosted GitHub Enterprise Server"
         },
         {

--- a/github-data-source-lj/create-github-token/content.json
+++ b/github-data-source-lj/create-github-token/content.json
@@ -40,53 +40,43 @@
       "autoCollapse": false,
       "blocks": [
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Sign in to your GitHub account at `github.com`."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Click your profile avatar in the upper right corner and select **Settings**."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "In the left sidebar, scroll down and click **Developer settings**."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Click **Personal access tokens > Tokens (classic)**."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Click **Generate new token > Generate new token (classic)**."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "In the **Note** field, enter a descriptive name for the token.\n\nFor example, enter `Grafana Cloud GitHub Data Source`."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Set the **Expiration** based on your organization's security policies.\n\nFor testing purposes, you can select **7 days**. For production use, consider your organization's token rotation policies."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Under **Select scopes**, select the following permissions:\n\n- For all repositories: `public_repo`, `repo:status`, `repo_deployment`, `read:packages`, `read:user`, `user:email`\n- For GitHub projects: `read:org`, `read:project`\n- An extra setting is required for private repositories: `repo` (Full control of private repositories)"
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Click **Generate token** at the bottom of the page."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Copy the generated token immediately and store it securely. GitHub will not display the token again after you leave this page.\n\n**Caution:** Treat your Personal Access Token like a password. Store it securely and never commit it to version control or share it publicly."
         }
       ]


### PR DESCRIPTION
Migrates the GitHub data source learning path from noop workaround steps to markdown content blocks so Pathfinder can render them as sequentially numbered section steps. Part of https://github.com/grafana/interactive-tutorials/issues/314.

Made with [Cursor](https://cursor.com)