### PR TITLE
Migrate first k6 test numbered steps

### DIFF
--- a/run-first-k6-test-lj/analyze-results/content.json
+++ b/run-first-k6-test-lj/analyze-results/content.json
@@ -22,23 +22,19 @@
           ]
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "On the Performance page, select the project that contains your test."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Select your test, then choose the most recent test run from the list to open the **Performance Overview** dashboard."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Review the **Performance Overview** dashboard, which displays test summary information (duration, virtual users, iterations), HTTP request statistics (total requests, success rate, error rate), response time metrics (average, median, p95), and throughput metrics (requests per second, data transfer rates)."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Scroll down to the **Cloud Insights** section.\n\nCloud Insights analyzes your test script and results, then generates scores and recommendations across categories such as best practice, reliability, and system performance."
         },
         {

--- a/run-first-k6-test-lj/install-k6/content.json
+++ b/run-first-k6-test-lj/install-k6/content.json
@@ -12,18 +12,15 @@
       "title": "Install k6",
       "blocks": [
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Choose the installation method for your operating system:\n\n| OS | Method |\n|---|---|\n| **macOS** | Homebrew |\n| **Linux (Debian/Ubuntu)** | APT |\n| **Linux (Fedora/CentOS)** | DNF/YUM |\n| **Windows** | Chocolatey or Winget |\n| **Any platform** | Docker or standalone binary |"
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "**In your terminal**, install k6 using your chosen method.\n\nFor macOS:\n```bash\nbrew install k6\n```\n\nFor Linux (Debian/Ubuntu):\n```bash\nsudo gpg -k\nsudo gpg --no-default-keyring --keyring /usr/share/keyrings/k6-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C5AD17C747E3415A3642D57D77C6C491D6AC1D69\necho \"deb [signed-by=/usr/share/keyrings/k6-archive-keyring.gpg] https://dl.k6.io/deb stable main\" | sudo tee /etc/apt/sources.list.d/k6.list\nsudo apt-get update\nsudo apt-get install k6\n```\n\nFor Docker:\n```bash\ndocker pull grafana/k6\n```"
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Verify the installation by checking the k6 version:\n\n```bash\nk6 version\n```\n\nYou should see version information displayed in your terminal."
         }
       ]

--- a/run-first-k6-test-lj/run-locally/content.json
+++ b/run-first-k6-test-lj/run-locally/content.json
@@ -12,18 +12,15 @@
       "title": "Run the test",
       "blocks": [
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "**In your terminal**, navigate to the directory containing your `script.js` file and run the test:\n\n```bash\nk6 run script.js\n```\n\nIf you're using Docker:\n```bash\ndocker run --rm -i grafana/k6 run - < script.js\n```"
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Observe the test execution in your terminal. k6 displays real-time progress including iteration count, HTTP request statistics, and response time metrics."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "When the test completes, review the summary. Look for:\n\n- **checks_succeeded**: Should be 100% if all requests returned status 200\n- **http_req_duration**: Average, median, and p95 response times\n- **http_req_failed**: Should be 0% for a healthy endpoint\n- **iterations**: Should show 10 completed iterations"
         }
       ]

--- a/run-first-k6-test-lj/send-to-grafana-cloud/content.json
+++ b/run-first-k6-test-lj/send-to-grafana-cloud/content.json
@@ -29,28 +29,23 @@
           "content": "In the left navigation under **Performance**, select **Settings** to find your API token."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Copy your API token from the Settings page. You'll use it in the next step to authenticate k6."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "**In your terminal**, navigate to the directory where you saved your `script.js` file, then log in to Grafana Cloud k6:\n\n```bash\nk6 cloud login --token YOUR_API_TOKEN\n```\n\nReplace `YOUR_API_TOKEN` with the token you just copied."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Run your test with the `--local-execution` flag to stream results to Grafana Cloud:\n\n```bash\nk6 cloud run --local-execution script.js\n```"
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "After the test completes, scroll up in your terminal output and find the `output:` line. It contains a URL like:\n\n`output: cloud (https://your-stack.grafana.net/a/k6-app/runs/...)`"
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Copy this URL — it links to your test results in Grafana Cloud. You'll use it in the next milestone to view your results."
         }
       ]

--- a/run-first-k6-test-lj/write-test-script/content.json
+++ b/run-first-k6-test-lj/write-test-script/content.json
@@ -12,28 +12,23 @@
       "title": "Write the test script",
       "blocks": [
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "**In your terminal**, create a new test file:\n\n```bash\ntouch script.js\n```\n\nYou can name the file anything you like, but it should have a `.js` or `.ts` extension."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Open the file in your code editor and import the k6 modules:\n\n```javascript\nimport http from 'k6/http';\nimport { check, sleep } from 'k6';\n```\n\nThe `http` module makes HTTP requests, and `sleep` simulates real-world delays between requests."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Define the test options to configure execution:\n\n```javascript\nexport const options = {\n  iterations: 10,\n};\n```\n\nThis tells k6 to execute the default function 10 times."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Define the default function with your test logic:\n\n```javascript\nexport default function () {\n  const res = http.get('https://quickpizza.grafana.com');\n  check(res, { 'status was 200': (r) => r.status === 200 });\n  sleep(1);\n}\n```\n\nThis makes a GET request, verifies a 200 status, and waits 1 second between iterations."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Save the complete script. Your `script.js` file should contain:\n\n```javascript\nimport http from 'k6/http';\nimport { check, sleep } from 'k6';\n\nexport const options = {\n  iterations: 10,\n};\n\nexport default function () {\n  const res = http.get('https://quickpizza.grafana.com');\n  check(res, { 'status was 200': (r) => r.status === 200 });\n  sleep(1);\n}\n```"
         }
       ]


### PR DESCRIPTION
Replace first k6 test noop workaround blocks with markdown content so Pathfinder can render section steps sequentially.

Linked issue: https://github.com/grafana/interactive-tutorials/issues/314

Made with [Cursor](https://cursor.com)