### PR TITLE
Migrate macOS integration numbered steps

### DIFF
--- a/macos-integration-lj/configure-alloy/content.json
+++ b/macos-integration-lj/configure-alloy/content.json
@@ -12,13 +12,11 @@
       "autoCollapse": false,
       "blocks": [
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "In Grafana Cloud, under the **Make configuration selections** section, click **Make optional selections** and ensure **Simple set-up** is checked."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "On your macOS machine, run the following command to open the Alloy configuration file:\n\n```\nnano $(brew --prefix)/etc/alloy/config.alloy\n```"
         },
         {
@@ -29,13 +27,11 @@
           "content": "Back in Grafana Cloud, scroll down to the **Prepare your configuration file** section and click **Copy to clipboard**."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "On your macOS machine, scroll to the end of the configuration file and paste the configuration snippets you copied from Grafana Cloud."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Press `Ctrl+O` to write the changes to the file, then press **Enter** to save. Press `Ctrl+X` to exit the editor."
         }
       ]

--- a/macos-integration-lj/install-alloy/content.json
+++ b/macos-integration-lj/install-alloy/content.json
@@ -19,48 +19,39 @@
           "content": "In the **Install Alloy** section, click **Run Grafana Alloy**."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Perform one of the following:\n\n| If you want to | Then |\n| --- | --- |\n| Create a new token | Click **Create new token**, enter a meaningful token name (e.g., `MyMacBookPro`), then click **Create token**. |\n| Use an existing token | Click **Use an existing token** and enter a token you have created in the past. |\n\n**Tip:** You don't need to copy the token. The token is added to a Grafana Alloy configuration command that you copy and run in a later step."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Verify that the **Enable Remote Configuration** toggle is set to on."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Log in to the Mac as a user with administrator permissions and open Terminal. Run the following command to install Alloy:\n\n```\nbrew install grafana/grafana/alloy\n```\n\n**Tip:** It may take a few minutes to install Alloy. Hang in there!"
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Return to Grafana Cloud in your browser and scroll down to the **Set up the Alloy Configuration** section."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Click **Copy to Clipboard** to copy a command to generate an Alloy configuration file."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Paste the contents of the clipboard into the terminal and press **Enter**. Enter your macOS password when requested.\n\nOnce the command completes, you'll see `Alloy is ready to run` in the terminal."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Enter the following command to restart Alloy:\n\n```\nbrew services restart grafana/grafana/alloy\n```\n\nIf you see `Successfully started alloy`, then Alloy is running."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Return to Grafana Cloud in your browser and click **Test Alloy connection**.\n\nIf Grafana Alloy is installed correctly, you'll see `Awesome! Grafana Alloy is good to go`.\n\n**Tip:** Testing the Alloy connection may take a minute or two. If the test initially times out, try clicking **Test Alloy connection** again."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Once Alloy is successfully installed, click **Proceed to install integration**."
         }
       ]

--- a/macos-integration-lj/install-dashboards-alerts/content.json
+++ b/macos-integration-lj/install-dashboards-alerts/content.json
@@ -27,8 +27,7 @@
           "content": "To view dashboards, click **View Dashboards**.\n\nA folder containing the macOS dashboards appears."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "To see the installed alerts, navigate to **Alerts & IRM > Alerting > Alert rules**.\n\nThe Alert rules page shows all active alerts. macOS integration alerts begin with `integrations-macos-node`."
         }
       ]

--- a/macos-integration-lj/select-architecture/content.json
+++ b/macos-integration-lj/select-architecture/content.json
@@ -32,8 +32,7 @@
           "content": "Click the **macOS** tile."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Use the following table to determine which architecture to select:\n\n| Architecture | Select |\n| --- | --- |\n| Mac with Apple M series processor | `Arm64` |\n| Mac with Intel processor | `Amd64` |"
         },
         {

--- a/macos-integration-lj/test-connection/content.json
+++ b/macos-integration-lj/test-connection/content.json
@@ -12,8 +12,7 @@
       "autoCollapse": false,
       "blocks": [
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "At the macOS Terminal, enter the following command and press **Enter**:\n\n```\nbrew services restart grafana/grafana/alloy\n```"
         },
         {


### PR DESCRIPTION
Replace macOS integration noop workaround blocks with markdown content so Pathfinder can render section steps sequentially.

Linked issue: https://github.com/grafana/interactive-tutorials/issues/314

Made with [Cursor](https://cursor.com)