### PR TITLE
[codex] Add DPM explore up metric guide

### DIFF
--- a/dpm-explore-up-metric/content.json
+++ b/dpm-explore-up-metric/content.json
@@ -8,25 +8,25 @@
     },
     {
       "type": "section",
-      "id": "query-up-dpm",
-      "title": "Open Explore with the up DPM query",
+      "id": "open-explore",
+      "title": "Open Explore",
       "requirements": [
         "has-datasource:prometheus"
       ],
       "blocks": [
         {
           "type": "markdown",
-          "content": "In this section, you will open Explore with an instant Prometheus query that counts samples for the `up` metric over the last minute. The query is shown here so you can copy it manually if your Explore state is different:\n\n```promql\nsort_desc(count_over_time({__name__=\"up\"}[1m]))\n```\n\nThe `up` metric is created by scrape-based Prometheus collection. If your metrics are pushed through OTLP instead of scraped, you might not have `up`; use another scraped metric name for this check."
+          "content": "Start from Explore so you can choose the Prometheus data source that contains the metric series you want to inspect."
         },
         {
           "type": "interactive",
           "action": "navigate",
-          "reftarget": "/explore?schemaVersion=1&panes=%7B%22dpm%22%3A%7B%22datasource%22%3A%22__default%22%2C%22queries%22%3A%5B%7B%22refId%22%3A%22A%22%2C%22expr%22%3A%22sort_desc%28count_over_time%28%7B__name__%3D%5C%22up%5C%22%7D%5B1m%5D%29%29%22%2C%22range%22%3Afalse%2C%22instant%22%3Atrue%7D%5D%2C%22range%22%3A%7B%22from%22%3A%22now-1h%22%2C%22to%22%3A%22now%22%7D%2C%22compact%22%3Afalse%7D%7D&orgId=1",
+          "reftarget": "/explore",
           "verify": "on-page:/explore",
           "requirements": [
             "has-datasource:prometheus"
           ],
-          "content": "Open **Explore** with the DPM query preloaded."
+          "content": "Open **Explore**."
         }
       ]
     },
@@ -47,12 +47,73 @@
             "on-page:/explore",
             "exists-reftarget"
           ],
-          "doIt": false,
-          "content": "Use the Explore data source picker to choose a Prometheus data source. If a Prometheus data source is already selected, keep it."
+          "content": "Open the data source picker and choose the Prometheus data source that contains your scraped metrics. If the right Prometheus data source is already selected, keep it."
         },
         {
           "type": "markdown",
-          "content": "Keep the query type set to **Instant**, not **Range** or **Both**. Instant queries return a single value per series for the selected time."
+          "content": "Use a Prometheus or Mimir data source backed by scraped metrics. The `up` metric is created by scrape-based Prometheus collection. If your metrics are pushed through OTLP instead of scraped, you might not have `up`; use another scraped metric name for this check."
+        }
+      ]
+    },
+    {
+      "type": "section",
+      "id": "enter-up-dpm-query",
+      "title": "Enter the up DPM query",
+      "requirements": [
+        "has-datasource:prometheus",
+        "on-page:/explore"
+      ],
+      "blocks": [
+        {
+          "type": "markdown",
+          "content": "This instant query counts samples for the `up` metric over the last minute. Copy it manually if you prefer to paste the query yourself:\n\n```promql\nsort_desc(count_over_time({__name__=\"up\"}[1m]))\n```"
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "div[data-testid='QueryEditorModeToggle'] label[for^='option-code-radiogroup']",
+          "requirements": [
+            "on-page:/explore",
+            "exists-reftarget"
+          ],
+          "content": "Switch the query editor to **Code** mode."
+        },
+        {
+          "type": "interactive",
+          "action": "formfill",
+          "reftarget": "textarea.inputarea",
+          "targetvalue": "sort_desc(count_over_time({__name__=\"up\"}[1m]))",
+          "requirements": [
+            "on-page:/explore",
+            "exists-reftarget"
+          ],
+          "content": "Add the `up` DPM query to the query editor."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "div[data-testid='data-testid prometheus options'] button[aria-expanded='false']",
+          "requirements": [
+            "on-page:/explore",
+            "exists-reftarget"
+          ],
+          "skippable": true,
+          "hint": "If the options are already expanded, skip this step.",
+          "content": "Open **Options** for the Prometheus query."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "fieldset[data-testid='data-testid prometheus type'] label[for^='option-instant-radiogroup']",
+          "requirements": [
+            "on-page:/explore",
+            "exists-reftarget"
+          ],
+          "content": "Select **Instant** so the query returns one value per series."
+        },
+        {
+          "type": "markdown",
+          "content": "Use **Instant**, not **Range** or **Both**. Instant queries return a single value per series for the selected time."
         }
       ]
     },
