### PR TITLE
Migrate MySQL DB O11y numbered steps

### DIFF
--- a/mysql-db-olly-lj/configure-alloy/content.json
+++ b/mysql-db-olly-lj/configure-alloy/content.json
@@ -16,43 +16,35 @@
           "content": "To configure Grafana Alloy to connect your MySQL database to Grafana Cloud, complete the following steps:"
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Install Grafana Alloy 1.14.0 or later. Refer to the [Alloy installation documentation](https://grafana.com/docs/alloy/latest/get-started/install/) for your platform."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Run Alloy with the public preview stability flag:\n\n```bash\nalloy run config.alloy --stability.level=public-preview\n```"
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Create the Data Source Name secret file. Replace the placeholders with your values:\n\n```bash\necho 'db-o11y:<DB_PASSWORD>@tcp(<DB_HOST>:<DB_PORT>)/' > /var/lib/alloy/mysql_secret\n```\n\nReplace:\n- **DB_PASSWORD** — Password for the `db-o11y` user you created\n- **DB_HOST** — Hostname or IP of your MySQL server\n- **DB_PORT** — MySQL port (default: 3306)"
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Add the core Database Observability blocks to your Alloy configuration file. These configure the MySQL exporter for metrics and the Database Observability component for query-level logs:\n\n```alloy\nlocal.file \"mysql_secret\" {\n  filename  = \"/var/lib/alloy/mysql_secret\"\n  is_secret = true\n}\n\nprometheus.exporter.mysql \"mysql\" {\n  data_source_name  = local.file.mysql_secret.content\n  enable_collectors = [\"perf_schema.eventsstatements\"]\n  perf_schema.eventsstatements {\n    text_limit = 0\n  }\n}\n\ndatabase_observability.mysql \"mysql\" {\n  data_source_name = local.file.mysql_secret.content\n  forward_to       = [loki.relabel.database_observability_mysql.receiver]\n  targets          = prometheus.exporter.mysql.mysql.targets\n}\n```"
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Add the relabeling rules and Prometheus scrape configuration:\n\n```alloy\nloki.relabel \"database_observability_mysql\" {\n  forward_to = [loki.write.logs_service.receiver]\n\n  rule {\n    target_label = \"instance\"\n    replacement  = \"<DB_HOST>:<DB_PORT>\"\n  }\n}\n\ndiscovery.relabel \"database_observability_mysql\" {\n  targets = database_observability.mysql.mysql.targets\n\n  rule {\n    target_label = \"job\"\n    replacement  = \"integrations/db-o11y\"\n  }\n  rule {\n    target_label = \"instance\"\n    replacement  = \"<DB_HOST>:<DB_PORT>\"\n  }\n}\n\nprometheus.scrape \"database_observability_mysql\" {\n  targets    = discovery.relabel.database_observability_mysql.output\n  forward_to = [prometheus.remote_write.metrics_service.receiver]\n}\n```"
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "In the relabeling blocks you just added, replace the `DB_HOST` and `DB_PORT` placeholder values with your MySQL host and port."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Add the Prometheus remote write and Loki write blocks. Find your Grafana Cloud credentials in your stack's configuration page:\n\n```alloy\nprometheus.remote_write \"metrics_service\" {\n  endpoint {\n    url = \"https://prometheus-<region>.grafana.net/api/prom/push\"\n    basic_auth {\n      username = \"<METRICS_USER>\"\n      password = \"<METRICS_API_KEY>\"\n    }\n  }\n}\n\nloki.write \"logs_service\" {\n  endpoint {\n    url = \"https://logs-<region>.grafana.net/loki/api/v1/push\"\n    basic_auth {\n      username = \"<LOGS_USER>\"\n      password = \"<LOGS_API_KEY>\"\n    }\n  }\n}\n```"
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Replace the region, usernames, and API keys with your Grafana Cloud stack values."
         },
         {

--- a/mysql-db-olly-lj/explore-queries/content.json
+++ b/mysql-db-olly-lj/explore-queries/content.json
@@ -39,18 +39,15 @@
           "requirements": ["navmenu-open"]
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Review the summary metrics at the top of the page: **Duration Average** (typical query execution time), **Errors** (total query errors and error percentage), and **Rate** (queries per second and total count). Spikes in these metrics indicate performance regressions or queries that need investigation."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Scroll down to the query performance table. Each row shows a normalized SQL statement with its duration, call count, errors, and wait events."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Click any query row to drill into its details. The detail view shows explain plans, query samples, and wait event breakdowns for that query."
         },
         {

--- a/mysql-db-olly-lj/prepare-mysql/content.json
+++ b/mysql-db-olly-lj/prepare-mysql/content.json
@@ -16,43 +16,35 @@
           "content": "To prepare your MySQL database instance for Database Observability, complete the following steps:"
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Verify that Performance Schema is enabled. It is on by default in MySQL 8.0 and later:\n\n```sql\nSHOW VARIABLES LIKE 'performance_schema';\n```\n\nExpected result: Value is `ON`."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Create a dedicated monitoring user and replace the password with a strong value:\n\n```sql\nCREATE USER 'db-o11y'@'%' IDENTIFIED BY '<STRONG_PASSWORD>';\n```"
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Grant the required privileges to the monitoring user:\n\n```sql\nGRANT PROCESS ON *.* TO 'db-o11y'@'%';\nGRANT REPLICATION CLIENT ON *.* TO 'db-o11y'@'%';\nGRANT SELECT ON performance_schema.* TO 'db-o11y'@'%';\n```"
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Exclude the monitoring user's own queries from Performance Schema data:\n\n```sql\nUPDATE performance_schema.setup_actors\nSET ENABLED = 'NO', HISTORY = 'NO'\nWHERE HOST = '%' AND USER = 'db-o11y';\n```"
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Grant object-level privileges for schema details and explain plans:\n\n```sql\nGRANT SELECT ON *.* TO 'db-o11y'@'%';\n```\n\nThis lets Alloy collect table schemas, indexes, and run `EXPLAIN` on sampled queries."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Increase the digest length to capture complete query text:\n\n```sql\nSET GLOBAL max_digest_length = 4096;\nSET GLOBAL performance_schema_max_digest_length = 4096;\n```"
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Verify both settings:\n\n```sql\nSHOW VARIABLES LIKE 'max_digest_length';\nSHOW VARIABLES LIKE 'performance_schema_max_digest_length';\n```\n\nExpected result: Both values are `4096`.\n\n> **Note:** Add these settings to your MySQL configuration file (`my.cnf`) to persist across restarts."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "**Optional:** Enable Performance Schema consumers for CPU and wait event data:\n\n```sql\nUPDATE performance_schema.setup_consumers\nSET ENABLED = 'YES'\nWHERE NAME IN ('events_statements_cpu', 'events_waits_current', 'events_waits_history');\n```\n\nThese consumers reset when MySQL restarts. You can grant Alloy permission to auto-enable them instead — refer to the [Database Observability MySQL setup documentation](https://grafana.com/docs/grafana-cloud/monitor-applications/database-observability/set-up/mysql/mysql/) for details."
         },
         {

--- a/mysql-db-olly-lj/verify-telemetry/content.json
+++ b/mysql-db-olly-lj/verify-telemetry/content.json
@@ -39,8 +39,7 @@
           "requirements": ["on-page:/a/grafana-dbo11y-app"]
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Select your MySQL instance from the **Instance** dropdown at the top of the page. Choose the instance label you configured in your Alloy relabeling rules."
         },
         {


### PR DESCRIPTION
Replace MySQL DB O11y noop workaround blocks with markdown content so Pathfinder can render section steps sequentially.

Linked issue: https://github.com/grafana/interactive-tutorials/issues/314

Made with [Cursor](https://cursor.com)