### PR TITLE
Migrate IIS web server numbered steps

### DIFF
--- a/iis-web-server-lj/configure-iis-counters/content.json
+++ b/iis-web-server-lj/configure-iis-counters/content.json
@@ -16,28 +16,23 @@
       "autoCollapse": false,
       "blocks": [
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Open **PowerShell as Administrator** on your Windows Server."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Verify that IIS is installed and the required role services are enabled:\n\n```powershell\nGet-WindowsFeature Web-Server, Web-Request-Monitor, Web-Http-Logging, Web-Stat-Compression\n```\n\nAll listed features should show `[X]` (installed). If any feature shows `[ ]`, install it in the next step."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "If any features are missing, install them:\n\n```powershell\nInstall-WindowsFeature Web-Request-Monitor, Web-Http-Logging, Web-Stat-Compression\n```\n\n> **Tip:** The `Web-Request-Monitor` feature enables the IIS Request Monitor module, which provides detailed per-request metrics."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Verify that IIS performance counter categories are available:\n\n```powershell\n[System.Diagnostics.PerformanceCounterCategory]::Exists('Web Service')\n[System.Diagnostics.PerformanceCounterCategory]::Exists('W3SVC_W3WP')\n```\n\nBoth commands should return `True`. The `Web Service` category provides site-level metrics and `W3SVC_W3WP` provides worker process metrics."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Verify that at least one IIS site is running:\n\n```powershell\nGet-IISSite\n```\n\nYou should see at least one site with a status of `Started`. If no sites are running, the integration won't have any metrics to collect."
         }
       ]

--- a/iis-web-server-lj/configure-iis-integration/content.json
+++ b/iis-web-server-lj/configure-iis-integration/content.json
@@ -20,28 +20,23 @@
       "autoCollapse": false,
       "blocks": [
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "In Grafana Cloud, under the **Set up Grafana Alloy to use the IIS integration** section, click **Copy to clipboard**."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "On your Windows Server, open Command Prompt as Administrator."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Open the Alloy configuration file with Notepad:\n\n```cmd\nnotepad \"C:\\Program Files\\GrafanaLabs\\Alloy\\config.alloy\"\n```"
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Scroll to the end of the configuration file and paste the code snippet you copied from Grafana Cloud.\n\nThe snippet configures the `prometheus.exporter.windows` component with the IIS collector enabled, which scrapes metrics from the `Web Service` and `W3SVC_W3WP` performance counter categories."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Click **File > Save** to save the changes, then close Notepad."
         }
       ]

--- a/iis-web-server-lj/install-alloy/content.json
+++ b/iis-web-server-lj/install-alloy/content.json
@@ -22,28 +22,23 @@
           "content": "In the **Install Alloy** section, click **Run Grafana Alloy** to expand the installation options."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "**Create or select a token:**\n\nYou can either create a new token or use an existing one. The token authorizes Alloy to send data to your Grafana Cloud instance.\n\n- **Create new token**: Click \"Create new token\", enter a meaningful name (e.g., `MyIISServer`), then click \"Create token\".\n- **Use existing token**: Click \"Use an existing token\" and enter a token you've created before."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Verify that the **Enable Remote Configuration** toggle switch is set to off."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Open **Command Prompt as Administrator** on your Windows Server, copy the installation command from Grafana Cloud, paste and run the command in Command Prompt, and wait for the installation to complete.\n\nWhen successful, you'll see:\n```\nStatus   Name               DisplayName\n------   ----               -----------\nRunning  Alloy              Alloy\n```"
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "After installing Alloy, click **Test Alloy connection** to verify the installation.\n\nIf successful, you'll see: **Awesome! Grafana Alloy is good to go.**"
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Click **Proceed to install integration** to continue to the next step."
         }
       ]

--- a/iis-web-server-lj/verify-metrics/content.json
+++ b/iis-web-server-lj/verify-metrics/content.json
@@ -12,13 +12,11 @@
       "autoCollapse": false,
       "blocks": [
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "On your Windows Server, open Command Prompt as Administrator."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Restart the Alloy service:\n\n```cmd\nsc stop \"Alloy\"\nsc start \"Alloy\"\nsc query \"Alloy\" | find \"STATE\"\n```\n\n> **Tip:** You will see output indicating the service is stopping and starting."
         },
         {


### PR DESCRIPTION
Replace IIS web server noop workaround blocks with markdown content so Pathfinder can render section steps sequentially.

Linked issue: https://github.com/grafana/interactive-tutorials/issues/314

Made with [Cursor](https://cursor.com)