### PR TITLE
Migrate PDC numbered steps

### DIFF
--- a/private-data-source-connect-lj/deploy-pdc-agent/content.json
+++ b/private-data-source-connect-lj/deploy-pdc-agent/content.json
@@ -18,34 +18,23 @@
       "autoCollapse": false,
       "blocks": [
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "If you deploy on Kubernetes or Docker, follow the instructions in Grafana Cloud for that method: use the published PDC agent image, supply your PDC signing token and any host or cluster values the UI shows, and start the workload. For more detail, see [Configure Private data source connect](https://grafana.com/docs/grafana-cloud/connect-externally-hosted/private-data-source-connect/configure-pdc).\n\nWhen the agent is running, continue to the connection test step at the end of this section."
         },
         {
-          "type": "interactive",
-          "action": "noop",
-          "skippable": true,
-          "hint": "Skip if you deployed on Kubernetes or Docker.",
+          "type": "markdown",
           "content": "If you installed the standalone binary on a server, on that machine open a terminal and go to the directory that contains the agent files. For example, after extracting the Linux x86_64 tarball:\n\n```\ncd pdc-agent_Linux_x86_64\n```"
         },
         {
-          "type": "interactive",
-          "action": "noop",
-          "skippable": true,
-          "hint": "Skip if you deployed on Kubernetes or Docker.",
+          "type": "markdown",
           "content": "If you are using the standalone binary, in Grafana Cloud copy the command in the **Run this binary** field."
         },
         {
-          "type": "interactive",
-          "action": "noop",
-          "skippable": true,
-          "hint": "Skip if you deployed on Kubernetes or Docker.",
+          "type": "markdown",
           "content": "If you are using the standalone binary, in your server terminal run the command you copied.\n\nYou should receive a success message indicating that the PDC agent is running."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "In Grafana Cloud, click **Test agent connection**.\n\nYou should receive an **Agent connected** message."
         }
       ]

--- a/private-data-source-connect-lj/install-pdc-binary/content.json
+++ b/private-data-source-connect-lj/install-pdc-binary/content.json
@@ -18,33 +18,27 @@
       "autoCollapse": false,
       "blocks": [
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "In Grafana Cloud, click the **PDC Agent releases page** link to open the [releases page](https://github.com/grafana/pdc-agent/releases/tag/v0.0.38)."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Download the file that matches your operating system and architecture."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Sign in to the server on which you are installing PDC and open the terminal.\n\nIf you are installing PDC on a Linux machine and you are unsure of the architecture, run `uname -m` in the terminal. If you are installing on Linux, run `sudo su -` to switch to the root user."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Download the PDC binary compressed file. For example:\n\n```\nwget https://github.com/grafana/pdc-agent/releases/download/v0.0.38/pdc-agent_Linux_x86_64.tar.gz\n```"
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Extract the contents of the compressed file. For example:\n\n```\ntar -xvzf pdc-agent_Linux_x86_64.tar.gz\n```"
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "You should see output similar to:\n\n```\npdc-agent_Linux_x86_64/LICENSE\npdc-agent_Linux_x86_64/README.md\npdc-agent_Linux_x86_64/pdc\n```"
         }
       ]

--- a/private-data-source-connect-lj/select-installation-method/content.json
+++ b/private-data-source-connect-lj/select-installation-method/content.json
@@ -12,8 +12,7 @@
       "autoCollapse": false,
       "blocks": [
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Sign in to your Grafana Cloud account."
         },
         {
@@ -37,13 +36,11 @@
           "content": "Click **+ Add new network**."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "In the **Connect to a new network** dialog, enter a name for your network or keep the default, then click **Add**."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "On the setup page, select your installation method: **Kubernetes**, **Docker**, or **Binary**."
         }
       ]


### PR DESCRIPTION
Migrates the Private data source connect learning path from noop workaround steps to markdown content blocks so Pathfinder can render them as sequentially numbered section steps. Part of https://github.com/grafana/interactive-tutorials/issues/314.

Made with [Cursor](https://cursor.com)