### PR TITLE
Migrate Windows integration numbered steps

### DIFF
--- a/windows-integration/configure-alloy/content.json
+++ b/windows-integration/configure-alloy/content.json
@@ -20,33 +20,27 @@
       "autoCollapse": false,
       "blocks": [
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "In Grafana Cloud, under the **Set up Grafana Alloy to use the Windows integration** section, click **Copy to clipboard**."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "On your Windows system, open Command Prompt as Administrator."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Open the Alloy configuration file with Notepad:\n\n```cmd\nnotepad \"C:\\Program Files\\GrafanaLabs\\Alloy\\config.alloy\"\n```"
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Scroll to the end of the configuration file and paste the code snippet you copied from Grafana Cloud."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Click **File > Save** to save the changes."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Close Notepad."
         }
       ]

--- a/windows-integration/install-alloy/content.json
+++ b/windows-integration/install-alloy/content.json
@@ -23,28 +23,23 @@
           "requirements": ["exists-reftarget"]
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "**Create or select a token:**\n\nYou can either create a new token or use an existing one. The token authorizes Alloy to send data to your Grafana Cloud instance.\n\n- **Create new token**: Click \"Create new token\", enter a meaningful name (e.g., `MyWindowsServer`), then click \"Create token\".\n- **Use existing token**: Click \"Use an existing token\" and enter a token you've created before."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Verify that the **Enable Remote Configuration** toggle switch is set to off."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Open **Command Prompt as Administrator** on your Windows system, copy the installation command from Grafana Cloud, paste and run the command in Command Prompt, and wait for the installation to complete.\n\nWhen successful, you'll see:\n```\nStatus   Name               DisplayName\n------   ----               -----------\nRunning  Alloy              Alloy\n```"
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "After installing Alloy, click **Test Alloy connection** to verify the installation.\n\nIf successful, you'll see: **Awesome! Grafana Alloy is good to go.**"
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Click **Proceed to install integration** to continue to the next step."
         }
       ]

--- a/windows-integration/test-connection/content.json
+++ b/windows-integration/test-connection/content.json
@@ -12,18 +12,15 @@
       "autoCollapse": false,
       "blocks": [
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "On your Windows system, open Command Prompt as Administrator."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Restart the Alloy service:\n\n```cmd\nsc stop \"Alloy\" \nsc start \"Alloy\" \nsc query \"Alloy\" | find \"STATE\"\n```\n\n> **Tip:** You will see output indicating the service is stopping and starting."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "In Grafana Cloud, click **Test connection**.\n\nIt might take up to a few minutes for the system to verify the connection.\n\nYou'll know the connection is working when you see `Integration is collecting data and sending it to Grafana Cloud`."
         }
       ]


### PR DESCRIPTION
Replace Windows integration noop workaround blocks with markdown content so Pathfinder can render section steps sequentially.

Linked issue: https://github.com/grafana/interactive-tutorials/issues/314

Made with [Cursor](https://cursor.com)