### PR TITLE
Remove Docs Platform as content code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,11 +14,11 @@
 /shared/ @Jayclifford345 @tomglenn
 
 # Docs can approve content PRs
-**/content.json      @chri2547 @tacole02 @jdbaldry @robbymilo @moxious @Jayclifford345 @tomglenn
-**/manifest.json     @chri2547 @tacole02 @jdbaldry @robbymilo @moxious @Jayclifford345 @tomglenn
-**/assets/*          @chri2547 @tacole02 @jdbaldry @robbymilo @moxious @Jayclifford345 @tomglenn
-/.github/CODEOWNERS  @chri2547 @tacole02 @jdbaldry @robbymilo @moxious @Jayclifford345 @tomglenn
-/index.json          @chri2547 @tacole02 @jdbaldry @robbymilo @moxious @Jayclifford345 @tomglenn
+**/content.json      @chri2547 @tacole02 @moxious @Jayclifford345 @tomglenn
+**/manifest.json     @chri2547 @tacole02 @moxious @Jayclifford345 @tomglenn
+**/assets/*          @chri2547 @tacole02 @moxious @Jayclifford345 @tomglenn
+/.github/CODEOWNERS  @chri2547 @tacole02 @moxious @Jayclifford345 @tomglenn
+/index.json          @chri2547 @tacole02 @moxious @Jayclifford345 @tomglenn
 
 /.cursor/commands/build-interactive-lj/ @chri2547
 


### PR DESCRIPTION
We don't really manage the content and so aren't reviewing the PRs.

It's for @chri2547 and @tacole02 to manage content code ownership.