### PR TITLE
Migrate PostgreSQL DB O11y numbered steps

### DIFF
--- a/postgresql-db-olly-lj/configure-alloy/content.json
+++ b/postgresql-db-olly-lj/configure-alloy/content.json
@@ -16,38 +16,31 @@
           "content": "To configure Grafana Alloy to connect your PostgreSQL database to Grafana Cloud, complete the following steps:"
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Install Grafana Alloy 1.15.0 or later. Refer to the [Alloy installation documentation](https://grafana.com/docs/alloy/latest/get-started/install/) for your platform."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Create the Data Source Name secret file. Replace the placeholders with your values:\n\n```bash\necho 'postgresql://db-o11y:<DB_PASSWORD>@<DB_HOST>:<DB_PORT>/postgres?sslmode=require' > /var/lib/alloy/postgres_secret\n```\n\nReplace:\n- **DB_PASSWORD** — Password for the `db-o11y` user you created\n- **DB_HOST** — Hostname or IP of your PostgreSQL server\n- **DB_PORT** — PostgreSQL port (default: 5432)"
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Add the core Database Observability blocks to your Alloy configuration file. These configure the PostgreSQL exporter for metrics and the Database Observability component for query-level logs:\n\n```alloy\nlocal.file \"postgres_secret\" {\n  filename  = \"/var/lib/alloy/postgres_secret\"\n  is_secret = true\n}\n\nprometheus.exporter.postgres \"postgres\" {\n  data_source_names  = [local.file.postgres_secret.content]\n  enabled_collectors = [\"stat_statements\"]\n}\n\ndatabase_observability.postgres \"postgres\" {\n  data_source_name  = local.file.postgres_secret.content\n  forward_to        = [loki.relabel.database_observability_postgres.receiver]\n  targets           = prometheus.exporter.postgres.postgres.targets\n  enable_collectors = [\"query_details\", \"query_samples\", \"schema_details\", \"explain_plans\"]\n  exclude_users     = [\"db-o11y\"]\n}\n```"
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Add the relabeling rules and Prometheus scrape configuration:\n\n```alloy\nloki.relabel \"database_observability_postgres\" {\n  forward_to = [loki.write.logs_service.receiver]\n\n  rule {\n    target_label = \"instance\"\n    replacement  = \"<DB_HOST>:<DB_PORT>\"\n  }\n}\n\ndiscovery.relabel \"database_observability_postgres\" {\n  targets = database_observability.postgres.postgres.targets\n\n  rule {\n    target_label = \"job\"\n    replacement  = \"integrations/db-o11y\"\n  }\n  rule {\n    target_label = \"instance\"\n    replacement  = \"<DB_HOST>:<DB_PORT>\"\n  }\n}\n\nprometheus.scrape \"database_observability_postgres\" {\n  targets    = discovery.relabel.database_observability_postgres.output\n  forward_to = [prometheus.remote_write.metrics_service.receiver]\n}\n```"
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "In the relabeling blocks you just added, replace the `DB_HOST` and `DB_PORT` placeholder values with your PostgreSQL host and port."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Add the Prometheus remote write and Loki write blocks. Find your Grafana Cloud credentials in your stack's configuration page:\n\n```alloy\nprometheus.remote_write \"metrics_service\" {\n  endpoint {\n    url = \"https://prometheus-<region>.grafana.net/api/prom/push\"\n    basic_auth {\n      username = \"<METRICS_USER>\"\n      password = \"<METRICS_API_KEY>\"\n    }\n  }\n}\n\nloki.write \"logs_service\" {\n  endpoint {\n    url = \"https://logs-<region>.grafana.net/loki/api/v1/push\"\n    basic_auth {\n      username = \"<LOGS_USER>\"\n      password = \"<LOGS_API_KEY>\"\n    }\n  }\n}\n```"
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Replace the region, usernames, and API keys with your Grafana Cloud stack values."
         },
         {

--- a/postgresql-db-olly-lj/explore-queries/content.json
+++ b/postgresql-db-olly-lj/explore-queries/content.json
@@ -39,18 +39,15 @@
           "requirements": ["navmenu-open"]
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Review the summary metrics at the top of the page: **Duration Average** (typical query execution time), **Errors** (total query errors and error percentage), and **Rate** (queries per second and total count). Spikes in these metrics indicate performance regressions or queries that need investigation."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Scroll down to the query performance table. Each row shows a normalized SQL statement with its duration, call count, errors, and wait events."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Click any query row to drill into its details. The detail view shows explain plans, query samples, and wait event breakdowns for that query."
         },
         {

--- a/postgresql-db-olly-lj/prepare-postgresql/content.json
+++ b/postgresql-db-olly-lj/prepare-postgresql/content.json
@@ -16,63 +16,51 @@
           "content": "To prepare your PostgreSQL database instance for Database Observability, complete the following steps:"
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Add `pg_stat_statements` to `shared_preload_libraries` in your `postgresql.conf` file and restart PostgreSQL to apply the change."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Create the extension in each database you want to monitor:\n\n```sql\nCREATE EXTENSION IF NOT EXISTS pg_stat_statements;\n```"
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Verify the extension is installed:\n\n```sql\nSELECT * FROM pg_extension WHERE extname = 'pg_stat_statements';\n```\n\nExpected result: One row confirming the extension exists."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Set `pg_stat_statements.track` to `all` in your `postgresql.conf` file:\n\n```\npg_stat_statements.track = all\n```"
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Verify the setting:\n\n```sql\nSHOW pg_stat_statements.track;\n```\n\nExpected result: Value is `all`."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Increase `track_activity_query_size` to `4096` in your `postgresql.conf` file to capture complete query text."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Verify the setting:\n\n```sql\nSHOW track_activity_query_size;\n```\n\nExpected result: `4kB` (4096)."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Create a dedicated monitoring user and grant the required roles:\n\n```sql\nCREATE USER \"db-o11y\" WITH PASSWORD '<DB_O11Y_PASSWORD>';\nGRANT pg_monitor TO \"db-o11y\";\nGRANT pg_read_all_stats TO \"db-o11y\";\n```"
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Replace the password with a strong value."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Verify that the monitoring user can query `pg_stat_statements`:\n\n```sql\n-- run with the db-o11y user\nSELECT * FROM pg_stat_statements LIMIT 1;\n```"
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Disable tracking of queries executed by the monitoring user:\n\n```sql\nALTER ROLE \"db-o11y\" SET pg_stat_statements.track = 'none';\n```"
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Grant object-level privileges for schema details and explain plans. Connect to each database and grant access to the schemas you want to monitor:\n\n```sql\nGRANT USAGE ON SCHEMA public TO \"db-o11y\";\nGRANT SELECT ON ALL TABLES IN SCHEMA public TO \"db-o11y\";\n```\n\nAlternatively, grant read access to all objects:\n\n```sql\nGRANT pg_read_all_data TO \"db-o11y\";\n```"
         },
         {

--- a/postgresql-db-olly-lj/verify-telemetry/content.json
+++ b/postgresql-db-olly-lj/verify-telemetry/content.json
@@ -38,13 +38,11 @@
           "requirements": ["on-page:/a/grafana-dbo11y-app"]
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Select your PostgreSQL instance from the **Instance** dropdown at the top of the page."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Choose the instance label you configured in your Alloy relabeling rules."
         },
         {


### PR DESCRIPTION
Replace PostgreSQL DB O11y noop workaround blocks with markdown content so Pathfinder can render section steps sequentially.

Linked issue: https://github.com/grafana/interactive-tutorials/issues/314

Made with [Cursor](https://cursor.com)