### PR TITLE
ci: auto-label content-only PRs

### DIFF
--- a/.github/workflows/label-content-only.yml
+++ b/.github/workflows/label-content-only.yml
@@ -1,0 +1,110 @@
+name: Label content-only PRs
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    name: Apply content-only label
+    runs-on: ubuntu-latest
+    steps:
+      - name: Evaluate changed files and label
+        # Applies the `content-only` label when every changed file in the PR is
+        # one of: any `manifest.json`, any `content.json`, or `.github/CODEOWNERS`.
+        # Removes the label if a previously-content-only PR grows to include
+        # other changes on a later push.
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const label = 'content-only';
+
+            const files = await github.paginate(
+              github.rest.pulls.listFiles,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.payload.pull_request.number,
+                per_page: 100,
+              }
+            );
+
+            if (files.length === 0) {
+              core.info('PR has no changed files; skipping.');
+              return;
+            }
+
+            const isContentFile = (path) => {
+              const base = path.split('/').pop();
+              if (base === 'manifest.json') return true;
+              if (base === 'content.json') return true;
+              if (path === '.github/CODEOWNERS') return true;
+              return false;
+            };
+
+            const offenders = files
+              .filter(f => f.status !== 'removed' || true) // include all statuses
+              .map(f => f.filename)
+              .filter(p => !isContentFile(p));
+
+            const allContent = offenders.length === 0;
+
+            core.info(`Changed files: ${files.length}`);
+            core.info(`Non-content files: ${offenders.length}`);
+            if (offenders.length > 0) {
+              core.info(`Examples: ${offenders.slice(0, 10).join(', ')}`);
+            }
+
+            // Ensure the label exists in the repo.
+            try {
+              await github.rest.issues.getLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: label,
+              });
+            } catch (err) {
+              if (err.status === 404) {
+                core.info(`Creating label "${label}".`);
+                await github.rest.issues.createLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name: label,
+                  color: '0e8a16',
+                  description: 'PR only modifies guide content (manifest.json, content.json, or CODEOWNERS)',
+                });
+              } else {
+                throw err;
+              }
+            }
+
+            const prNumber = context.payload.pull_request.number;
+            const current = await github.rest.issues.listLabelsOnIssue({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+            });
+            const hasLabel = current.data.some(l => l.name === label);
+
+            if (allContent && !hasLabel) {
+              core.info(`Adding "${label}" label.`);
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                labels: [label],
+              });
+            } else if (!allContent && hasLabel) {
+              core.info(`Removing "${label}" label (PR now contains non-content changes).`);
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                name: label,
+              });
+            } else {
+              core.info('No label change needed.');
+            }


### PR DESCRIPTION
## Summary
- New workflow `.github/workflows/label-content-only.yml` that applies the `content-only` label to PRs whose changes are *entirely* limited to `manifest.json`, `content.json`, or `.github/CODEOWNERS`.
- Label is auto-removed if a later push adds files outside that allowlist, so the label always reflects the current state of the PR.
- Label is auto-created (green) on first run if it doesn't already exist in the repo.

## Implementation notes
- Triggers: `opened`, `synchronize`, `reopened`, `ready_for_review`.
- Uses `pull_request_target` so labeling works for fork PRs. The workflow only reads the PR file list via API — it never checks out PR code — so this is safe.
- Paginates `pulls.listFiles` so PRs with >100 changed files are handled correctly.
- Requires repo Actions setting "Allow GitHub Actions to create and approve pull requests" / workflow write permissions; if labeling silently no-ops on the first PR, that's where to look.

## Test plan
- [ ] Open a PR that only touches a `manifest.json` → label appears.
- [ ] Open a PR that only touches a `content.json` → label appears.
- [ ] Open a PR that only touches `.github/CODEOWNERS` → label appears.
- [ ] Open a PR mixing one of the above with, e.g., a workflow change → label is NOT applied.
- [ ] Start a content-only PR (label applied), push a non-content commit → label is removed on the new run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)