### PR TITLE
docs: point recommendation guidance at manifest.json targeting (index.json is frozen)

### DIFF
--- a/.cursor/how-to-write-recommendations.mdc
+++ b/.cursor/how-to-write-recommendations.mdc
@@ -1,34 +1,53 @@
 ---
-description: Guidelines for writing recommender rules in index.json for new interactive guides.
+description: Guidelines for making a new interactive guide contextually recommended via manifest.json targeting.
 globs:
-  - "**/index.json"
+  - "**/manifest.json"
 ---
 
-This repo contains a file called [`index.json`](../index.json) which gates recommendations of guides in this
-repository.  When new guides come in, we'll need some guidelines on how to recommend them.
+[`index.json`](../index.json) is **frozen**. A CI check ([`.github/workflows/freeze-index-json.yml`](../.github/workflows/freeze-index-json.yml))
+fails any PR that adds or changes `index.json`. Recommendation targeting for a guide now lives in that guide's
+`manifest.json` under `targeting.match`. See [docs/manifest-reference.md](../docs/manifest-reference.md) for the
+full field reference.
 
-Consult these rules to assist users in how to write recommender rules for [`index.json`](../index.json). That file
-is also a source of good examples on how valid recommender rules are written.
+Consult these rules when deciding how a new guide should be recommended. Existing `manifest.json` files in this
+repo are good examples of valid `targeting.match` blocks.
 
-A recommender rule is a single JSON object that is inserted into [`index.json`](../index.json).
+The `targeting.match` value uses the same expression syntax the old `index.json` rules used, so the decisions are
+the same -- they just live in the manifest now.
 
-- ALWAYS use "type": "docs-page"; all guides in this repo should be listed as "type": "docs-page"
-- ALWAYS include "title", "description", and "url".  You should always read the guide, and make
-default suggestions for title and description based on what is in the guide.
-- For URL, ALWAYS use the URL `https://github.com/grafana/interactive-tutorials/tree/main/DIRECTORY_NAME`
-where `DIRECTORY_NAME` is the location in this project of where the guide resides.
+- ALWAYS set `targeting.match` in the guide's `manifest.json` (never edit `index.json`).
+- The guide's `description` and `category` also live in `manifest.json`. Read the guide and base the
+  description on what's in it.
 - ASK THE USER whether the guide pertains to things that are cloud, or both cloud & OSS.
-  - If the guide is BOTH, no special rule is needed.
+  - If the guide is BOTH, no platform clause is needed.
   - If the guide is "Cloud" meaning it should only be targeted to Grafana Cloud, add `{ "targetPlatform": "cloud" }`
   as a match clause.
 - ASK the user which app states or URLs the guide should be suggested for. You may consult this list of
-app states to make suggestions:  https://github.com/grafana/grafana-pathfinder-app/blob/main/product-knowledge/app-states.mdc.  For example, if the guide deals with SLO or Service Center, that app states list indicates that functionality lives behind URLs like `/a/grafana-slo-app/services`, so you 
+app states to make suggestions:  https://github.com/grafana/grafana-pathfinder-app/blob/main/product-knowledge/app-states.mdc.  For example, if the guide deals with SLO or Service Center, that app states list indicates that functionality lives behind URLs like `/a/grafana-slo-app/services`, so you
 would suggest the URL to use to be that one.
-  - The user should specify a URL for recommendation; entries cannot be valid without one
-  - The user may specify more than one URL
-  - All URLs specified become part of the match block, e.g. `{ "urlPrefix": "SPECIFIED URL" }`
+  - The user should specify at least one URL; a guide with no URL match can never be recommended.
+  - The user may specify more than one URL.
+  - URLs become part of the match block: use `{ "urlPrefix": "SPECIFIED URL" }` for one, or
+  `{ "urlPrefixIn": ["URL1", "URL2"] }` for several.
+  - Combine clauses with `and` / `or` as needed (for example, `targetPlatform` cloud AND a `urlPrefixIn` list).
 - ASK the user if the guide modifies resources or causes users to create new things. These are "mutating guides"
 and that means that they cannot be run on environments like Play, where users don't have access to change things.
-  - If the user indicates the guide does create new things (or you can infer from reading the guide), this 
-  cannot be expressed in JSON match rules at the moment, so simply advise the user of this limitation.
-- ALWAYS ensure your JSON is pretty-printed and follows conventions in index.json.
+  - If the user indicates the guide does create new things (or you can infer from reading the guide), this
+  cannot be expressed in match rules at the moment, so simply advise the user of this limitation.
+- ALSO set `startingLocation` (where the guide launches) and `testEnvironment` per the manifest reference.
+- ALWAYS ensure your JSON is pretty-printed and follows the conventions in existing `manifest.json` files.
+
+## Example targeting.match
+
+```json
+{
+  "targeting": {
+    "match": {
+      "and": [
+        { "targetPlatform": "cloud" },
+        { "urlPrefixIn": ["/a/grafana-cmab-app/usage-alerts", "/a/grafana-cmab-app"] }
+      ]
+    }
+  }
+}
+```

--- a/.cursor/review-guide-pr.mdc
+++ b/.cursor/review-guide-pr.mdc
@@ -168,17 +168,19 @@ The first interactive action in a guide should establish the user's page context
 - **New guide**: recommend the PR author add their handle to `.github/CODEOWNERS` for the guide directory
 - **Existing guide**: check that a CODEOWNERS entry exists; if missing, advise the author that repo owners can add it
 
-## 6. index.json Entry Check
+## 6. Recommendation targeting check
 
