### PR TITLE
Migrate Kafka monitoring numbered steps

### DIFF
--- a/kafka-monitoring-lj/configure-alloy-kafka-metrics/content.json
+++ b/kafka-monitoring-lj/configure-alloy-kafka-metrics/content.json
@@ -12,33 +12,27 @@
       "autoCollapse": false,
       "blocks": [
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "On the Kafka integration page, scroll to the **Set up Grafana Alloy to use the Kafka integration** section and copy the provided Alloy configuration snippet for Kafka."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "**On the machine where Alloy is installed**, open the Alloy configuration file:\n\n- **Linux:** `/etc/alloy/config.alloy`\n- **macOS (Homebrew):** `/opt/homebrew/etc/alloy/config.alloy`\n- **Windows:** `C:\\Program Files\\GrafanaLabs\\Alloy\\config.alloy`\n- **Docker:** Depends on your volume mount configuration\n\nFor more information, refer to [Grafana Alloy configuration file locations](https://grafana.com/docs/alloy/latest/configure/)."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Paste the Kafka configuration snippet into the config file, then update the targets list with your Kafka broker addresses and JMX ports. For example:\n\n```\ntargets = [{__address__ = \"kafka-broker-1:9999\"}, {__address__ = \"kafka-broker-2:9999\"}]\n```"
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Review the `forward_to` parameter to ensure it points to your Grafana Cloud remote write endpoint. Optionally, adjust the `scrape_interval` (default is typically 60s). Save the configuration file."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Restart the Alloy service to apply the new configuration:\n\n- **Linux:** `sudo systemctl restart alloy`\n- **macOS:** `brew services restart alloy`\n- **Windows:** Restart the Alloy service from Services Manager"
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Check the Alloy logs to confirm the service restarted successfully and is connecting to your Kafka brokers."
         }
       ]

--- a/kafka-monitoring-lj/explore-kafka-metrics/content.json
+++ b/kafka-monitoring-lj/explore-kafka-metrics/content.json
@@ -23,48 +23,39 @@
           "content": "Navigate to **Dashboards** from the main menu."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Find and open the **Kafka** dashboards folder, then open the **Kafka Overview** dashboard."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Review the **Messages In Rate** panel to see the volume of messages being produced to your topics."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Check the **Bytes In/Out Rate** panels to monitor data throughput across your cluster."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Examine the **Under Replicated Partitions** panel — this should typically be **0** in a healthy cluster."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Review the **Request Latency** panels to identify slow produce or fetch requests."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Check the **Active Controller Count** panel — this should always be **1** in a healthy cluster."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Navigate to the **Kafka Broker Metrics** dashboard to view individual broker performance, including CPU usage, network throughput, and request queue size."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Explore the **Kafka Topic Metrics** dashboard to analyze per-topic message rates and retention."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Use the time range selector to analyze historical trends and identify patterns."
         }
       ]

--- a/kafka-monitoring-lj/install-dashboards/content.json
+++ b/kafka-monitoring-lj/install-dashboards/content.json
@@ -28,8 +28,7 @@
           "content": "Click **View Dashboards** to open the Kafka dashboards folder. A folder containing the Kafka dashboards appears."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "To see the installed alerts, click the **Home** button in the top left corner of the screen. The left-side menu appears."
         },
         {

--- a/kafka-monitoring-lj/install-grafana-alloy/content.json
+++ b/kafka-monitoring-lj/install-grafana-alloy/content.json
@@ -38,8 +38,7 @@
           "content": "Select the **Kafka** integration tile."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Under **Select platform**, choose your operating system and architecture."
         },
         {
@@ -49,13 +48,11 @@
           "content": "Click **Run Grafana Alloy**. This opens a dialog to generate your Alloy installation command, which may include creating an API token."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Complete the dialog steps, then copy the generated installation command."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "On the machine where you want to collect Kafka metrics, open a terminal with administrator or root privileges, paste and run the installation command, then wait for the installation to complete."
         }
       ]

--- a/kafka-monitoring-lj/verify-kafka-metrics/content.json
+++ b/kafka-monitoring-lj/verify-kafka-metrics/content.json
@@ -39,13 +39,11 @@
           "content": "Click the **Run query** button to execute the query."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Verify that data points appear in the graph and table views. Check the labels to confirm they include your broker information (`instance`, `job`, `topic`)."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Try querying additional Kafka metrics to ensure comprehensive data collection."
         }
       ]


### PR DESCRIPTION
Replace Kafka monitoring noop workaround blocks with markdown content so Pathfinder can render section steps sequentially.

Linked issue: https://github.com/grafana/interactive-tutorials/issues/314

Made with [Cursor](https://cursor.com)