### PR TITLE
Migrate MongoDB integration numbered steps

### DIFF
--- a/mongodb-integration-lj/configure-alloy/content.json
+++ b/mongodb-integration-lj/configure-alloy/content.json
@@ -15,8 +15,7 @@
       "type": "section",
       "blocks": [
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "On the MongoDB integration page in Grafana Cloud, scroll to the **Set up Grafana Alloy to use the MongoDB integration** section."
         },
         {
@@ -28,13 +27,11 @@
           "doIt": false
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Create or open your Grafana Alloy configuration file.\n\nThe default configuration file location is `/etc/alloy/config.alloy`."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Paste the integration snippet into the configuration file."
         }
       ]

--- a/mongodb-integration-lj/install-alloy/content.json
+++ b/mongodb-integration-lj/install-alloy/content.json
@@ -23,38 +23,31 @@
           "doIt": false
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Perform one of the following:\n\n| If you want to        | Then                                                                                                                                                                                                                                                                                                              |\n| --------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |\n| Create a new token    | <ol><li>Click <b>Create new token</b>.</li><li><p>Enter a token name.</p><p>Make sure the token name is meaningful to you and something you'll remember. For example, <code>prodUS</code>.</p></li><li><p>Click <b>Create token.</b></p><p><b>Note:</b> You don't need to adjust the <b>Scopes</b>.</p></li></ol> |\n| Use an existing token | <ol><li>Click <b>Use an existing token</b>.</li><li>Enter a token you have created in the past.</li></ol>                                                                                                                                                                                                         |\n\n**Tip:** You don't need to copy the token. The token is added to the install Grafana Alloy script that you copy in the next steps."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Verify that the **Enable Remote Configuration** toggle switch is set to on."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "In the **Install and run Grafana Alloy** section, click **Copy to Clipboard**."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Log into the machine on which you are installing Grafana Alloy and open the Terminal."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Paste the contents of the clipboard into the terminal and press **Enter**.\n\nThis command installs Grafana Alloy on the machine. When the installation is complete, you'll see `Alloy is now running!`"
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "To verify that Grafana Alloy is installed correctly, click **Test Alloy connection**.\n\nIf Grafana Alloy is installed correctly, you'll see `Awesome! Grafana Alloy is good to go`."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "If Alloy is successfully installed, click **Proceed to install integration**."
         }
       ]

--- a/mongodb-integration-lj/install-dashboards-alerts/content.json
+++ b/mongodb-integration-lj/install-dashboards-alerts/content.json
@@ -15,18 +15,15 @@
       "type": "section",
       "blocks": [
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "In the **Install dashboards and alerts** section of Grafana Cloud, click **Install**.\n\nYou should see the following message: `Dashboards and alerts have been installed.`"
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Verify the dashboard installation by navigating to **Dashboards** in the main menu and searching for `MongoDB`.\n\nYou should see the following installed dashboards:\n- MongoDB Cluster: A dashboard for cluster-wide monitoring\n- MongoDB Instance: A dashboard for individual server metrics\n- MongoDB ReplicaSet: A dashboard for replication monitoring"
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Verify the alert rule installation by navigating to **Alerting > Alert rules** and searching for `MongoDB`.\n\nThe following alert rules monitor critical MongoDB conditions and notify you when intervention is required:\n\n| Alert Rule | Severity | Description |\n|------------|----------|-------------|\n| MongodbDown | Critical | MongoDB instance is not responding |\n| MongodbReplicaMemberUnhealthy | Critical | Replica set member is unhealthy |\n| MongodbReplicationLag | Critical | Replication lag exceeds threshold |\n| MongodbReplicationHeadroom | Critical | Replication headroom is too low |\n| MongodbTooManyConnections | Warning | Connection count is too high |\n| MongodbVirtualMemoryUsage | Warning | Virtual memory usage is excessive |\n| MongodbCursorsTimeouts | Warning | Cursor timeouts are increasing |\n| MongodbNumberCursorsOpen | Warning | Too many cursors are open |\n| MongodbReadRequestsQueueingUp | Warning | Read requests are queuing |\n| MongodbWriteRequestsQueueingUp | Warning | Write requests are queuing |"
         }
       ]