-If `index.json` is modified:
+`index.json` is **frozen** -- a CI check (`.github/workflows/freeze-index-json.yml`) fails any PR that modifies it. Targeting now lives in each guide's `manifest.json` under `targeting.match`.
 
-- Entry `id` must match the guide's `content.json` `id`
-- `type` must be `"docs-page"`
-- `urlPrefix` must match where the guide should be recommended
-- `title` and `description` should be present and accurate
-- `url` must follow the pattern `https://github.com/grafana/interactive-tutorials/tree/main/DIRECTORY_NAME`
+For a standalone guide (or a `*-lj` path root), check the `manifest.json`:
 
-If a **new** guide is added but `index.json` is not modified, note that an index entry will be needed for the guide to appear in recommendations.
+- `id` must match the guide's `content.json` `id`
+- `targeting.match` should include the URL(s) where the guide is recommended (`urlPrefix` or `urlPrefixIn`)
+- Cloud-only guides should include `{ "targetPlatform": "cloud" }`
+- `description` and `category` should be present and accurate
+- LJ step guides omit `targeting` (targeting lives at the path level)
+
+If the PR modifies `index.json`, flag it: that change will fail the freeze check, and the targeting belongs in `manifest.json` instead. See [how-to-write-recommendations.mdc](how-to-write-recommendations.mdc) and [docs/manifest-reference.md](../docs/manifest-reference.md).
 
 ## 7. Deep Reference Links
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@ description: Overview of this repository and task routing for AI agents.
 
 # Interactive Guides Repository
 
-This repository contains interactive Grafana guides in JSON format. Each guide lives in its own directory with a `content.json` file defining the guide structure, and an optional `index.json` entry controls where the guide is recommended.
+This repository contains interactive Grafana guides in JSON format. Each guide lives in its own directory with a `content.json` file defining the guide structure and a `manifest.json` file whose `targeting.match` controls where the guide is recommended. (`index.json` is frozen and no longer edited per guide -- a CI check fails any PR that changes it.)
 
 Full reference documentation lives in `docs/`. AI-oriented references live in `.cursor/`.
 
@@ -44,7 +44,7 @@ Full reference documentation lives in `docs/`. AI-oriented references live in `.
 | Decision trees & code smells | [best-practices.mdc](.cursor/best-practices.mdc) | [authoring-guide.mdc](.cursor/authoring-guide.mdc), `docs/` |
 | Create new guide | `/new` command | [authoring-guide.mdc](.cursor/authoring-guide.mdc), [complete-example-tutorial.mdc](.cursor/complete-example-tutorial.mdc) |
 | Validate guide | `/lint`, `/check`, `/attack` commands | [authoring-guide.mdc](.cursor/authoring-guide.mdc), [best-practices.mdc](.cursor/best-practices.mdc) |
-| Write index.json entry | [how-to-write-recommendations.mdc](.cursor/how-to-write-recommendations.mdc) | `index.json` |
+| Make a guide recommended | [how-to-write-recommendations.mdc](.cursor/how-to-write-recommendations.mdc) | `manifest.json`, [docs/manifest-reference.md](docs/manifest-reference.md) |
 | Write/edit manifest.json | [docs/manifest-reference.md](docs/manifest-reference.md) | [authoring-guide.mdc](.cursor/authoring-guide.mdc) |
 | Understand the system | [system-architecture.mdc](.cursor/system-architecture.mdc) | `docs/` |
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ When a doc here disagrees with the upstream schema, the schema wins. Authoritati
 | Decision trees & code smells | [.cursor/best-practices.mdc](.cursor/best-practices.mdc) | [authoring-guide.mdc](.cursor/authoring-guide.mdc), [docs/](docs/) |
 | Create a new guide | [/new](.cursor/commands/new.md) command | [authoring-guide.mdc](.cursor/authoring-guide.mdc), [complete-example-tutorial.mdc](.cursor/complete-example-tutorial.mdc) |
 | Validate a guide | [/lint](.cursor/commands/lint.md), [/check](.cursor/commands/check.md), [/attack](.cursor/commands/attack.md) | [authoring-guide.mdc](.cursor/authoring-guide.mdc), [best-practices.mdc](.cursor/best-practices.mdc) |
-| Write recommender entry | [.cursor/how-to-write-recommendations.mdc](.cursor/how-to-write-recommendations.mdc) | [`index.json`](index.json) |
+| Make a guide recommended | [.cursor/how-to-write-recommendations.mdc](.cursor/how-to-write-recommendations.mdc) | `manifest.json`, [docs/manifest-reference.md](docs/manifest-reference.md) |
 | Write / edit manifest.json | [docs/manifest-reference.md](docs/manifest-reference.md) | [authoring-guide.mdc](.cursor/authoring-guide.mdc) |
 | Understand the system | [.cursor/system-architecture.mdc](.cursor/system-architecture.mdc) | [docs/](docs/) |
 | Generate / migrate from source | [autogen-guide](.cursor/skills/autogen-guide/SKILL.md), [autogen-guide-dashboard](.cursor/skills/autogen-guide-dashboard/SKILL.md), [migrate-guide](.cursor/skills/migrate-guide/SKILL.md) | [shared/critical-rules.md](.cursor/skills/shared/critical-rules.md) |


### PR DESCRIPTION
This PR updates recommender guidance for Agents. 
Updates the agent/author instructions to reflect that index.json is frozen (enforced by the freeze-index-json workflow): recommendation targeting now lives in each guide's `manifest.json` under targeting.match. 
Revises:
- `how-to-write-recommendations.mdc`
- `review-guide-pr.mdc` checklist
- `AGENTS.md`
- `CLAUDE.md` 

and retargets the rule's globs from `index.json` to `manifest.json`