### PR TITLE
Migrate Send logs Alloy Loki numbered steps

### DIFF
--- a/send-logs-alloy-loki-lj/inspect-configuration/content.json
+++ b/send-logs-alloy-loki-lj/inspect-configuration/content.json
@@ -23,8 +23,7 @@
       "type": "section",
       "blocks": [
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Open `http://localhost:12345/` in your browser of choice. By default, Alloy UI is served on port `12345` unless configured otherwise.\n\nYou should see that all components are healthy if they are configured correctly."
         },
         {
@@ -33,8 +32,7 @@
           "alt": "Image showing the Alloy UI homepage"
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Click the **Graph** tab at the top.\n\nYou should see the following graph, which illustrates how the components are all connected."
         },
         {
@@ -43,8 +41,7 @@
           "alt": "Image showing the Alloy UI graph and how the components are connected"
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Click a component to view more information about its function.\n\nIn the following example, the `local.file_match` component is selected. It shows all the log files that Alloy is sourcing."
         },
         {

--- a/send-logs-alloy-loki-lj/install-alloy/content.json
+++ b/send-logs-alloy-loki-lj/install-alloy/content.json
@@ -44,33 +44,27 @@
           "content": "Click **Install Grafana Alloy**."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Use the following table to select the operating system.\n\n| If you are running              | Select |\n| ------------------------------- | ------ |\n| Debian                          | Debian |\n| Ubuntu                          | Debian |\n| Red Hat Enterprise Linux (RHEL) | RedHat |\n| Fedora                          | RedHat |\n| CentOS                          | RedHat |\n| Windows                         | Windows|\n| MacOS                           | MacOS |\n\nIf you are on MacOS, select the installation method."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Perform one of the following:\n\n| If you want to        | Then                                                                                                                                                                                                                                                                                                              |\n| --------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |\n| Create a new token    | <ol><li>Click <b>Create new token</b>.</li><li><p>Enter a token name.</p><p>Make sure the token name is meaningful to you and something you'll remember. For example, <code>prodUS</code>.</p></li><li><p>Click <b>Create token.</b></p><p><b>Note:</b> You don't need to adjust the <b>Scopes</b>.</p></li></ol> |\n| Use an existing token | <ol><li>Click <b>Use an existing token</b>.</li><li>Enter a token you have created in the past.</li></ol>                                                                                                                                                                                                         |\n\n> **Tip:** You don't need to copy the token. The token is added to the install Grafana Alloy script that you copy in the steps below."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Toggle the **Enable Remote Configuration** off.\n\nFleet Management is not used in this learning path."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "In your local machine, open the Terminal."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "In the **Install and run Grafana Alloy** section, copy the Alloy script content into the terminal and press **Enter**.\n\n> **Note:** For macOS users, the scripts are broken down so you install Alloy first, set up the Alloy configuration, and run Alloy. Make sure to execute all scripts in order.\n\nYou should see a message `Successfully started alloy` in your terminal or something similar."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "To verify that Grafana Alloy is installed correctly, navigate back to Grafana Cloud and click **Test Alloy connection**.\n\nIf Grafana Alloy is installed correctly, you'll see `Awesome! Grafana Alloy is good to go.`"
         }
       ]

--- a/send-logs-alloy-loki-lj/send-logs-loki/content.json
+++ b/send-logs-alloy-loki-lj/send-logs-loki/content.json
@@ -35,18 +35,15 @@
       "type": "section",
       "blocks": [
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "To configure Alloy to search for log files to source, copy and paste the following component configuration before the [`loki.write`](/docs/alloy/latest/reference/components/loki/loki.write/) component.\n\nWhile not required, the recommended order of components provides for better organization and readability.\n\n```alloy\nlocal.file_match \"local_files\" {\n    path_targets = [{\"__path__\" = \"/var/log/*.log\"}]\n    sync_period = \"5s\"\n}\n```\n\nThis configuration creates a [`local.file_match`](/docs/alloy/latest/reference/components/local/local.file_match/) component named `local_files` which does the following:\n\n- It tells Alloy which files to source.\n- It checks for new files every 5 seconds."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "To configure Alloy to read log entries from files and forward them to other `loki.*` components, copy and paste the following component configuration after the `local.file_match` component.\n\n```alloy\n  loki.source.file \"log_scrape\" {\n    targets    = local.file_match.local_files.targets\n    forward_to = [loki.write.grafana_cloud_loki.receiver]\n  }\n```\n\nThis configuration creates a [`loki.source.file`](/docs/alloy/latest/reference/components/loki/loki.source.file/) component named `log_scrape` which does the following:\n\n- It connects to the `local_files` component as its source or target.\n- It forwards the logs it scrapes to the `loki.write` component called `grafana_cloud_loki`."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Run the following command to call the `/-/reload` endpoint to tell Alloy to reload the configuration file without a system service restart.\n\n```bash\ncurl -X POST http://localhost:12345/-/reload\n```\n\nYou should see the message `config reloaded` printed on your terminal.\n\n> **Note:** Run the reload command whenever you make changes to the configuration."
         }
       ]

--- a/send-logs-alloy-loki-lj/view-logs/content.json
+++ b/send-logs-alloy-loki-lj/view-logs/content.json
@@ -34,8 +34,7 @@
           ]
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "If you have multiple log files, you can view logs per file by clicking **Add label** and selecting `filename`.\n\nThe Logs Drilldown Overview page shows log visualization and log samples per file. You can see that logs are flowing through to Loki as expected, and the end-to-end configuration was successful."
         },
         {
@@ -44,8 +43,7 @@
           "alt": "Logs Drilldown page for multiple files"
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Select the log file you want to view and click **Show logs**.\n\nGrafana displays the **Logs** tab for the selected file."
         },
         {


### PR DESCRIPTION
Replace Send logs to Loki noop workaround blocks with markdown content so Pathfinder can render section steps sequentially.

Linked issue: https://github.com/grafana/interactive-tutorials/issues/314

Made with [Cursor](https://cursor.com)