### PR TITLE
Migrate traces visualization numbered steps

### DIFF
--- a/visualization-traces-lj/add-traces-panel/content.json
+++ b/visualization-traces-lj/add-traces-panel/content.json
@@ -27,8 +27,7 @@
           ]
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "On the new panel, enter a title and description, and click **Configure**."
         },
         {
@@ -62,13 +61,11 @@
           "requirements": ["exists-reftarget"]
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Enter `${traceId}` in the TraceQL query field to create a dashboard variable.\n\nThis variable is used as the template query."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Under the **Panel options**, enter a **Title** for your trace panel."
         },
         {

--- a/visualization-traces-lj/add-traces-table/content.json
+++ b/visualization-traces-lj/add-traces-table/content.json
@@ -23,8 +23,7 @@
           "requirements": ["exists-reftarget"]
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "For any of the search criteria, select an operator and a value.\n\nFor example, when:\n- Service Name = `app-2048`\n- Span Name = `POST /`\n- Status = `Error`\n\nThe resulting TraceQL query is:\n`{resource.service.name=\"app-2048\" && name=\"POST /\" && status=error}`"
         },
         {
@@ -35,8 +34,7 @@
           "requirements": ["exists-reftarget"]
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "On the right of the page, under **Panel options**, enter a panel **Title** and description.\n\nThe title appears at the top of the panel."
         },
         {
@@ -47,13 +45,11 @@
           "requirements": ["exists-reftarget"]
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Enter a title and description for your dashboard, and select a folder, if applicable."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Click **Save** to save the dashboard."
         },
         {

--- a/visualization-traces-lj/add-variable/content.json
+++ b/visualization-traces-lj/add-variable/content.json
@@ -31,18 +31,15 @@
           "doIt": false
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "From the **Variable type** drop-down list, select `Custom`."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "In the **Name** field of the **Custom variable** modal, enter `traceId`."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "In the **Label** field, enter `Trace ID`.\n\n`Trace ID` appears above the panel."
         }
       ]

--- a/visualization-traces-lj/add-visualization/content.json
+++ b/visualization-traces-lj/add-visualization/content.json
@@ -16,8 +16,7 @@
       "autoCollapse": false,
       "blocks": [
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Sign in to your Grafana Cloud environment, for example `mystack.grafana.net`."
         },
         {
@@ -43,13 +42,11 @@
           ]
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "In the **Add** drawer, click the **Panel** card to add a new visualization to your dashboard.\n\nA new panel is added to your dashboard."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "On the new panel, enter a panel title and description, and click **Configure** to open the Edit panel view."
         },
         {

--- a/visualization-traces-lj/test-dashboard/content.json
+++ b/visualization-traces-lj/test-dashboard/content.json
@@ -12,18 +12,15 @@
       "autoCollapse": false,
       "blocks": [
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "While in dashboard edit mode, hover your cursor over the traces table panel until you see a move cursor."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Click and drag the traces table and place it above the traces panel.\n\n**You aren't required to change the order of the panels, but having the traces table above the traces panel makes working with the dashboard a bit more intuitive for users."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Copy a **Trace ID** from the traces table, paste it into the **Trace ID** field at the top of the dashboard, and press **Enter**.\n\nThe traces panel should populate with more detailed information about the trace.\n\nYou can use the traces panel to explore span attributes and resource attributes, which you can use to troubleshoot issues with your system."
         }
       ]

--- a/visualization-traces-lj/time-range-refresh/content.json
+++ b/visualization-traces-lj/time-range-refresh/content.json
@@ -24,8 +24,7 @@
           "doIt": false
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Select a time range from the options (for example, **Last 1 hour**, **Last 6 hours**, or a custom range)."
         },
         {
@@ -37,8 +36,7 @@
           "doIt": false
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Select a refresh interval from the options (for example, **1m**, **5m**, or **Off**)."
         }
       ]


### PR DESCRIPTION
Replace traces visualization noop workaround blocks with markdown content so Pathfinder can render section steps sequentially.

Linked issue: https://github.com/grafana/interactive-tutorials/issues/314

Made with [Cursor](https://cursor.com)