### PR TITLE
Migrate Prometheus remote write numbered steps

### DIFF
--- a/prom-remote-write-lj/configure-prom-remote-write/content.json
+++ b/prom-remote-write-lj/configure-prom-remote-write/content.json
@@ -24,8 +24,7 @@
       "autoCollapse": false,
       "blocks": [
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Log into your Cloud Portal and select your stack."
         },
         {
@@ -34,23 +33,19 @@
           "alt": "Image of stack selected in the Grafana Cloud Portal"
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Click the name of your stack under **Grafana Cloud** located on the left navigation panel."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "On the **Prometheus** tile, click **Send Metrics**."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Scroll down the page until you locate the **Sending metrics with Prometheus** section.\n\nThis section contains a snippet of code that you'll add to your Prometheus deployment."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Just below the code sample, click **Generate now** to generate an API token.\n\nThe API token ensures a secure connection to Grafana Cloud."
         },
         {
@@ -59,58 +54,47 @@
           "alt": "Picture of Generate now link to create API token"
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "On the **Create an API token** screen, enter a name for the token and click **Create token**.\n\nThe code snippet populates with the token you just created."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "On the **Create an API token** screen, click **Close**."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Just below the code snippet, click **Copy to clipboard**.\n\nIn the following steps, you'll add the code snippet to the `prometheus.yml` file."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Log into the machine on which Prometheus is installed."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Open a terminal and if required, switch to a user with write privileges.\n\nFor example:\n\n```\nsudo su -\n```"
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Open the `prometheus.yml` file located under `/etc/prometheus`.\n\nFor example, if you are using Vim, run:\n\n```\nvim /etc/prometheus/prometheus.yml\n```"
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Edit the YAML file.\n\nWhen using Vi or Vim as the text editor, press `i` to edit the YAML file.\n\nThe button you use to the edit the YAML file depends on the text editor you are using."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Scroll to the end of the file and paste the snippet of code you copied from the Grafana Cloud Portal."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Exit edit mode and save your changes.\n\nFor example, when using Vi or Vim, press the `Esc` key to exit insert mode type `:wq` to save your changes and exit."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Restart the Prometheus service to apply the changes.\n\nFor example: run the command\n\n```\nsystemctl restart prometheus.yml\n```\n\nAfter restarting the Prometheus service, metrics should be forwarded to Grafana Cloud."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "To check the Prometheus service status, run the following command:\n\n```\nsystemctl status prometheus.service\n```\n\nIf there are errors, refer to the relevant logs in `/var/log/syslog` or `journalctl`."
         }
       ]

--- a/prom-remote-write-lj/verify-metrics-query-works/content.json
+++ b/prom-remote-write-lj/verify-metrics-query-works/content.json
@@ -26,8 +26,7 @@
           "content": "In the Grafana side menu, click **Drilldown > Metrics**."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "If you see a **Let's start!** button, click it."
         }
       ]

--- a/prom-remote-write-lj/verify-prom-data/content.json
+++ b/prom-remote-write-lj/verify-prom-data/content.json
@@ -24,18 +24,15 @@
       "autoCollapse": false,
       "blocks": [
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Log into the machine on which Prometheus is installed."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "If required, switch to a user that has administrative privileges."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "To check the Prometheus service status, run one of the following commands:\n\nFor Linux:\n\n```\nsystemctl status prometheus.service\n```\n\nFor Windows:\n\n```\nsc query prometheus\n```\n\nYou should see something similar to the following:"
         },
         {
@@ -44,8 +41,7 @@
           "alt": "Picture that shows the Prometheus service up and running"
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "To ensure that Prometheus is capturing the metrics, open a browser tab and navigate to the metrics endpoint URL.\n\nFor example, navigate to `http://localhost:9090/metrics`\n\nYou should see something similar to the following:"
         },
         {


### PR DESCRIPTION
Replace Prometheus remote write noop workaround blocks with markdown content so Pathfinder can render section steps sequentially.

Linked issue: https://github.com/grafana/interactive-tutorials/issues/314

Made with [Cursor](https://cursor.com)