### PR TITLE
Migrate Adaptive Logs numbered steps

### DIFF
--- a/adaptive-logs-lj/content.json
+++ b/adaptive-logs-lj/content.json
@@ -53,8 +53,7 @@
       "title": "Review patterns and recommendations",
       "blocks": [
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "The patterns table lists log patterns, query frequency, volume, current and recommended drop rates, and projected savings. Use the filters to narrow results by service or frequency."
         },
         {
@@ -69,8 +68,7 @@
           "doIt": false
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Review the projected savings in the confirmation dialog, then click **Apply** to confirm."
         }
       ]
@@ -101,8 +99,7 @@
           "doIt": false
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Optionally provide business context in the **Reason** field, then click **Save**."
         }
       ]
@@ -125,8 +122,7 @@
           "content": "Click **Add new segment** to create a segment."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Enter a descriptive name, select a log stream label (for example, `namespace`), and specify the values that match the team's logs. Click **Add** to save."
         }
       ]

--- a/adaptive-logs-lj/exemptions/content.json
+++ b/adaptive-logs-lj/exemptions/content.json
@@ -17,30 +17,20 @@
           "content": "Select the **Exemptions** tab."
         },
         {
-          "type": "interactive",
-          "action": "noop",
-          "reftarget": "Add new exemption",
+          "type": "markdown",
           "content": "Click **Add new exemption**."
         },
         {
-          "type": "interactive",
-          "action": "noop",
-          "reftarget": "[data-testid='stream-selector-input']",
-          "targetvalue": "",
-          "content": "In the Add exemption window, enter a valid stream selector.",
-          "doIt": false
+          "type": "markdown",
+          "content": "In the Add exemption window, enter a valid stream selector."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Optionally provide business context in the **Reason** field."
         },
         {
-          "type": "interactive",
-          "action": "noop",
-          "reftarget": "[data-testid='data-testid Confirm Modal Danger Button']",
-          "content": "Click **Save**.",
-          "doIt": false
+          "type": "markdown",
+          "content": "Click **Save**."
         }
       ]
     },

--- a/adaptive-logs-lj/review-apply/content.json
+++ b/adaptive-logs-lj/review-apply/content.json
@@ -53,8 +53,7 @@
           "content": "The **Apply recommended drop rate(s)** dialog box provides information about ingest volume vs projected volume and the projected savings of applying the recommendations."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Review the recommended drop rates in the dialog."
         },
         {

--- a/adaptive-logs-lj/segmentation/content.json
+++ b/adaptive-logs-lj/segmentation/content.json
@@ -17,44 +17,28 @@
           "content": "Select the **Segments** tab."
         },
         {
-          "type": "interactive",
-          "action": "noop",
-          "reftarget": "Add new segment",
+          "type": "markdown",
           "content": "Click **Add new segment**."
         },
         {
-          "type": "interactive",
-          "action": "noop",
-          "reftarget": "#segment-name",
-          "targetvalue": "",
-          "content": "Enter a descriptive name that clearly identifies the team this segment applies to.",
-          "doIt": false
+          "type": "markdown",
+          "content": "Enter a descriptive name that clearly identifies the team this segment applies to."
         },
         {
-          "type": "interactive",
-          "action": "noop",
-          "reftarget": "#segment-label",
-          "content": "Select the log stream label that distinguishes the metrics belonging to a particular team (for example, `namespace` in Kubernetes).",
-          "doIt": false
+          "type": "markdown",
+          "content": "Select the log stream label that distinguishes the metrics belonging to a particular team (for example, `namespace` in Kubernetes)."
         },
         {
-          "type": "interactive",
-          "action": "noop",
-          "reftarget": "#segment-value",
-          "content": "Enter the values that match the label you specified (for example, `web-frontend`, `web-backend`). Each value can only be used once across segments.",
-          "doIt": false
+          "type": "markdown",
+          "content": "Enter the values that match the label you specified (for example, `web-frontend`, `web-backend`). Each value can only be used once across segments."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "(Optional) Select **Fallback to default pattern configuration** to apply default drop rates to log streams outside any segment."
         },
         {
-          "type": "interactive",
-          "action": "noop",
-          "reftarget": "[data-testid='data-testid Confirm Modal Danger Button']",
-          "content": "Click **Add**.",
-          "doIt": false
+          "type": "markdown",
+          "content": "Click **Add**."
         }
       ]
     },
@@ -66,33 +50,24 @@
       "type": "section",
       "blocks": [
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Select the segment you want to set drop rates for."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Select the patterns for that particular segment."
         },
         {
-          "type": "interactive",
-          "action": "noop",
-          "reftarget": "[aria-label='drop-rate-edit']",
-          "content": "Click **Bulk edit service drop rates**.",
-          "doIt": false
+          "type": "markdown",
+          "content": "Click **Bulk edit service drop rates**."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Enter the percentage drop rate you want to set for the segment. The projected savings after you apply changes is displayed."
         },
         {
-          "type": "interactive",
-          "action": "noop",
-          "reftarget": "Apply",
-          "content": "Click **Apply**.",
-          "doIt": false
+          "type": "markdown",
+          "content": "Click **Apply**."
         }
       ]
     },
@@ -104,23 +79,19 @@
       "type": "section",
       "blocks": [
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "On the **Pattern** tab, expand a pattern."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Review which services are producing logs with that pattern."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Click the **Edit** icon to edit drop rates."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Enter the percentage drop rate you want to add for each service. The projected savings after you apply changes is displayed."
         },
         {


### PR DESCRIPTION
Replace Adaptive Logs noop workaround blocks with markdown content so Pathfinder can render section steps sequentially.

Linked issue: https://github.com/grafana/interactive-tutorials/issues/314

Made with [Cursor](https://cursor.com)