--- a/mongodb-integration-lj/prepare-configuration/content.json
+++ b/mongodb-integration-lj/prepare-configuration/content.json
@@ -15,18 +15,15 @@
       "type": "section",
       "blocks": [
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Connect to your MongoDB instance and create a user with read-only permissions.\n\nThe following script creates a dedicated MongoDB user for monitoring.\n\n```javascript\nuse admin\ndb.createUser({\n  user: \"grafana_monitoring\",\n  pwd: \"secure_password_here\", \n  roles: [\n    { role: \"read\", db: \"admin\" },\n    { role: \"clusterMonitor\", db: \"admin\" },\n    { role: \"read\", db: \"local\" }\n  ]\n})\n```"
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Open the Grafana Alloy configuration file and replace the placeholders with your specific values.\n\nThis defines the MongoDB connection URI.\n\n```alloy\nmongodb_uri = \"mongodb://grafana_monitoring:secure_password_here@mongodb.example.com:27017/admin\"\n```\n\nFor MongoDB cloud deployments, include additional parameters:\n\n```alloy\nmongodb_uri = \"mongodb+srv://grafana_monitoring:secure_password_here@cluster.example.mongodb.net/admin?retryWrites=true\"\n```"
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Configure the service and cluster labels by updating the label values in the Grafana Alloy configuration file.\n\n```alloy\nrule {\n    target_label = \"service_name\"\n    replacement  = \"mongodb-production\"\n}\n\nrule {\n    target_label = \"mongodb_cluster\"  \n    replacement  = \"main-cluster\"\n}\n\nrule {\n    target_label = \"instance\"\n    replacement  = \"mongodb-prod-01\"\n}\n```"
         }
       ]

--- a/mongodb-integration-lj/select-platform/content.json
+++ b/mongodb-integration-lj/select-platform/content.json
@@ -15,13 +15,11 @@
       "type": "section",
       "blocks": [
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Sign in to your Grafana Cloud environment, for example `mystack.grafana.net`."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "On the Grafana Cloud home page, open the navigation menu on the left side of the screen and click **Connections > Add new connection**."
         },
         {
@@ -40,23 +38,19 @@
           "content": "Click the **MongoDB** tile to open the integration setup page."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Select your operating system and architecture.\n\nGrafana Alloy supports the following platforms:\n- **Linux** (x86_64, ARM64)\n- **macOS** (x86_64, ARM64)\n- **Windows** (x86_64)\n- **Docker containers**\n- **Kubernetes deployments**"
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Select the architecture."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "If you are unsure of the architecture, perform the following steps:\n\na. On the Linux machine, open the Terminal.\n\nb. Run the following command:\n\n   ```\n   uname -m\n   ```\n\nIf this command returns `x86_64`, then select `Amd64`. If the command returns `aarch64`, then select `Arm64`. If the command returns anything else, your system isn't supported by Grafana Alloy; you need to use a 64-bit x86 or ARM system."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "If you are installing Grafana Alloy on MacOS, select an installation method that best fits your infrastructure:\n- **Homebrew** for direct system deployment\n- **Binary download** for custom installations"
         }
       ]

--- a/mongodb-integration-lj/test-connection/content.json
+++ b/mongodb-integration-lj/test-connection/content.json
@@ -15,18 +15,15 @@
       "type": "section",
       "blocks": [
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Save your Grafana Alloy configuration file.\n\nEnsure all changes are saved to `/etc/alloy/config.alloy` (Linux), `$(brew --prefix)/etc/alloy/config.alloy` (macOS), or your custom configuration location."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Restart the Grafana Alloy service.\n\nOn a Linux machine, run:\n\n```bash\nsudo systemctl restart alloy\n```\n\nOn macOS, run:\n\n```bash\nbrew services restart grafana/grafana/alloy\n```"
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Check the service status to ensure Alloy is running properly.\n\nOn a Linux machine, run:\n\n```bash\nsudo systemctl status alloy\n```\n\nOn macOS, run:\n\n```bash\nbrew services info grafana/grafana/alloy\n```\n\nThe output should show `active (running)` status."
         },
         {
@@ -37,13 +34,11 @@
           "content": "In Grafana Cloud, click **Test connection**."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "It might take up to a few minutes for the system to verify the connection.\n\nYou'll know the connection is working when you see `Integration is collecting data and sending it to Grafana Cloud`."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Verify metrics are appearing in Grafana Cloud:\n\n1. In Grafana Cloud navigate to **Explore**.\n2. Select your Prometheus data source.\n3. Query for MongoDB metrics using: `mongodb_up`\n\nIf the connection is successful, you should see a value of `1` indicating MongoDB is reachable."
         }
       ]


### PR DESCRIPTION
Replace MongoDB integration noop workaround blocks with markdown content so Pathfinder can render section steps sequentially.

Linked issue: https://github.com/grafana/interactive-tutorials/issues/314

Made with [Cursor](https://cursor.com)