### PR TITLE
Migrate MySQL integration numbered steps

### DIFF
--- a/mysql-integration-lj/configure-alloy/content.json
+++ b/mysql-integration-lj/configure-alloy/content.json
@@ -12,48 +12,39 @@
       "autoCollapse": false,
       "blocks": [
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "On the MySQL integration page in Grafana Cloud, scroll to the **Set up Grafana Alloy to use the MySQL integration** section."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "At the bottom of the snippet, click **Copy to clipboard**."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Open the Grafana Alloy configuration file on your system. For example, on a Linux machine, run:\n\n```\nsudo nano /etc/alloy/config.alloy\n```"
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Paste the integration snippet into the configuration file."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Update the `data_source_name` parameter with your MySQL connection details. For example: `alloy_monitor:secure_password@(localhost:3306)/`"
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Review the log path in the logs configuration and update it if necessary:\n\n- For Linux systems, the default path is `/var/log/mysql/*.log`\n- For Windows systems, the default path is `C:\\ProgramData\\MySQL\\MySQL Server*\\Data\\*.log`"
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Save the configuration file and exit the editor."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Restart the Grafana Alloy service to apply the configuration. On Linux, run:\n\n```\nsudo systemctl restart alloy\n```"
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Check the service status to ensure it started successfully. On Linux, run:\n\n```\nsudo systemctl status alloy\n```"
         }
       ]

--- a/mysql-integration-lj/install-alloy/content.json
+++ b/mysql-integration-lj/install-alloy/content.json
@@ -19,33 +19,27 @@
           "content": "In the **Install Alloy** section, click **Run Grafana Alloy**."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Perform one of the following:\n\n| If you want to | Then |\n| --- | --- |\n| Create a new token | Click **Create new token**, enter a meaningful token name (e.g., `prodUS`), then click **Create token**. |\n| Use an existing token | Click **Use an existing token** and enter a token you have created in the past. |\n\n**Tip:** You don't need to copy the token. The token is added to the install Grafana Alloy script that you copy in the next step."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Verify that the **Enable Remote Configuration** toggle is set to on."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "In the **Install and run Grafana Alloy** section, click **Copy to Clipboard**."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Log into the machine where you are installing Grafana Alloy, open the Terminal, and paste the contents of the clipboard. Press **Enter** to install Grafana Alloy.\n\nWhen the installation is complete, you'll see `Alloy is now running!`"
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "To verify that Grafana Alloy is installed correctly, click **Test Alloy connection**.\n\nIf Grafana Alloy is installed correctly, you'll see `Awesome! Grafana Alloy is good to go`."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "If Alloy is successfully installed, click **Proceed to install integration**."
         }
       ]

--- a/mysql-integration-lj/install-dashboards-alerts/content.json
+++ b/mysql-integration-lj/install-dashboards-alerts/content.json
@@ -12,8 +12,7 @@
       "autoCollapse": false,
       "blocks": [
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "On the MySQL integration page in Grafana Cloud, scroll to the **Install dashboards and alerts** section."
         },
         {
@@ -24,8 +23,7 @@
           "content": "Click the **Install** button to add the pre-built dashboards and alerts to your Grafana Cloud instance."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Wait for the installation to complete. You'll see a confirmation message when the dashboards and alerts are successfully installed."
         },
         {
@@ -37,8 +35,7 @@
           "content": "Navigate to **Dashboards** in your Grafana Cloud instance to view the installed MySQL dashboards:\n\n- **MySQL**: Overview dashboard with key performance metrics\n- **MySQL logs**: Log analysis dashboard for troubleshooting"
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Navigate to **Alerts & IRM > Alerting > Alert rules** to view the installed MySQL alert rules."
         }
       ]

--- a/mysql-integration-lj/prepare-configuration/content.json
+++ b/mysql-integration-lj/prepare-configuration/content.json
@@ -12,38 +12,31 @@
       "autoCollapse": false,
       "blocks": [
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Connect to your MySQL server as an administrative user:\n\n```\nmysql -u root -p\n```"
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Create a dedicated monitoring user for Grafana Alloy:\n\n```sql\nCREATE USER 'alloy_monitor'@'localhost' IDENTIFIED BY 'secure_password';\n```"
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Grant the necessary privileges for monitoring:\n\n```sql\nGRANT PROCESS, REPLICATION CLIENT, SELECT ON *.* TO 'alloy_monitor'@'localhost';\nGRANT SELECT ON performance_schema.* TO 'alloy_monitor'@'localhost';\n```"
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Apply the privilege changes:\n\n```sql\nFLUSH PRIVILEGES;\n```"
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Exit the MySQL client:\n\n```sql\nEXIT;\n```"
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Test the monitoring user connection:\n\n```\nmysql -u alloy_monitor -p -e \"SHOW STATUS LIKE 'Uptime';\"\n```"
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Note your MySQL connection details for the next milestone:\n\n- Hostname: `localhost` (or your MySQL server hostname)\n- Port: `3306` (or your custom MySQL port)\n- Username: `alloy_monitor`\n- Password: The password you set for the monitoring user\n- Database: Leave empty for monitoring all databases"
         }
       ]

--- a/mysql-integration-lj/select-platform/content.json
+++ b/mysql-integration-lj/select-platform/content.json
@@ -34,8 +34,7 @@
           "requirements": ["exists-reftarget"]
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Grafana Alloy supports the following platforms:\n- **Linux** (x86_64, ARM64)\n- **macOS** (x86_64, ARM64)\n- **Windows** (x86_64)\n- **Kubernetes deployments**"
         },
         {

--- a/mysql-integration-lj/test-connection/content.json
+++ b/mysql-integration-lj/test-connection/content.json
@@ -12,8 +12,7 @@
       "autoCollapse": false,
       "blocks": [
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "On the MySQL integration page in Grafana Cloud, scroll to the **Test connection** section."
         },
         {
@@ -24,8 +23,7 @@
           "content": "Click the **Test connection** button to validate that data is flowing from your MySQL instance to Grafana Cloud."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Wait for the connection test to complete. A successful test indicates that:\n\n- Grafana Alloy is running and configured correctly\n- MySQL metrics are being collected\n- Data is reaching your Grafana Cloud instance"
         }
       ]


### PR DESCRIPTION
Replace MySQL integration noop workaround blocks with markdown content so Pathfinder can render section steps sequentially.

Linked issue: https://github.com/grafana/interactive-tutorials/issues/314

Made with [Cursor](https://cursor.com)