### PR TITLE
fix(dpm-explore-up-metric): correct recommender targeting

### DIFF
--- a/dpm-explore-up-metric/manifest.json
+++ b/dpm-explore-up-metric/manifest.json
@@ -14,13 +14,14 @@
           "urlPrefix": "/explore"
         },
         {
-          "urlPrefix": "/dashboards"
-        },
-        {
-          "urlPrefix": "/billing"
-        },
-        {
-          "urlPrefix": "/usage"
+          "and": [
+            {
+              "targetPlatform": "cloud"
+            },
+            {
+              "urlPrefix": "/a/grafana-costmanagementui-app"
+            }
+          ]
         }
       ]
     }


### PR DESCRIPTION
## What

Fixes the `targeting` block in `dpm-explore-up-metric/manifest.json` so the guide is actually surfaced where it's relevant.

## Why

Follow-up to #374. The original targeting recommended the guide on `/billing` and `/usage`, which are **not real Grafana routes**. The recommender's `urlPrefix` match is a `startsWith` test against `location.pathname`, so those prefixes never matched any page and the guide could never surface there. `/dashboards` was also too broad for a DPM-in-Explore flow.

(Flagged by @ in the [review thread](https://github.com/grafana/interactive-tutorials/pull/374): "you're recommending yourself on /billing which doesn't exist".)

## Change

| Before | After |
| --- | --- |
| `/explore` | `/explore` (cross-platform) |
| `/dashboards` | _(dropped)_ |
| `/billing` | `/a/grafana-costmanagementui-app` (cloud-only) |
| `/usage` | _(folded into the above)_ |

```json
"targeting": {
  "match": {
    "or": [
      { "urlPrefix": "/explore" },
      { "and": [
          { "targetPlatform": "cloud" },
          { "urlPrefix": "/a/grafana-costmanagementui-app" }
      ]}
    ]
  }
}
```

- **Explore** (`/explore`) stays cross-platform: it's where the guide tells you to run the DPM query.
- **Cost management / billing** is the Grafana Cloud cost-management app at `/a/grafana-costmanagementui-app`. The no-trailing-segment prefix covers the overview and every sub-tab (`/metrics`, `/logs`, `/traces`, `/profiles`). Gated with `targetPlatform: cloud` since the app is Cloud-only — this mirrors the existing `billing-usage-lj` journey's targeting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)