### PR TITLE
Migrate GitHub visualize numbered steps

### DIFF
--- a/github-visualize-lj/build-issues-panel/content.json
+++ b/github-visualize-lj/build-issues-panel/content.json
@@ -18,13 +18,11 @@
           "requirements": ["navmenu-open"]
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Click **New** and select **New dashboard**."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Open the panel editor by doing one of the following:\n\n- If you see an **Add visualization** button or placeholder, click it.\n- If you see a **Configure visualization** button, click it.\n- If you see a **+** icon in the top toolbar, click it and select **Configure**.\n\nAny of these options opens the panel editor."
         },
         {
@@ -35,13 +33,11 @@
           "content": "Click the **data source** dropdown and select your GitHub data source from the list. If you have multiple data sources, look for the one named after your GitHub connection."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "If you see a **New query editor** banner with a **Back to classic** button, click **Back to classic**. The GitHub data source requires the classic query editor to show the Query Type dropdown."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "In the query editor at the bottom of the screen, find the **Query Type** dropdown and choose **Issues**."
         },
         {
@@ -59,8 +55,7 @@
           "content": "Enter your repository name in the **Repository** field. For example, `grafana`."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "In the query editor, find the **Time Field** dropdown and select **Created At**."
         },
         {
@@ -79,13 +74,11 @@
           "content": "In the **Panel options** on the right, enter a title for your panel in the **Title** field. For example, `GitHub Issues (Open/Closed) Overview`."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Click **Save dashboard**. In the dialog that appears, enter a title for your dashboard and click **Save**."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Click **Back to dashboard** to exit the panel editor and return to the dashboard view."
         }
       ]

--- a/github-visualize-lj/build-pr-panel/content.json
+++ b/github-visualize-lj/build-pr-panel/content.json
@@ -11,8 +11,7 @@
       "title": "Create a pull requests panel",
       "blocks": [
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Open your existing dashboard. Click **Add** in the top-right toolbar and select **Visualization**. If you don't see an **Add** button, click **Edit** to enter edit mode first, then click **Add** > **Visualization**."
         },
         {
@@ -23,13 +22,11 @@
           "content": "Click the **data source** dropdown and select your GitHub data source from the list. If you have multiple data sources, look for the one named after your GitHub connection."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "If you see a **New query editor** banner with a **Back to classic** button, click **Back to classic**. The GitHub data source requires the classic query editor to show the Query Type dropdown."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "In the query editor at the bottom of the screen, find the **Query Type** dropdown and choose **Pull Requests**."
         },
         {
@@ -47,8 +44,7 @@
           "content": "Enter your repository name in the **Repository** field. For example, `grafana`."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "In the **Time Field** dropdown, select **Closed At**."
         },
         {
@@ -67,13 +63,11 @@
           "content": "In the **Panel options** on the right, enter a title for your panel in the **Title** field. For example, `GitHub Pull Requests Overview`."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Click **Save dashboard**. In the dialog that appears, click **Save**."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Click **Back to dashboard** to exit the panel editor and return to the dashboard view."
         }
       ]

--- a/github-visualize-lj/build-repository-panel/content.json
+++ b/github-visualize-lj/build-repository-panel/content.json
@@ -11,8 +11,7 @@
       "title": "Create a repository panel",
       "blocks": [
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Open your existing dashboard. Click **Add** in the top-right toolbar and select **Visualization**. If you don't see an **Add** button, click **Edit** to enter edit mode first, then click **Add** > **Visualization**."
         },
         {
@@ -23,13 +22,11 @@
           "content": "Click the **data source** dropdown and select your GitHub data source from the list. If you have multiple data sources, look for the one named after your GitHub connection."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "If you see a **New query editor** banner with a **Back to classic** button, click **Back to classic**. The GitHub data source requires the classic query editor to show the Query Type dropdown."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "In the query editor at the bottom of the screen, find the **Query Type** dropdown and choose **Repositories**."
         },
         {
@@ -47,8 +44,7 @@
           "content": "Enter your repository name in the **Repository** field. For example, `grafana`."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "In the **Time Field** dropdown, select **Created At**."
         },
         {
@@ -74,8 +70,7 @@
           "content": "Click the **time picker** and select an appropriate range, for example **Last 30 days**."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Click **Save dashboard**. In the dialog that appears, click **Save**."
         }
       ]


### PR DESCRIPTION
Replace GitHub visualize noop workaround blocks with markdown content so Pathfinder can render section steps sequentially.

Linked issue: https://github.com/grafana/interactive-tutorials/issues/314

Made with [Cursor](https://cursor.com)