@@ -73,11 +134,11 @@
             "on-page:/explore",
             "exists-reftarget"
           ],
-          "content": "Click **Run query**."
+          "content": "Run the instant query."
         },
         {
           "type": "markdown",
-          "content": "You have run an instant query with a 1-minute lookback. A value near `1` means about one sample per minute. A value near `4` means about one sample every 15 seconds."
+          "content": "A value near `1` means about one sample per minute. A value near `4` means about one sample every 15 seconds."
         }
       ]
     },
@@ -92,7 +153,7 @@
       "blocks": [
         {
           "type": "markdown",
-          "content": "In this section, you will adapt the instant query for other metrics and learn when to avoid broad selectors. Use an exact metric name when you know what you want to inspect:\n\n```promql\nsort_desc(count_over_time({__name__=\"your_metric_name\"}[1m]))\n```"
+          "content": "To inspect a specific metric, first find its metric name. In Explore, click **Metrics browser** and search by integration, service, or metric prefix. You can also use **Metrics Drilldown** to browse active metrics, filter by labels, and copy a metric name back into Explore. Start with one exact metric name when you know what you want to inspect:\n\n```promql\nsort_desc(count_over_time({__name__=\"your_metric_name\"}[1m]))\n```"
         },
         {
           "type": "markdown",
@@ -100,13 +161,14 @@
         },
         {
           "type": "interactive",
-          "action": "navigate",
-          "reftarget": "/explore?schemaVersion=1&panes=%7B%22dpm%22%3A%7B%22datasource%22%3A%22__default%22%2C%22queries%22%3A%5B%7B%22refId%22%3A%22A%22%2C%22expr%22%3A%22sort_desc(count_over_time(%7B__name__%3D~%5C%22up%7Cprometheus_build_info%5C%22%7D%5B1m%5D))%22%2C%22range%22%3Afalse%2C%22instant%22%3Atrue%7D%5D%2C%22range%22%3A%7B%22from%22%3A%22now-1h%22%2C%22to%22%3A%22now%22%7D%2C%22compact%22%3Afalse%7D%7D&orgId=1",
-          "verify": "on-page:/explore",
+          "action": "formfill",
+          "reftarget": "textarea.inputarea",
+          "targetvalue": "sort_desc(count_over_time({__name__=~\"up|prometheus_build_info\"}[1m]))",
           "requirements": [
-            "has-datasource:prometheus"
+            "on-page:/explore",
+            "exists-reftarget"
           ],
-          "content": "Load the instant regex DPM query in Explore."
+          "content": "Replace the query with the instant regex DPM example."
         },
         {
           "type": "interactive",

--- a/dpm-explore-up-metric/content.json
+++ b/dpm-explore-up-metric/content.json
@@ -9,29 +9,62 @@
     {
       "type": "section",
       "id": "query-up-dpm",
-      "title": "Query DPM for up",
+      "title": "Open Explore with the up DPM query",
       "requirements": [
         "has-datasource:prometheus"
       ],
       "blocks": [
         {
           "type": "markdown",
-          "content": "In this section, you will open Explore with an instant Prometheus query that counts samples for the `up` metric over the last minute."
+          "content": "In this section, you will open Explore with an instant Prometheus query that counts samples for the `up` metric over the last minute. The query is shown here so you can copy it manually if your Explore state is different:\n\n```promql\nsort_desc(count_over_time({__name__=\"up\"}[1m]))\n```\n\nThe `up` metric is created by scrape-based Prometheus collection. If your metrics are pushed through OTLP instead of scraped, you might not have `up`; use another scraped metric name for this check."
         },
         {
           "type": "interactive",
           "action": "navigate",
-          "reftarget": "/explore?schemaVersion=1&panes={\"dpm\":{\"datasource\":\"__default\",\"queries\":[{\"refId\":\"A\",\"expr\":\"sort_desc(count_over_time({__name__=\\\"up\\\"}[1m]))\",\"range\":false,\"instant\":true}],\"range\":{\"from\":\"now-1h\",\"to\":\"now\"},\"compact\":false}}&orgId=1",
+          "reftarget": "/explore?schemaVersion=1&panes=%7B%22dpm%22%3A%7B%22datasource%22%3A%22__default%22%2C%22queries%22%3A%5B%7B%22refId%22%3A%22A%22%2C%22expr%22%3A%22sort_desc%28count_over_time%28%7B__name__%3D%5C%22up%5C%22%7D%5B1m%5D%29%29%22%2C%22range%22%3Afalse%2C%22instant%22%3Atrue%7D%5D%2C%22range%22%3A%7B%22from%22%3A%22now-1h%22%2C%22to%22%3A%22now%22%7D%2C%22compact%22%3Afalse%7D%7D&orgId=1",
           "verify": "on-page:/explore",
           "requirements": [
             "has-datasource:prometheus"
           ],
           "content": "Open **Explore** with the DPM query preloaded."
+        }
+      ]
+    },
+    {
+      "type": "section",
+      "id": "choose-prometheus-datasource",
+      "title": "Choose a Prometheus data source",
+      "requirements": [
+        "has-datasource:prometheus",
+        "on-page:/explore"
+      ],
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "div[data-testid='data-testid Data source picker select container']",
+          "requirements": [
+            "on-page:/explore",
+            "exists-reftarget"
+          ],
+          "doIt": false,
+          "content": "Use the Explore data source picker to choose a Prometheus data source. If a Prometheus data source is already selected, keep it."
         },
         {
           "type": "markdown",
-          "content": "If Explore did not use a Prometheus data source, use the data source picker in the Explore toolbar to select one. Keep the query type set to **Instant**, not **Range** or **Both**."
-        },
+          "content": "Keep the query type set to **Instant**, not **Range** or **Both**. Instant queries return a single value per series for the selected time."
+        }
+      ]
+    },
+    {
+      "type": "section",
+      "id": "run-up-dpm-query",
+      "title": "Run the up DPM query",
+      "requirements": [
+        "has-datasource:prometheus",
+        "on-page:/explore"
+      ],
+      "blocks": [
         {
           "type": "interactive",
           "action": "highlight",
@@ -59,23 +92,35 @@
       "blocks": [
         {
           "type": "markdown",
-          "content": "In this section, you will adapt the instant query for other metrics and learn when to avoid broad selectors."
+          "content": "In this section, you will adapt the instant query for other metrics and learn when to avoid broad selectors. Use an exact metric name when you know what you want to inspect:\n\n```promql\nsort_desc(count_over_time({__name__=\"your_metric_name\"}[1m]))\n```"
         },
         {
           "type": "markdown",
-          "content": "Use an exact metric name when you know what you want to inspect:\n\n```promql\nsort_desc(count_over_time({__name__=\"your_metric_name\"}[1m]))\n```"
+          "content": "You can also use a regex matcher to inspect a family of metric names. This can be useful during exploration, but it can be expensive because Grafana may need to scan many metric names and series. Start exact, keep the `[1m]` lookback small, and broaden only when the result set is manageable.\n\nTry this instant regex example in the local test environment:\n\n```promql\nsort_desc(count_over_time({__name__=~\"up|prometheus_build_info\"}[1m]))\n```"
+        },
+        {
+          "type": "interactive",
+          "action": "navigate",
+          "reftarget": "/explore?schemaVersion=1&panes=%7B%22dpm%22%3A%7B%22datasource%22%3A%22__default%22%2C%22queries%22%3A%5B%7B%22refId%22%3A%22A%22%2C%22expr%22%3A%22sort_desc(count_over_time(%7B__name__%3D~%5C%22up%7Cprometheus_build_info%5C%22%7D%5B1m%5D))%22%2C%22range%22%3Afalse%2C%22instant%22%3Atrue%7D%5D%2C%22range%22%3A%7B%22from%22%3A%22now-1h%22%2C%22to%22%3A%22now%22%7D%2C%22compact%22%3Afalse%7D%7D&orgId=1",
+          "verify": "on-page:/explore",
+          "requirements": [
+            "has-datasource:prometheus"
+          ],
+          "content": "Load the instant regex DPM query in Explore."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "button[data-testid='data-testid RefreshPicker run button']",
+          "requirements": [
+            "on-page:/explore",
+            "exists-reftarget"
+          ],
+          "content": "Run the regex query and compare the returned series."
         },
         {
           "type": "markdown",
-          "content": "Use a regex matcher only when you need to inspect a family of metrics:\n\n```promql\nsort_desc(count_over_time({__name__=~\"your_metric_prefix_.*\"}[1m]))\n```"
-        },
-        {
-          "type": "markdown",
-          "content": "Regex matchers can be expensive because they may scan many metric names and series. Start with an exact metric name, keep the `[1m]` lookback small, and broaden the selector only when the result set is manageable."
-        },
-        {
-          "type": "markdown",
-          "content": "You have learned how to adapt the DPM query and when regex selectors can add query cost."
+          "content": "You have learned how to adapt the DPM query, how to keep it instant, and when regex selectors can add query cost."
         }
       ]
     },

--- a/dpm-explore-up-metric/content.json
+++ b/dpm-explore-up-metric/content.json
@@ -86,7 +86,7 @@
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "div[data-testid='QueryEditorModeToggle'] input[id^='option-code-radiogroup']",
+          "reftarget": "div[data-testid='QueryEditorModeToggle'] label:contains('Code')",
           "requirements": [
             "on-page:/explore",
             "exists-reftarget"
@@ -119,7 +119,7 @@
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "fieldset[data-testid='data-testid prometheus type'] label[for^='option-instant-radiogroup']",
+          "reftarget": "fieldset[data-testid='data-testid prometheus type'] label:contains('Instant')",
           "requirements": [
             "on-page:/explore",
             "exists-reftarget"

--- a/dpm-explore-up-metric/content.json
+++ b/dpm-explore-up-metric/content.json
@@ -1,0 +1,87 @@
+{
+  "id": "dpm-explore-up-metric",
+  "title": "Explore DPM with the up metric",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "Use this guide to estimate data points per minute (DPM) for a familiar Prometheus metric. DPM measures how often each active series sends data to Grafana Cloud, so unexpectedly high DPM can increase ingestion volume and cost."
+    },
+    {
+      "type": "section",
+      "id": "query-up-dpm",
+      "title": "Query DPM for up",
+      "requirements": [
+        "has-datasource:prometheus"
+      ],
+      "blocks": [
+        {
+          "type": "markdown",
+          "content": "In this section, you will open Explore with an instant Prometheus query that counts samples for the `up` metric over the last minute."
+        },
+        {
+          "type": "interactive",
+          "action": "navigate",
+          "reftarget": "/explore?schemaVersion=1&panes={\"dpm\":{\"datasource\":\"__default\",\"queries\":[{\"refId\":\"A\",\"expr\":\"sort_desc(count_over_time({__name__=\\\"up\\\"}[1m]))\",\"range\":false,\"instant\":true}],\"range\":{\"from\":\"now-1h\",\"to\":\"now\"},\"compact\":false}}&orgId=1",
+          "verify": "on-page:/explore",
+          "requirements": [
+            "has-datasource:prometheus"
+          ],
+          "content": "Open **Explore** with the DPM query preloaded."
+        },
+        {
+          "type": "markdown",
+          "content": "If Explore did not use a Prometheus data source, use the data source picker in the Explore toolbar to select one. Keep the query type set to **Instant**, not **Range** or **Both**."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "button[data-testid='data-testid RefreshPicker run button']",
+          "requirements": [
+            "on-page:/explore",
+            "exists-reftarget"
+          ],
+          "content": "Click **Run query**."
+        },
+        {
+          "type": "markdown",
+          "content": "You have run an instant query with a 1-minute lookback. A value near `1` means about one sample per minute. A value near `4` means about one sample every 15 seconds."
+        }
+      ]
+    },
+    {
+      "type": "section",
+      "id": "advanced-dpm-options",
+      "title": "Try advanced DPM queries",
+      "requirements": [
+        "has-datasource:prometheus",
+        "on-page:/explore"
+      ],
+      "blocks": [
+        {
+          "type": "markdown",
+          "content": "In this section, you will adapt the instant query for other metrics and learn when to avoid broad selectors."
+        },
+        {
+          "type": "markdown",
+          "content": "Use an exact metric name when you know what you want to inspect:\n\n```promql\nsort_desc(count_over_time({__name__=\"your_metric_name\"}[1m]))\n```"
+        },
+        {
+          "type": "markdown",
+          "content": "Use a regex matcher only when you need to inspect a family of metrics:\n\n```promql\nsort_desc(count_over_time({__name__=~\"your_metric_prefix_.*\"}[1m]))\n```"
+        },
+        {
+          "type": "markdown",
+          "content": "Regex matchers can be expensive because they may scan many metric names and series. Start with an exact metric name, keep the `[1m]` lookback small, and broaden the selector only when the result set is manageable."
+        },
+        {
+          "type": "markdown",
+          "content": "You have learned how to adapt the DPM query and when regex selectors can add query cost."
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "More to explore:\n\n- [Reduce metrics costs by adjusting DPM](https://grafana.com/docs/grafana-cloud/cost-management-and-billing/analyze-costs/reduce-costs/metrics-costs/adjust-data-points-per-minute/)\n- [Data points per minute in Grafana Cloud](https://grafana.com/blog/data-points-per-minute-in-grafana-cloud-what-you-need-to-know-about-dpm/)\n- [dpm-finder](https://github.com/grafana-ps/dpm-finder) for larger metric scans through the Prometheus HTTP API"
+    }
+  ]
+}

--- a/dpm-explore-up-metric/content.json
+++ b/dpm-explore-up-metric/content.json
@@ -80,10 +80,6 @@
       ],
       "blocks": [
         {
-          "type": "markdown",
-          "content": "This instant query counts samples for the `up` metric over the last minute. Copy it manually if you prefer to paste the query yourself:\n\n```promql\nsort_desc(count_over_time({__name__=\"up\"}[1m]))\n```"
-        },
-        {
           "type": "interactive",
           "action": "highlight",
           "reftarget": "div[data-testid='QueryEditorModeToggle'] label:contains('Code')",
@@ -92,6 +88,10 @@
             "exists-reftarget"
           ],
           "content": "Select **Code** mode. If Code is already selected, this action keeps it selected."
+        },
+        {
+          "type": "markdown",
+          "content": "This instant query counts samples for the `up` metric over the last minute. Copy it manually if you prefer to paste the query yourself:\n\n```promql\nsort_desc(count_over_time({__name__=\"up\"}[1m]))\n```"
         },
         {
           "type": "interactive",

--- a/dpm-explore-up-metric/content.json
+++ b/dpm-explore-up-metric/content.json
@@ -40,14 +40,29 @@
       ],
       "blocks": [
         {
-          "type": "interactive",
-          "action": "highlight",
-          "reftarget": "div[data-testid='data-testid Data source picker select container']",
-          "requirements": [
-            "on-page:/explore",
-            "exists-reftarget"
+          "type": "multistep",
+          "content": "Open the data source picker and choose a Prometheus data source. **Do it** selects the first Prometheus option in the list. If your stack has more than one Prometheus data source, choose the one that contains the scraped metrics you want to inspect.",
+          "steps": [
+            {
+              "action": "highlight",
+              "reftarget": "grafana:components.DataSourcePicker.inputV2",
+              "requirements": [
+                "exists-reftarget"
+              ],
+              "tooltip": "Open the data source picker."
+            },
+            {
+              "action": "highlight",
+              "reftarget": "div[data-testid=\"data-source-card\"]:has(small:contains(\"Prometheus\")) button:nth-match(1)",
+              "requirements": [
+                "exists-reftarget"
+              ],
+              "tooltip": "Select the first Prometheus data source in the list."
+            }
           ],
-          "content": "Open the data source picker and choose the Prometheus data source that contains your scraped metrics. If the right Prometheus data source is already selected, keep it."
+          "requirements": [
+            "on-page:/explore"
+          ]
         },
         {
           "type": "markdown",
@@ -71,12 +86,12 @@
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "div[data-testid='QueryEditorModeToggle'] label[for^='option-code-radiogroup']",
+          "reftarget": "div[data-testid='QueryEditorModeToggle'] input[id^='option-code-radiogroup']",
           "requirements": [
             "on-page:/explore",
             "exists-reftarget"
           ],
-          "content": "Switch the query editor to **Code** mode."
+          "content": "Select **Code** mode. If Code is already selected, this action keeps it selected."
         },
         {
           "type": "interactive",

--- a/dpm-explore-up-metric/manifest.json
+++ b/dpm-explore-up-metric/manifest.json
@@ -1,0 +1,44 @@
+{
+  "id": "dpm-explore-up-metric",
+  "type": "guide",
+  "description": "Estimate data points per minute for the Prometheus up metric in Explore, then adapt the instant query for other metrics.",
+  "category": "take-action",
+  "author": {
+    "team": "interactive-learning"
+  },
+  "startingLocation": "/explore",
+  "targeting": {
+    "match": {
+      "or": [
+        {
+          "urlPrefix": "/explore"
+        },
+        {
+          "urlPrefix": "/dashboards"
+        },
+        {
+          "urlPrefix": "/billing"
+        },
+        {
+          "urlPrefix": "/usage"
+        }
+      ]
+    }
+  },
+  "testEnvironment": {
+    "tier": "cloud",
+    "datasources": [
+      "prometheus"
+    ]
+  },
+  "depends": [],
+  "recommends": [
+    "billing-usage-learn-cost-calculations"
+  ],
+  "suggests": [
+    "billing-usage-create-billing-alert"
+  ],
+  "provides": [
+    "dpm-explored"
+  ]
+}


### PR DESCRIPTION
## What changed

- Added a standalone `dpm-explore-up-metric` guide with `content.json` and `manifest.json`.
- Guides users through Explore with the instant query `sort_desc(count_over_time({__name__="up"}[1m]))`.
- Adds advanced exact-name and regex query examples with a query cost caveat.
- Links to the Grafana Cloud DPM docs, the DPM blog post, and `grafana-ps/dpm-finder`.

## Why

This gives Pathfinder a simple first guide for estimating data points per minute before moving on to more complex flows.

## Validation

- `node /Users/jorge/git/work/grafana-pathfinder-app/dist/cli/cli/index.js validate --package dpm-explore-up-metric`
- `node /Users/jorge/git/work/grafana-pathfinder-app/dist/cli/cli/index.js build-repository . --exclude shared -o /private/tmp/interactive-tutorials-repository.json`

Tested in my stack
<img width="1222" height="1263" alt="Screenshot 2026-06-01 at 15 42 29" src="https://github.com/user-attachments/assets/0f711c41-bbe2-4325-b375-28d31db4474c" />
<img width="1315" height="1255" alt="Screenshot 2026-06-01 at 15 42 24" src="https://github.com/user-attachments/assets/649d5450-4823-40a6-8d8b-b3dee22b7ba0" />



## Notes

- No local PR template was found in `grafana/interactive-tutorials`.
- Manual preview should verify the live Explore selectors, especially the manual **Type** to **Instant** step.



