### PR TITLE
Migrate PostgreSQL integration numbered steps

### DIFF
--- a/postgresql-integration-lj/configure-alloy/content.json
+++ b/postgresql-integration-lj/configure-alloy/content.json
@@ -16,8 +16,7 @@
       "autoCollapse": false,
       "blocks": [
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "On the PostgreSQL integration page in Grafana Cloud, scroll to the **Set up Grafana Alloy to use the PostgreSQL integration** section."
         },
         {
@@ -27,38 +26,31 @@
           "content": "At the bottom of the snippet, click **Copy to clipboard**."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Open the Grafana Alloy configuration file on your system. For example, on a Linux machine, run:\n\n```\nsudo nano /etc/alloy/config.alloy\n```"
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Paste the integration snippet into the configuration file."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Update the `data_source_names` parameter with your PostgreSQL connection details.\n\nReplace the placeholder `postgresql://localhost:5432/postgres` with your actual connection string.\n\nFor example: `postgresql://alloy_monitor:secure_password@localhost:5432/postgres`"
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Review the log path in the logs configuration and update it if necessary:\n\n- For Linux systems, the default path is `/var/log/postgresql/postgres.log`\n- For macOS systems, the default path is `/var/log/postgresql/postgres.log`\n- For Windows systems, the default path is `C:\\Program Files\\PostgreSQL\\*\\data\\pg_log`"
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Save the configuration file and exit the editor."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Restart the Grafana Alloy service to apply the configuration. On Linux, run:\n\n```\nsudo systemctl restart alloy\n```"
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Check the service status to ensure it started successfully. On Linux, run:\n\n```\nsudo systemctl status alloy\n```"
         }
       ]

--- a/postgresql-integration-lj/install-alloy/content.json
+++ b/postgresql-integration-lj/install-alloy/content.json
@@ -25,33 +25,27 @@
           "content": "In the **Install Alloy** section, click **Run Grafana Alloy**."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "**Create or select a token:**\n\n- **Create new token**: Click **Create new token**, enter a meaningful token name (e.g., `prodUS`), then click **Create token**.\n- **Use existing token**: Click **Use an existing token** and enter a token you have created in the past.\n\n**Tip:** You don't need to copy the token. The token is added to the install Grafana Alloy script that you copy in the next step."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Verify that the **Enable Remote Configuration** toggle is set to on."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "In the **Install and run Grafana Alloy** section, click **Copy to Clipboard**."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Log into the machine where you are installing Grafana Alloy, open the Terminal, and paste the contents of the clipboard. Press **Enter** to install Grafana Alloy.\n\nWhen the installation is complete, you'll see `Alloy is now running!`"
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "To verify that Grafana Alloy is installed correctly, click **Test Alloy connection**.\n\nIf Grafana Alloy is installed correctly, you'll see `Awesome! Grafana Alloy is good to go`."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "If Alloy is successfully installed, click **Proceed to install integration**."
         }
       ]

--- a/postgresql-integration-lj/install-dashboards-alerts/content.json
+++ b/postgresql-integration-lj/install-dashboards-alerts/content.json
@@ -16,8 +16,7 @@
       "autoCollapse": false,
       "blocks": [
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "On the PostgreSQL integration page in Grafana Cloud, scroll to the **Install dashboards and alerts** section."
         },
         {
@@ -27,8 +26,7 @@
           "content": "Click **Install** to add the pre-built dashboards and alerts to your Grafana Cloud instance."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Wait for the installation to complete. You'll see a confirmation message when the dashboards and alerts are successfully installed."
         },
         {
@@ -39,8 +37,7 @@
           "doIt": false
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Navigate to **Alerts & IRM > Alerting > Alert rules** to view the installed PostgreSQL alert rules."
         }
       ]

--- a/postgresql-integration-lj/prepare-configuration/content.json
+++ b/postgresql-integration-lj/prepare-configuration/content.json
@@ -16,43 +16,35 @@
       "autoCollapse": false,
       "blocks": [
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Connect to your PostgreSQL server as an administrative user:\n\n```\npsql -U postgres -h localhost\n```"
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Create a dedicated monitoring user for Grafana Alloy:\n\n```sql\nCREATE USER alloy_monitor WITH PASSWORD 'secure_password';\n```"
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Grant the necessary privileges for monitoring:\n\n```sql\nGRANT CONNECT ON DATABASE postgres TO alloy_monitor;\nGRANT SELECT ON pg_stat_database TO alloy_monitor;\nGRANT SELECT ON pg_stat_user_tables TO alloy_monitor;\nGRANT SELECT ON pg_stat_user_indexes TO alloy_monitor;\n```"
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "For PostgreSQL 10+, grant additional monitoring privileges:\n\n```sql\nGRANT pg_monitor TO alloy_monitor;\n```"
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "For PostgreSQL versions below 10, grant individual monitoring functions:\n\n```sql\nGRANT EXECUTE ON FUNCTION pg_stat_file(text) TO alloy_monitor;\nGRANT EXECUTE ON FUNCTION pg_stat_file(text,boolean) TO alloy_monitor;\nGRANT EXECUTE ON FUNCTION pg_ls_dir(text) TO alloy_monitor;\nGRANT EXECUTE ON FUNCTION pg_ls_dir(text,boolean,boolean) TO alloy_monitor;\n```"
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Exit the PostgreSQL client:\n\n```sql\n\\q\n```"
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Test the monitoring user connection:\n\n```\npsql -U alloy_monitor -h localhost -d postgres -c \"SELECT version();\"\n```"
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Note your PostgreSQL connection details for the next milestone:\n\n- Hostname: `localhost` (or your PostgreSQL server hostname)\n- Port: `5432` (or your custom PostgreSQL port)\n- Username: `alloy_monitor`\n- Password: The password you set for the monitoring user\n- Database: `postgres` (or your target database name)"
         }
       ]

--- a/postgresql-integration-lj/select-platform/content.json
+++ b/postgresql-integration-lj/select-platform/content.json
@@ -54,8 +54,7 @@
           "doIt": false
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "If you are installing Grafana Alloy on macOS, select an installation method that best fits your infrastructure:\n- **Homebrew** for direct system deployment\n- **Binary download** for custom installations"
         }
       ]

--- a/postgresql-integration-lj/test-connection/content.json
+++ b/postgresql-integration-lj/test-connection/content.json
@@ -16,8 +16,7 @@
       "autoCollapse": false,
       "blocks": [
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "On the PostgreSQL integration page in Grafana Cloud, scroll to the **Test connection** section."
         },
         {
@@ -27,8 +26,7 @@
           "content": "Click **Test connection** to validate that data is flowing from your PostgreSQL instance to Grafana Cloud."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Wait for the connection test to complete. A successful test indicates that:\n\n- Grafana Alloy is running and configured correctly\n- PostgreSQL metrics are being collected\n- Data is reaching your Grafana Cloud instance"
         },
         {
@@ -55,8 +53,7 @@
           "content": "In the query editor, search for `pg_up` to verify that the PostgreSQL exporter is reporting the database status."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Check that the metric returns a value of `1`, indicating that PostgreSQL is up and responding to monitoring queries."
         }
       ]


### PR DESCRIPTION
Replace PostgreSQL integration noop workaround blocks with markdown content so Pathfinder can render section steps sequentially.

Linked issue: https://github.com/grafana/interactive-tutorials/issues/314

Made with [Cursor](https://cursor.com)