### PR TITLE
Migrate availability SLO numbered steps

### DIFF
--- a/create-availability-slo-lj/configure-targets/content.json
+++ b/create-availability-slo-lj/configure-targets/content.json
@@ -15,8 +15,7 @@
       "type": "section",
       "blocks": [
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "In the SLO wizard, click **Set target and error budget**."
         },
         {
@@ -27,13 +26,11 @@
           "doIt": false
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Review the statistical predictions displayed in the wizard.\n\nThe wizard queries 90 days of history and shows the probability of meeting your SLO target. Use this to sense-check whether your target is achievable. If the probability is very low, consider a slightly lower target or improving reliability first."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Click **Add name and description**."
         },
         {
@@ -51,8 +48,7 @@
           "doIt": false
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "From the **Folder** dropdown, select an existing folder or click **+ Create folder** to create a new one.\n\nOptionally, add labels to categorize your SLO for searching and management."
         },
         {

--- a/create-availability-slo-lj/create-availability-slo/content.json
+++ b/create-availability-slo-lj/create-availability-slo/content.json
@@ -49,18 +49,15 @@
           "doIt": false
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "For **Query type**, select **Ratio query**.\n\nThe Ratio query option appears when you select a Prometheus-compatible data source."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "In the **Success metric** field, enter a Prometheus counter metric for successful events.\n\nFor example, you might enter `http_requests_total{status!~\"5..\"}` to count successful responses (non-5xx status codes)."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "In the **Total metric** field, enter a Prometheus counter metric for all events (e.g., `http_requests_total`)."
         },
         {

--- a/create-availability-slo-lj/define-reliability-sli/content.json
+++ b/create-availability-slo-lj/define-reliability-sli/content.json
@@ -19,23 +19,19 @@
       "type": "section",
       "blocks": [
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Identify the service or endpoint you want to measure.\n\nFor example, identify your API gateway, a specific microservice, or a critical user-facing endpoint."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Define what \"success\" means for your service.\n\nFor example, a successful request might be one that does not return a server error (HTTP 5xx)"
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Define the total event count that represents all attempts.\n\nFor example, all HTTP requests to the endpoint, regardless of status code."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Verify your metrics exist in Grafana.\n\nSign in to your Grafana Cloud account if you haven't already."
         },
         {
@@ -46,13 +42,11 @@
           "content": "In Grafana Cloud, open **Explore** from the main menu (or the Explore icon)."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Run a query for your success metric and a query for your total metric. You should see time series or values returned. If you get no data, the metric name or labels may be wrong, or the data may not be in this data source. See the **Verify in Explore** section below for an example."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "(Optional) Document your SLI definition for reference.\n\nFor example, write: \"SLI = (successful requests / total requests) where successful = HTTP status < 500\""
         }
       ]

--- a/create-availability-slo-lj/monitor-slo/content.json
+++ b/create-availability-slo-lj/monitor-slo/content.json
@@ -29,28 +29,23 @@
           "content": "Click **SLO**."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Click on your SLO name to open the detail view."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Review the **Error Budget Burndown** chart to see how your error budget is being consumed over time."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Check the **SLI** panel to see your current reliability percentage."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Review the **Error budget remaining** indicator to understand how much error budget you have left."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Use the time range selector to zoom in on specific periods of interest."
         }
       ]


### PR DESCRIPTION
Replace availability SLO noop workaround blocks with markdown content so Pathfinder can render section steps sequentially.

Linked issue: https://github.com/grafana/interactive-tutorials/issues/314

Made with [Cursor](https://cursor.com)