### PR TITLE
Add description and show_play metadata to learning paths

### DIFF
--- a/adaptive-logs-lj/end-journey/website.yaml
+++ b/adaptive-logs-lj/end-journey/website.yaml
@@ -20,3 +20,5 @@ side_journeys:
     link: /docs/grafana-cloud/adaptive-telemetry/adaptive-traces/
   - title: Understand logs usage and cost
     link: /docs/grafana-cloud/cost-management-and-billing/understand-usage-cost/logs/
+description: Celebrate completing the Adaptive Logs journey and discover next steps to extend optimization across telemetry
+  and cost management.

--- a/adaptive-logs-lj/exemptions/website.yaml
+++ b/adaptive-logs-lj/exemptions/website.yaml
@@ -18,3 +18,5 @@ side_journeys:
     link: /docs/grafana-cloud/adaptive-telemetry/adaptive-logs/create-exemptions/
   - title: Pause Adaptive Logs
     link: //docs/grafana-cloud/adaptive-telemetry/adaptive-logs/create-exemptions/pause-adaptive-logs/
+description: Learn how to create exemptions to ensure critical log streams and labels are preserved and excluded from
+  optimization recommendations.

--- a/adaptive-logs-lj/how-it-works/website.yaml
+++ b/adaptive-logs-lj/how-it-works/website.yaml
@@ -10,3 +10,5 @@ keywords:
 - recommendations
 - cardinality-reduction
 - logs-optimization
+description: Learn how Adaptive Logs analyzes, recommends, reduces, integrates, and adapts to continuously optimize
+  your log volume and label cardinality.

--- a/adaptive-logs-lj/monitor-validate/website.yaml
+++ b/adaptive-logs-lj/monitor-validate/website.yaml
@@ -16,3 +16,5 @@ side_journeys:
   items:
   - title: Understand logs usage and cost
     link: /docs/grafana-cloud/cost-management-and-billing/understand-usage-cost/logs/
+description: Learn how to monitor dashboards and log volume to confirm applied recommendations and customization are
+  delivering expected outcomes.

--- a/adaptive-logs-lj/review-apply/website.yaml
+++ b/adaptive-logs-lj/review-apply/website.yaml
@@ -16,3 +16,5 @@ side_journeys:
   items:
   - title: Review and apply recommendations
     link: /docs/grafana-cloud/adaptive-telemetry/adaptive-logs/manage-recommendations/
+description: Learn how to review and apply Adaptive Logs recommendations to reduce log volume while keeping dashboards
+  and alerts working.

--- a/adaptive-logs-lj/segmentation/website.yaml
+++ b/adaptive-logs-lj/segmentation/website.yaml
@@ -16,3 +16,5 @@ side_journeys:
   items:
   - title: Configure segments
     link: /docs/grafana-cloud/adaptive-telemetry/adaptive-logs/additional-configuration/create-segment-overrides/
+description: Learn how to create segments so each team can view and manage recommendations and overrides for only their
+  own logs.

--- a/adaptive-logs-lj/value-adaptive-logs/website.yaml
+++ b/adaptive-logs-lj/value-adaptive-logs/website.yaml
@@ -16,3 +16,5 @@ side_journeys:
   items:
   - title: Adaptive Telemetry
     link: /docs/grafana-cloud/adaptive-telemetry/
+description: Understand how Adaptive Logs helps you control costs, improve performance, and maintain observability
+  quality as log volume grows.

--- a/adaptive-logs-lj/website.yaml
+++ b/adaptive-logs-lj/website.yaml
@@ -23,3 +23,5 @@ keywords:
 - cost-optimization
 - observability
 - grafana-cloud
+description: Adaptive Logs reduces log volume and cost in Grafana Cloud by automatically identifying and dropping low-value
+  logs while preserving the insights that matter.

--- a/billing-usage-lj/business-value/website.yaml
+++ b/billing-usage-lj/business-value/website.yaml
@@ -9,3 +9,5 @@ keywords:
 - cost-optimization
 - observability
 - business-value
+description: Learn how understanding your billing and usage helps you optimize costs, allocate resources, and make
+  informed decisions about your observability investment.

--- a/billing-usage-lj/create-billing-alert/website.yaml
+++ b/billing-usage-lj/create-billing-alert/website.yaml
@@ -19,3 +19,4 @@ side_journeys:
     link: /docs/grafana-cloud/cost-management-and-billing/reduce-costs/
   - title: Grafana alerting
     link: /docs/grafana-cloud/alerting-and-irm/alerting/
+description: Set up proactive billing alerts to monitor your Grafana Cloud usage and prevent unexpected charges.

--- a/billing-usage-lj/end-journey/website.yaml
+++ b/billing-usage-lj/end-journey/website.yaml
@@ -18,3 +18,5 @@ side_journeys:
     link: /docs/grafana-cloud/cost-management-and-billing/generate-usage-attribution-report/
   - title: Adaptive telemetry
     link: /docs/grafana-cloud/cost-management-and-billing/adaptive-telemetry/
+description: Congratulations on completing the billing and usage learning path! Discover what you've accomplished and
+  explore related paths.

--- a/billing-usage-lj/identify-cost-sources/website.yaml
+++ b/billing-usage-lj/identify-cost-sources/website.yaml
@@ -16,3 +16,5 @@ side_journeys:
   items:
   - title: Generate usage attribution report
     link: /docs/grafana-cloud/cost-management-and-billing/generate-usage-attribution-report/
+description: Learn how to use the billing dashboard to identify which Grafana Cloud services and features are driving
+  your monthly costs.

--- a/billing-usage-lj/learn-cost-calculations/website.yaml
+++ b/billing-usage-lj/learn-cost-calculations/website.yaml
@@ -24,3 +24,5 @@ side_journeys:
     link: /docs/grafana-cloud/cost-management-and-billing/understand-your-invoice/logs-invoice/
   - title: Understand your Grafana Cloud Traces invoice
     link: /docs/grafana-cloud/cost-management-and-billing/understand-your-invoice/traces-invoice/
+description: Understand how Grafana Cloud calculates billing for metrics, logs, traces, and other services using product-specific
+  methodologies.

--- a/billing-usage-lj/navigate-to-billing-dashboard/website.yaml
+++ b/billing-usage-lj/navigate-to-billing-dashboard/website.yaml
@@ -15,3 +15,5 @@ side_journeys:
   items:
   - title: Understand your Grafana Cloud invoice
     link: /docs/grafana-cloud/cost-management-and-billing/understand-your-invoice/
+description: Learn how to access the Grafana Cloud billing dashboard and understand its key components for tracking
+  usage and costs.

--- a/billing-usage-lj/website.yaml
+++ b/billing-usage-lj/website.yaml
@@ -23,3 +23,5 @@ keywords:
 - cost-management
 - alerts
 - observability
+description: Welcome to the Grafana Cloud learning path that teaches you how to understand and manage your billing
+  and usage, identify cost drivers, and set up alerts to control spending.

--- a/categorize-collector-fleet-lj/add-environment-attribute/website.yaml
+++ b/categorize-collector-fleet-lj/add-environment-attribute/website.yaml
@@ -14,3 +14,5 @@ side_journeys:
   items:
   - title: Streamline your workflows
     link: /docs/grafana-cloud/send-data/fleet-management/streamline-workflows/
+description: Learn how to create the `env` attribute that identifies the deployment environment for targeted configuration
+  management.

--- a/categorize-collector-fleet-lj/add-service-attribute/website.yaml
+++ b/categorize-collector-fleet-lj/add-service-attribute/website.yaml
@@ -8,3 +8,4 @@ keywords:
 - service attribute
 - service monitoring
 - Fleet Management
+description: Learn how to create the `service.name` attribute that identifies which service the collector monitors.

--- a/categorize-collector-fleet-lj/add-team-attribute/website.yaml
+++ b/categorize-collector-fleet-lj/add-team-attribute/website.yaml
@@ -14,3 +14,4 @@ side_journeys:
   items:
   - title: Manage your Fleet
     link: /docs/grafana-cloud/send-data/fleet-management/manage-fleet/
+description: Learn how to create the `team` attribute that identifies collector ownership for operational accountability.

--- a/categorize-collector-fleet-lj/business-value/website.yaml
+++ b/categorize-collector-fleet-lj/business-value/website.yaml
@@ -9,3 +9,5 @@ keywords:
 - remote configuration
 - remote attributes
 - collector management
+description: Understand how attributes enable remote configuration management and operational organization of your
+  collector fleet.

--- a/categorize-collector-fleet-lj/end-journey/website.yaml
+++ b/categorize-collector-fleet-lj/end-journey/website.yaml
@@ -8,3 +8,4 @@ keywords:
 - journey completion
 - Fleet Management
 - collector categorization
+description: Celebrate completing the journey and review what you've accomplished in categorizing your collector fleet.

--- a/categorize-collector-fleet-lj/navigate-to-fleet/website.yaml
+++ b/categorize-collector-fleet-lj/navigate-to-fleet/website.yaml
@@ -8,3 +8,4 @@ keywords:
 - Fleet Management
 - navigation
 - Grafana Cloud
+description: Learn how to access Fleet Management in Grafana Cloud to view and manage your collector fleet.

--- a/categorize-collector-fleet-lj/select-collector/website.yaml
+++ b/categorize-collector-fleet-lj/select-collector/website.yaml
@@ -8,3 +8,4 @@ keywords:
 - collector selection
 - Fleet Management
 - attributes
+description: Learn how to select a specific set of collectors from your fleet to begin the categorization process.

--- a/categorize-collector-fleet-lj/website.yaml
+++ b/categorize-collector-fleet-lj/website.yaml
@@ -23,3 +23,8 @@ keywords:
 - fleet organization
 - remote attributes
 - remote configuration
+description: Welcome to the Grafana Fleet Management learning path that shows you how to organize and categorize your
+  collector fleet using custom attributes for remote configuration. Learn to categorize your infrastructure
+  with meaningful attributes that answer critical questions such as who owns this collector, which service
+  does it support, and where is it running.
+show_play: false

--- a/create-availability-slo-lj/configure-targets/website.yaml
+++ b/create-availability-slo-lj/configure-targets/website.yaml
@@ -17,3 +17,4 @@ side_journeys:
     link: /docs/grafana-cloud/alerting-and-irm/slo/
   - title: SLI examples
     link: /docs/slo/latest/sli-examples/
+description: Set your reliability target, name your SLO, and save it.

--- a/create-availability-slo-lj/create-availability-slo/website.yaml
+++ b/create-availability-slo-lj/create-availability-slo/website.yaml
@@ -17,3 +17,4 @@ side_journeys:
     link: /docs/grafana-cloud/alerting-and-irm/slo/
   - title: SLO best practices
     link: /docs/slo/latest/best-practices/
+description: Use the Grafana SLO wizard to define your SLI and create an availability SLO.

--- a/create-availability-slo-lj/define-reliability-sli/website.yaml
+++ b/create-availability-slo-lj/define-reliability-sli/website.yaml
@@ -15,3 +15,4 @@ side_journeys:
   items:
   - title: Explore metrics in Grafana
     link: /docs/grafana-cloud/visualizations/panels-visualizations/
+description: Identify the metrics that measure your service's success and total events.

--- a/create-availability-slo-lj/end-journey/website.yaml
+++ b/create-availability-slo-lj/end-journey/website.yaml
@@ -8,3 +8,4 @@ keywords:
 - SLO
 - reliability
 - learning path complete
+description: Congratulations on completing the learning path about creating an availability SLO in Grafana Cloud.

--- a/create-availability-slo-lj/monitor-slo/website.yaml
+++ b/create-availability-slo-lj/monitor-slo/website.yaml
@@ -15,3 +15,4 @@ side_journeys:
   items:
   - title: SLO dashboards
     link: /docs/grafana-cloud/alerting-and-irm/slo/
+description: Review your SLO's performance and interpret the error budget burndown chart.

--- a/create-availability-slo-lj/value-of-slos/website.yaml
+++ b/create-availability-slo-lj/value-of-slos/website.yaml
@@ -15,3 +15,4 @@ side_journeys:
   items:
   - title: SLO documentation
     link: /docs/grafana-cloud/alerting-and-irm/slo/
+description: Understand why SLOs matter for measuring and improving service reliability.

--- a/create-availability-slo-lj/website.yaml
+++ b/create-availability-slo-lj/website.yaml
@@ -29,3 +29,5 @@ related_journeys:
   items:
   - title: Create infrastructure alert rules in Grafana Cloud
     link: /docs/learning-paths/infrastructure-alerting/
+description: Welcome to the Grafana learning path that shows you how to define a reliability SLI and create an SLO
+  to track service availability.

--- a/detect-outages-synthetic-monitoring-lj/create-ping-check/website.yaml
+++ b/detect-outages-synthetic-monitoring-lj/create-ping-check/website.yaml
@@ -15,3 +15,4 @@ side_journeys:
   items:
   - title: Ping check reference
     link: /docs/grafana-cloud/testing/synthetic-monitoring/create-checks/checks/ping/
+description: Learn how to create your first ping check to test endpoint reachability and measure response latency.

--- a/detect-outages-synthetic-monitoring-lj/end-journey/website.yaml
+++ b/detect-outages-synthetic-monitoring-lj/end-journey/website.yaml
@@ -20,3 +20,5 @@ side_journeys:
     link: /docs/grafana-cloud/testing/synthetic-monitoring/configure-alerts/
   - title: Set up private probes
     link: /docs/grafana-cloud/testing/synthetic-monitoring/set-up/set-up-private-probes/
+description: Congratulations on completing the Synthetic Monitoring get started learning path! Explore next steps for
+  expanding your monitoring capabilities.

--- a/detect-outages-synthetic-monitoring-lj/initialize-plugin/website.yaml
+++ b/detect-outages-synthetic-monitoring-lj/initialize-plugin/website.yaml
@@ -9,3 +9,4 @@ keywords:
 - plugin initialization
 - setup
 - data sources
+description: Learn how to initialize the Synthetic Monitoring plugin to set up the required data sources for your checks.

--- a/detect-outages-synthetic-monitoring-lj/navigate-to-synthetic-monitoring/website.yaml
+++ b/detect-outages-synthetic-monitoring-lj/navigate-to-synthetic-monitoring/website.yaml
@@ -8,3 +8,4 @@ keywords:
 - Synthetic Monitoring
 - navigation
 - Grafana Cloud
+description: Learn how to access the Synthetic Monitoring app within Grafana Cloud to view and manage your checks.

--- a/detect-outages-synthetic-monitoring-lj/select-probe-locations/website.yaml
+++ b/detect-outages-synthetic-monitoring-lj/select-probe-locations/website.yaml
@@ -17,3 +17,4 @@ side_journeys:
     link: /docs/grafana-cloud/testing/synthetic-monitoring/create-checks/public-probes/
   - title: Private probes reference
     link: /docs/grafana-cloud/testing/synthetic-monitoring/set-up/set-up-private-probes/
+description: Learn how to select global probe locations and create your check to start monitoring your services.

--- a/detect-outages-synthetic-monitoring-lj/value-of-synthetic-monitoring/website.yaml
+++ b/detect-outages-synthetic-monitoring-lj/value-of-synthetic-monitoring/website.yaml
@@ -15,3 +15,5 @@ side_journeys:
   items:
   - title: Introduction to Synthetic Monitoring
     link: /docs/grafana-cloud/testing/synthetic-monitoring/introduction/
+description: Understand the advantages of using Synthetic Monitoring to proactively detect availability and performance
+  issues from an external perspective.

--- a/detect-outages-synthetic-monitoring-lj/view-check-dashboard/website.yaml
+++ b/detect-outages-synthetic-monitoring-lj/view-check-dashboard/website.yaml
@@ -18,3 +18,4 @@ side_journeys:
     link: /docs/grafana-cloud/testing/synthetic-monitoring/analyze-results/
   - title: Visualize check execution with the time point explorer
     link: /docs/grafana-cloud/testing/synthetic-monitoring/analyze-results/visualize-check-execution/
+description: Learn how to view and interpret the check dashboard with uptime, latency, and reachability metrics.

--- a/detect-outages-synthetic-monitoring-lj/website.yaml
+++ b/detect-outages-synthetic-monitoring-lj/website.yaml
@@ -23,3 +23,5 @@ keywords:
 - ping check
 - availability
 - probes
+description: Welcome to the Grafana Cloud learning path that shows you how to set up Synthetic Monitoring and create
+  your first check to monitor endpoint availability from global probe locations.

--- a/drilldown-logs-lj/add-log-dashboard/website.yaml
+++ b/drilldown-logs-lj/add-log-dashboard/website.yaml
@@ -4,3 +4,4 @@ step: 8
 layout: single-journey
 cta:
   type: continue
+description: Learn how to save your query and add it to a dashboard for ongoing monitoring

--- a/drilldown-logs-lj/business-value-log-metrics/website.yaml
+++ b/drilldown-logs-lj/business-value-log-metrics/website.yaml
@@ -10,3 +10,4 @@ side_journeys:
   items:
   - title: Simplified exploration with Drilldown apps
     link: /docs/grafana/latest/explore/simplified-exploration/
+description: Understand the value of using Logs Drilldown in Grafana Cloud.

--- a/drilldown-logs-lj/end-journey/website.yaml
+++ b/drilldown-logs-lj/end-journey/website.yaml
@@ -18,3 +18,4 @@ side_journeys:
     link: /docs/grafana/latest/panels-visualizations/configure-thresholds/
   - title: Configure standard options
     link: /docs/grafana/latest/panels-visualizations/configure-standard-options/
+description: Your journey concludes and it's time to learn about related paths you can take

--- a/drilldown-logs-lj/labels-and-fields/website.yaml
+++ b/drilldown-logs-lj/labels-and-fields/website.yaml
@@ -10,3 +10,4 @@ side_journeys:
   items:
   - title: Labels and Fields
     link: /docs/grafana-cloud/visualizations/simplified-exploration/logs/labels-and-fields/
+description: Learn how to analyze and investigate logs with labels and fields

--- a/drilldown-logs-lj/log-patterns/website.yaml
+++ b/drilldown-logs-lj/log-patterns/website.yaml
@@ -10,3 +10,4 @@ side_journeys:
   items:
   - title: Log patterns
     link: /docs/grafana-cloud/visualizations/simplified-exploration/logs/patterns/
+description: Learn how to analyze and investigate logs with log patterns

--- a/drilldown-logs-lj/open-logs-explore/website.yaml
+++ b/drilldown-logs-lj/open-logs-explore/website.yaml
@@ -10,3 +10,4 @@ side_journeys:
   items:
   - title: Use Grafana Explore to query, collect, and analyze data
     link: /docs/grafana/latest/explore/
+description: Learn how to open a log visualization in Explore

--- a/drilldown-logs-lj/search-logs/website.yaml
+++ b/drilldown-logs-lj/search-logs/website.yaml
@@ -4,3 +4,4 @@ step: 4
 layout: single-journey
 cta:
   type: continue
+description: Learn how to search logs

--- a/drilldown-logs-lj/view-logs/website.yaml
+++ b/drilldown-logs-lj/view-logs/website.yaml
@@ -4,3 +4,4 @@ step: 3
 layout: single-journey
 cta:
   type: success
+description: Learn how to view logs for a service

--- a/drilldown-logs-lj/website.yaml
+++ b/drilldown-logs-lj/website.yaml
@@ -34,3 +34,5 @@ related_journeys:
     link: /docs/learning-paths/send-logs-alloy-loki/
   - title: Monitor a macOS system in Grafana Cloud
     link: /docs/learning-paths/macos-integration/
+description: Welcome to the Grafana learning path that shows you how to use Logs Drilldown to explore your logs and
+  provide insight into troubleshooting.

--- a/drilldown-metrics-lj/add-metric-dashboard/website.yaml
+++ b/drilldown-metrics-lj/add-metric-dashboard/website.yaml
@@ -4,3 +4,4 @@ step: 6
 layout: single-journey
 cta:
   type: continue
+description: Learn how to save your query and add it to a dashboard for ongoing monitoring

--- a/drilldown-metrics-lj/analyze-data/website.yaml
+++ b/drilldown-metrics-lj/analyze-data/website.yaml
@@ -4,3 +4,4 @@ step: 4
 layout: single-journey
 cta:
   type: continue
+description: Learn how to analyze metric data and explore related metrics

--- a/drilldown-metrics-lj/business-value-drilldown-metrics/website.yaml
+++ b/drilldown-metrics-lj/business-value-drilldown-metrics/website.yaml
@@ -10,3 +10,4 @@ side_journeys:
   items:
   - title: Simplified exploration with Drilldown apps
     link: /docs/grafana/latest/explore/simplified-exploration/
+description: Understand the value of using Metrics Drilldown in Grafana Cloud.

--- a/drilldown-metrics-lj/end-journey/website.yaml
+++ b/drilldown-metrics-lj/end-journey/website.yaml
@@ -18,3 +18,4 @@ side_journeys:
     link: /docs/grafana/latest/panels-visualizations/configure-thresholds/
   - title: Configure standard options
     link: /docs/grafana/latest/panels-visualizations/configure-standard-options/
+description: Your journey concludes and it's time to learn about related paths you can take

--- a/drilldown-metrics-lj/open-metrics-explore/website.yaml
+++ b/drilldown-metrics-lj/open-metrics-explore/website.yaml
@@ -10,3 +10,4 @@ side_journeys:
   items:
   - title: Use Grafana Explore to query, collect, and analyze data
     link: /docs/grafana/latest/explore/
+description: Learn how to open a metrics visualization in Explore

--- a/drilldown-metrics-lj/search-metrics/website.yaml
+++ b/drilldown-metrics-lj/search-metrics/website.yaml
@@ -4,3 +4,4 @@ step: 3
 layout: single-journey
 cta:
   type: continue
+description: Learn how to search for and filter metrics to focus on the data that matters most

--- a/drilldown-metrics-lj/website.yaml
+++ b/drilldown-metrics-lj/website.yaml
@@ -38,3 +38,5 @@ related_journeys:
     link: /docs/learning-paths/mongodb-integration/
   - title: Monitor MySQL databases with Grafana Alloy
     link: /docs/learning-paths/mysql-integration/
+description: Welcome to the Grafana learning path that shows you how to use Metrics Drilldown to explore your metrics
+  and provide insight into troubleshooting.

--- a/drilldown-traces-lj/business-value-drilldown-traces/website.yaml
+++ b/drilldown-traces-lj/business-value-drilldown-traces/website.yaml
@@ -10,3 +10,4 @@ side_journeys:
   items:
   - title: About Traces Drilldown
     link: /docs/grafana/latest/explore/simplified-exploration/traces/
+description: Understand the value of using Traces Drilldown in Grafana Cloud

--- a/drilldown-traces-lj/end-journey/website.yaml
+++ b/drilldown-traces-lj/end-journey/website.yaml
@@ -18,3 +18,4 @@ side_journeys:
     link: /docs/grafana-cloud/visualizations/explore/trace-integration/
   - title: Explore data using Metrics Drilldown
     link: /docs/learning-paths/drilldown-metrics/
+description: Your journey concludes and it's time to learn about related paths you can take

--- a/drilldown-traces-lj/view-details-trace-span/website.yaml
+++ b/drilldown-traces-lj/view-details-trace-span/website.yaml
@@ -4,3 +4,4 @@ step: 6
 layout: single-journey
 cta:
   type: continue
+description: Learn how to view trace span details so you can identify the root cause of failures

--- a/drilldown-traces-lj/view-distribution/website.yaml
+++ b/drilldown-traces-lj/view-distribution/website.yaml
@@ -12,3 +12,4 @@ side_journeys:
     link: /docs/grafana/latest/explore/simplified-exploration/traces/investigate/choose-red-metric/
   - title: The RED Method - How to Instrument Your Services
     link: https://grafana.com/blog/2018/08/02/the-red-method-how-to-instrument-your-services/
+description: Learn how to interpret trace span durations so that you gain insight into traces and system performance

--- a/drilldown-traces-lj/view-slowest-traces/website.yaml
+++ b/drilldown-traces-lj/view-slowest-traces/website.yaml
@@ -4,3 +4,4 @@ step: 4
 layout: single-journey
 cta:
   type: continue
+description: Learn how to see which traces are potentially causing bottlenecks and inefficiencies in a system

--- a/drilldown-traces-lj/view-trace-details/website.yaml
+++ b/drilldown-traces-lj/view-trace-details/website.yaml
@@ -10,3 +10,5 @@ side_journeys:
   items:
   - title: Traces structure
     link: /docs/grafana-cloud/visualizations/simplified-exploration/traces/concepts/trace-structure/
+description: Learn how to view the details of a trace so that you can determine which operations or services are causing
+  delays

--- a/drilldown-traces-lj/website.yaml
+++ b/drilldown-traces-lj/website.yaml
@@ -24,3 +24,5 @@ related_journeys:
   items:
   - title: Send traces to Grafana Cloud using Alloy
     link: /docs/learning-paths/send-traces-alloy/
+description: Welcome to the Grafana learning path that shows you how to use Traces Drilldown help you identify the
+  root cause of latency in service requests.

--- a/github-data-source-lj/advantages-github-datasource/website.yaml
+++ b/github-data-source-lj/advantages-github-datasource/website.yaml
@@ -9,3 +9,5 @@ keywords:
 - plugin advantages
 - repository monitoring
 - Grafana integration
+description: Learn about the specific benefits and capabilities that the GitHub data source plugin provides for monitoring
+  repository data.

--- a/github-data-source-lj/business-value/website.yaml
+++ b/github-data-source-lj/business-value/website.yaml
@@ -15,3 +15,5 @@ side_journeys:
   items:
   - title: What is observability?
     link: /docs/grafana-cloud/introduction/what-is-observability/
+description: Understand why monitoring GitHub repositories through observability platforms provides valuable insights
+  for development teams.

--- a/github-data-source-lj/config-github-datasource/website.yaml
+++ b/github-data-source-lj/config-github-datasource/website.yaml
@@ -9,3 +9,4 @@ keywords:
 - data source credentials
 - connection testing
 - API verification
+description: Learn how to configure your GitHub data source with authentication credentials and test the connection.

--- a/github-data-source-lj/create-github-token/website.yaml
+++ b/github-data-source-lj/create-github-token/website.yaml
@@ -10,3 +10,4 @@ keywords:
 - authentication
 - API access
 - repository permissions
+description: Learn how to create a GitHub Personal Access Token for authenticating your GitHub data source connection.

--- a/github-data-source-lj/end-journey/website.yaml
+++ b/github-data-source-lj/end-journey/website.yaml
@@ -9,3 +9,5 @@ keywords:
 - journey completion
 - repository dashboards
 - development metrics
+description: Congratulations on completing the GitHub data source learning path and building comprehensive repository
+  monitoring dashboards.

--- a/github-data-source-lj/install-github-plugin/website.yaml
+++ b/github-data-source-lj/install-github-plugin/website.yaml
@@ -9,3 +9,4 @@ keywords:
 - Grafana Cloud plugins
 - plugin management
 - data source setup
+description: Learn how to install and add the GitHub data source in your Grafana Cloud instance.

--- a/github-data-source-lj/website.yaml
+++ b/github-data-source-lj/website.yaml
@@ -23,3 +23,5 @@ keywords:
 - Grafana Cloud
 - repository monitoring
 - pull requests
+description: Welcome to the GitHub data source learning path that shows you how to connect GitHub repository data in
+  Grafana Cloud.

--- a/github-visualize-lj/build-issues-panel/website.yaml
+++ b/github-visualize-lj/build-issues-panel/website.yaml
@@ -9,3 +9,5 @@ keywords:
 - dashboard panel
 - data visualization
 - repository metrics
+description: Learn how to add a dashboard panel that visualizes GitHub issues data, including open and closed issues
+  over time.

--- a/github-visualize-lj/build-pr-panel/website.yaml
+++ b/github-visualize-lj/build-pr-panel/website.yaml
@@ -9,3 +9,5 @@ keywords:
 - dashboard panel
 - code review metrics
 - development workflow
+description: Learn how to add a dashboard panel that visualizes GitHub pull requests data including open and closed
+  pull requests over time.

--- a/github-visualize-lj/build-repository-panel/website.yaml
+++ b/github-visualize-lj/build-repository-panel/website.yaml
@@ -9,3 +9,5 @@ keywords:
 - dashboard panel
 - code review metrics
 - development workflow
+description: Learn how to add a dashboard panel that shows a list of all the repositories with details such as owner,
+  forks, status, etc. in your organization.

--- a/github-visualize-lj/business-value/website.yaml
+++ b/github-visualize-lj/business-value/website.yaml
@@ -10,3 +10,5 @@ keywords:
 - development velocity
 - data visualization
 - Grafana Cloud
+description: Understand why visualizing GitHub repository data in Grafana Cloud helps engineering teams track development
+  velocity, monitor project health, and make data-driven decisions.

--- a/github-visualize-lj/end-journey/website.yaml
+++ b/github-visualize-lj/end-journey/website.yaml
@@ -9,3 +9,5 @@ keywords:
 - journey completion
 - repository dashboards
 - development metrics
+description: Congratulations on completing the GitHub data source learning path and building comprehensive repository
+  monitoring dashboards.

--- a/github-visualize-lj/website.yaml
+++ b/github-visualize-lj/website.yaml
@@ -29,3 +29,5 @@ related_journeys:
   items:
   - title: Connect to a GitHub data source in Grafana Cloud
     link: /docs/learning-paths/github-data-source/
+description: Welcome to the GitHub data source learning path that shows you how to visualize GitHub repository data
+  in Grafana Cloud.

--- a/grafana-cloud-tour-lj/business-value/website.yaml
+++ b/grafana-cloud-tour-lj/business-value/website.yaml
@@ -4,3 +4,5 @@ step: 2
 layout: single-journey
 cta:
   type: continue
+description: Learn why a managed observability platform eliminates operational overhead and provides a complete environment
+  to collect, analyze, and act on your data.

--- a/grafana-cloud-tour-lj/end-journey/website.yaml
+++ b/grafana-cloud-tour-lj/end-journey/website.yaml
@@ -4,3 +4,4 @@ step: 7
 layout: single-journey
 cta:
   type: conclusion
+description: Congratulations on completing the Tour Grafana Cloud capabilities learning path.

--- a/grafana-cloud-tour-lj/explore-connect-data/website.yaml
+++ b/grafana-cloud-tour-lj/explore-connect-data/website.yaml
@@ -12,3 +12,5 @@ side_journeys:
     link: /docs/grafana-cloud/get-started/connect-send/
   - title: Work with demo data in Grafana Cloud
     link: /docs/grafana-cloud/get-started/connect-send/explore-demo-data/
+description: Learn the options available to connect externally hosted data sources to Grafana Cloud so you can visualize
+  and query data without moving it.

--- a/grafana-cloud-tour-lj/explore-dashboards/website.yaml
+++ b/grafana-cloud-tour-lj/explore-dashboards/website.yaml
@@ -10,3 +10,4 @@ side_journeys:
   items:
   - title: Dashboards
     link: /docs/grafana-cloud/visualizations/
+description: Learn what options are available to create dashboards

--- a/grafana-cloud-tour-lj/explore-platform-components/website.yaml
+++ b/grafana-cloud-tour-lj/explore-platform-components/website.yaml
@@ -22,3 +22,4 @@ side_journeys:
     link: /docs/grafana-cloud/adaptive-telemetry/
   - title: Cost Management and Billing
     link: /docs/grafana-cloud/cost-management-and-billing/
+description: Learn about the core services included in every Grafana Cloud stack.

--- a/grafana-cloud-tour-lj/explore-send-data/website.yaml
+++ b/grafana-cloud-tour-lj/explore-send-data/website.yaml
@@ -12,3 +12,5 @@ side_journeys:
     link: /docs/grafana-cloud/get-started/connect-send/
   - title: Instrument and send data to Grafana Cloud
     link: /docs/grafana-cloud/send-data/
+description: Learn about the observability databases included in your Grafana Cloud stack and how to send data using
+  Grafana Alloy or Prometheus remote_write.

--- a/grafana-cloud-tour-lj/website.yaml
+++ b/grafana-cloud-tour-lj/website.yaml
@@ -23,3 +23,4 @@ keywords:
 - observability
 - tour
 - getting started
+description: Welcome to the Grafana Cloud learning path that shows you how to explore the key capabilities of the platform.

--- a/haproxy-load-balancer-lj/business-value/website.yaml
+++ b/haproxy-load-balancer-lj/business-value/website.yaml
@@ -15,3 +15,4 @@ side_journeys:
   items:
   - title: What is observability?
     link: /docs/grafana-cloud/introduction/what-is-observability/
+description: Learn why monitoring HAProxy load balancers is critical for maintaining application reliability and performance

--- a/haproxy-load-balancer-lj/configure-haproxy-stats/website.yaml
+++ b/haproxy-load-balancer-lj/configure-haproxy-stats/website.yaml
@@ -9,3 +9,4 @@ keywords:
 - stats endpoint
 - Prometheus exporter
 - configuration
+description: Enable the HAProxy stats and Prometheus endpoints so Grafana Alloy can collect metrics

--- a/haproxy-load-balancer-lj/configure-integration/website.yaml
+++ b/haproxy-load-balancer-lj/configure-integration/website.yaml
@@ -9,3 +9,4 @@ keywords:
 - integration
 - configuration
 - Grafana Cloud
+description: Set up the Grafana Cloud HAProxy integration to collect frontend and backend metrics

--- a/haproxy-load-balancer-lj/end-journey/website.yaml
+++ b/haproxy-load-balancer-lj/end-journey/website.yaml
@@ -14,3 +14,4 @@ side_journeys:
     link: /docs/grafana-cloud/alerting-and-irm/irm/incident/get-started
   - title: Scale your deployment
     link: /docs/grafana-cloud/send-data/fleet-management
+description: Your journey concludes and it's time to learn about related paths you can take

--- a/haproxy-load-balancer-lj/install-alerts/website.yaml
+++ b/haproxy-load-balancer-lj/install-alerts/website.yaml
@@ -10,3 +10,4 @@ keywords:
 - alerting
 - prebuilt
 - integration
+description: Review the prebuilt alert rules installed with the HAProxy integration

--- a/haproxy-load-balancer-lj/install-alloy/website.yaml
+++ b/haproxy-load-balancer-lj/install-alloy/website.yaml
@@ -16,3 +16,4 @@ side_journeys:
     link: /oss/alloy-opentelemetry-collector
   - title: Grafana Alloy on GitHub
     link: https://github.com/grafana/alloy
+description: Install Grafana Alloy on your HAProxy server to collect and forward metrics to Grafana Cloud

--- a/haproxy-load-balancer-lj/install-dashboards/website.yaml
+++ b/haproxy-load-balancer-lj/install-dashboards/website.yaml
@@ -9,3 +9,4 @@ keywords:
 - dashboards
 - prebuilt
 - integration
+description: Install the prebuilt dashboards that come with the HAProxy integration

--- a/haproxy-load-balancer-lj/select-platform/website.yaml
+++ b/haproxy-load-balancer-lj/select-platform/website.yaml
@@ -9,3 +9,4 @@ keywords:
 - platform
 - operating system
 - architecture
+description: Select the operating system and architecture where you'll install Grafana Alloy

--- a/haproxy-load-balancer-lj/verify-metrics/website.yaml
+++ b/haproxy-load-balancer-lj/verify-metrics/website.yaml
@@ -9,3 +9,4 @@ keywords:
 - metrics
 - verification
 - Explore
+description: Confirm that HAProxy metrics are being collected and are visible in Grafana Cloud

--- a/haproxy-load-balancer-lj/website.yaml
+++ b/haproxy-load-balancer-lj/website.yaml
@@ -29,3 +29,5 @@ related_journeys:
   items:
   - title: Monitor a Linux server in Grafana Cloud
     link: /docs/learning-paths/linux-server-integration/
+description: Welcome to the Grafana learning path that walks you through monitoring HAProxy load balancers using Grafana
+  Cloud.

--- a/iis-web-server-lj/business-value/website.yaml
+++ b/iis-web-server-lj/business-value/website.yaml
@@ -17,3 +17,5 @@ side_journeys:
     link: https://grafana.com/docs/grafana-cloud/introduction/what-is-observability/
   - title: Grafana Cloud integrations
     link: https://grafana.com/docs/grafana-cloud/monitor-infrastructure/integrations/
+description: Learn why monitoring IIS web servers matters and how Grafana Cloud helps you detect issues before they
+  affect users.

--- a/iis-web-server-lj/configure-iis-counters/website.yaml
+++ b/iis-web-server-lj/configure-iis-counters/website.yaml
@@ -17,3 +17,4 @@ side_journeys:
     link: https://learn.microsoft.com/en-us/iis/manage/provisioning-and-managing-iis/managing-iis-log-file-storage
   - title: Windows exporter IIS collector
     link: https://grafana.com/docs/alloy/latest/reference/components/prometheus/prometheus.exporter.windows/
+description: Verify and enable the IIS features and performance counters required for metrics collection.

--- a/iis-web-server-lj/configure-iis-integration/website.yaml
+++ b/iis-web-server-lj/configure-iis-integration/website.yaml
@@ -17,3 +17,4 @@ side_journeys:
     link: https://grafana.com/docs/alloy/latest/configure
   - title: Windows exporter IIS collector
     link: https://grafana.com/docs/alloy/latest/reference/components/prometheus/prometheus.exporter.windows/
+description: Learn how to configure Grafana Alloy to collect IIS request rates, error codes, and worker process metrics.

--- a/iis-web-server-lj/end-journey/website.yaml
+++ b/iis-web-server-lj/end-journey/website.yaml
@@ -14,3 +14,4 @@ side_journeys:
     link: https://grafana.com/docs/grafana/latest/dashboards/build-dashboards/
   - title: Scale your deployment
     link: https://grafana.com/docs/grafana-cloud/send-data/fleet-management/introduction/
+description: Your journey concludes and it's time to learn about related paths you can take.

--- a/iis-web-server-lj/explore-metrics/website.yaml
+++ b/iis-web-server-lj/explore-metrics/website.yaml
@@ -18,3 +18,5 @@ side_journeys:
     link: https://grafana.com/docs/grafana/latest/dashboards/build-dashboards/
   - title: Windows exporter IIS collector
     link: https://grafana.com/docs/alloy/latest/reference/components/prometheus/prometheus.exporter.windows/
+description: Learn how to use the pre-built IIS dashboards to monitor request rates, error rates, and worker process
+  health.

--- a/iis-web-server-lj/install-alloy/website.yaml
+++ b/iis-web-server-lj/install-alloy/website.yaml
@@ -18,3 +18,4 @@ side_journeys:
     link: https://www.youtube.com/watch?v=NrnLyDXpfq0
   - title: Grafana Alloy on GitHub
     link: https://github.com/grafana/alloy
+description: Learn how to install Grafana Alloy on your Windows Server to collect IIS metrics.

--- a/iis-web-server-lj/install-dashboards/website.yaml
+++ b/iis-web-server-lj/install-dashboards/website.yaml
@@ -8,3 +8,4 @@ keywords:
 - IIS
 - dashboards
 - Grafana Cloud
+description: Install the pre-built IIS dashboards and learn where to find them in Grafana Cloud.

--- a/iis-web-server-lj/select-integration/website.yaml
+++ b/iis-web-server-lj/select-integration/website.yaml
@@ -8,3 +8,4 @@ keywords:
 - IIS
 - integration
 - connections
+description: Learn how to find and select the IIS integration in Grafana Cloud.

--- a/iis-web-server-lj/understand-alerts/website.yaml
+++ b/iis-web-server-lj/understand-alerts/website.yaml
@@ -16,3 +16,4 @@ side_journeys:
     link: https://grafana.com/docs/grafana/latest/alerting
   - title: Create an alert rule
     link: https://grafana.com/docs/grafana/latest/alerting/alerting-rules/create-grafana-managed-rule
+description: Learn about the pre-built IIS alerts and how to respond to each one.

--- a/iis-web-server-lj/verify-metrics/website.yaml
+++ b/iis-web-server-lj/verify-metrics/website.yaml
@@ -9,3 +9,4 @@ keywords:
 - metrics
 - Grafana Cloud
 - verification
+description: Restart Grafana Alloy and verify that IIS metrics are flowing to Grafana Cloud.

--- a/iis-web-server-lj/website.yaml
+++ b/iis-web-server-lj/website.yaml
@@ -29,3 +29,6 @@ related_journeys:
   items:
   - title: Monitor a Windows system in Grafana Cloud
     link: https://grafana.com/docs/learning-paths/windows-integration/
+description: Set up the IIS integration to monitor request rates, error rates, and worker process health for your IIS
+  web servers.
+show_play: false

--- a/infinity-csv-lj/add-data-source/website.yaml
+++ b/infinity-csv-lj/add-data-source/website.yaml
@@ -17,3 +17,4 @@ side_journeys:
     link: https://www.youtube.com/watch?v=cqHO0oYW6Ic&list=PLDGkOdUX1Ujo27m6qiTPPCpFHVfyKq9jT&index=8
   - title: Data source plugins for Grafana
     link: https://grafana.com/grafana/plugins/data-source-plugins/
+description: Learn how to navigate Grafana Cloud and add the Infinity data source

--- a/infinity-csv-lj/advantages-infinity/website.yaml
+++ b/infinity-csv-lj/advantages-infinity/website.yaml
@@ -9,3 +9,4 @@ keywords:
 - observability
 - CSV
 - Infinity
+description: Learn about the various ways you can use the Infinity data source to create visualizations

--- a/infinity-csv-lj/build-dashboard/website.yaml
+++ b/infinity-csv-lj/build-dashboard/website.yaml
@@ -20,3 +20,4 @@ side_journeys:
     link: /docs/grafana-cloud/visualizations/dashboards/manage-dashboards/
   - title: Filtering data / Using template variables in Query
     link: /docs/plugins/yesoreyeram-infinity-datasource/latest/query/filters/
+description: Learn how to build a dashboard that visualizes CSV data

--- a/infinity-csv-lj/business-value/website.yaml
+++ b/infinity-csv-lj/business-value/website.yaml
@@ -9,3 +9,4 @@ keywords:
 - monitoring
 - Infinity
 - CSV
+description: Learn about observability and how it can help you solve real-world problems

--- a/infinity-csv-lj/check-health/website.yaml
+++ b/infinity-csv-lj/check-health/website.yaml
@@ -9,3 +9,4 @@ keywords:
 - CSV
 - Data source
 - Infinity
+description: Learn how to test the connection to the CSV endpoint

--- a/infinity-csv-lj/config-authentication/website.yaml
+++ b/infinity-csv-lj/config-authentication/website.yaml
@@ -15,3 +15,4 @@ side_journeys:
   items:
   - title: Authentication methods
     link: /docs/plugins/yesoreyeram-infinity-datasource/latest/setup/authentication/
+description: Learn how to configure basic authentication

--- a/infinity-csv-lj/end-journey/website.yaml
+++ b/infinity-csv-lj/end-journey/website.yaml
@@ -13,3 +13,4 @@ side_journeys:
     link: https://grafana.com/grafana/plugins/data-source-plugins/
   - title: Grafana data sources
     link: /docs/grafana-cloud/connect-externally-hosted/data-sources/
+description: Your journey concludes and it's time to learn about related paths you can take

--- a/infinity-csv-lj/select-private-connection/website.yaml
+++ b/infinity-csv-lj/select-private-connection/website.yaml
@@ -14,3 +14,4 @@ side_journeys:
   items:
   - title: Create a private connection to a data source
     link: /docs/learning-paths/private-data-source-connect
+description: Learn how to select a private data source connect agent

--- a/infinity-csv-lj/website.yaml
+++ b/infinity-csv-lj/website.yaml
@@ -23,3 +23,6 @@ related_journeys:
   items:
   - title: Create a private connection to a data source
     link: /docs/learning-paths/private-data-source-connect/
+description: Welcome to the Grafana learning path that provides the best practice for creating a dashboard that visualizes
+  CSV data using the Infinity data source.
+show_play: false

--- a/influxdb-data-source-lj/add-data-source/website.yaml
+++ b/influxdb-data-source-lj/add-data-source/website.yaml
@@ -17,3 +17,4 @@ side_journeys:
     link: /docs/grafana/latest/administration/data-source-management/
   - title: Data source plugins for Grafana
     link: https://grafana.com/grafana/plugins/data-source-plugins/
+description: Learn how to navigate Grafana Cloud and add the InfluxDB data source.

--- a/influxdb-data-source-lj/business-value/website.yaml
+++ b/influxdb-data-source-lj/business-value/website.yaml
@@ -17,3 +17,5 @@ side_journeys:
     link: /docs/grafana/latest/datasources/influxdb/
   - title: Data source management in Grafana
     link: /docs/grafana/latest/administration/data-source-management/
+description: Learn when querying InfluxDB directly from Grafana is the right choice and how it compares to remote-writing
+  metrics.

--- a/influxdb-data-source-lj/configure-connection/website.yaml
+++ b/influxdb-data-source-lj/configure-connection/website.yaml
@@ -23,3 +23,4 @@ side_journeys:
     link: https://docs.influxdata.com/influxdb/latest/reference/syntax/influxql/
   - title: Private Data Source Connect
     link: /docs/grafana-cloud/connect-externally-hosted/private-data-source-connect/
+description: Learn how to configure the query language, URL, and authentication for your InfluxDB data source.

--- a/influxdb-data-source-lj/end-journey/website.yaml
+++ b/influxdb-data-source-lj/end-journey/website.yaml
@@ -19,3 +19,4 @@ side_journeys:
     link: /docs/grafana/latest/datasources/influxdb/
   - title: Transform data in dashboards
     link: /docs/learning-paths/data-transformation/
+description: Congratulations on completing the InfluxDB data source learning path!

--- a/influxdb-data-source-lj/explore-data/website.yaml
+++ b/influxdb-data-source-lj/explore-data/website.yaml
@@ -26,3 +26,4 @@ side_journeys:
     link: /docs/grafana/latest/explore/
   - title: Building dashboards from Explore
     link: /docs/grafana/latest/explore/add-to-dashboard/
+description: Run a sample query in Grafana Explore to verify your InfluxDB data is accessible.

--- a/influxdb-data-source-lj/test-connection/website.yaml
+++ b/influxdb-data-source-lj/test-connection/website.yaml
@@ -17,3 +17,4 @@ side_journeys:
     link: /docs/grafana/latest/datasources/influxdb/configure/
   - title: Grafana alerting with InfluxDB data
     link: /docs/grafana/latest/alerting/
+description: Save and test your InfluxDB data source connection to verify Grafana can reach your instance.

--- a/influxdb-data-source-lj/verify-influxdb/website.yaml
+++ b/influxdb-data-source-lj/verify-influxdb/website.yaml
@@ -19,3 +19,4 @@ side_journeys:
     link: https://docs.influxdata.com/influxdb/latest/admin/tokens/
   - title: Private Data Source Connect
     link: /docs/grafana-cloud/connect-externally-hosted/private-data-source-connect/
+description: Confirm that your InfluxDB instance is running and gather the credentials needed to connect from Grafana.

--- a/influxdb-data-source-lj/website.yaml
+++ b/influxdb-data-source-lj/website.yaml
@@ -31,3 +31,5 @@ related_journeys:
   items:
   - title: Create a private connection to a data source
     link: /docs/learning-paths/private-data-source-connect/
+description: Welcome to the Grafana learning path that shows you how to connect Grafana Cloud to an existing InfluxDB
+  instance and query your time series data.

--- a/infrastructure-alerting-lj/build-your-query/website.yaml
+++ b/infrastructure-alerting-lj/build-your-query/website.yaml
@@ -11,3 +11,4 @@ side_journeys:
     link: /docs/grafana/latest/panels-visualizations/query-transform-data/
   - title: Grafana-managed alert rules
     link: /docs/grafana/latest/alerting/alerting-rules/create-grafana-managed-rule/
+description: Navigate to alert rules and create the query that defines what data your alert monitors.

--- a/infrastructure-alerting-lj/end-journey/website.yaml
+++ b/infrastructure-alerting-lj/end-journey/website.yaml
@@ -8,3 +8,4 @@ keywords:
 - infrastructure alerting
 - learning path completion
 - Grafana Alerting
+description: Congratulations on completing the infrastructure alerting learning path.

--- a/infrastructure-alerting-lj/evaluation-and-labels/website.yaml
+++ b/infrastructure-alerting-lj/evaluation-and-labels/website.yaml
@@ -9,3 +9,4 @@ side_journeys:
   items:
   - title: Labels and label matchers
     link: /docs/grafana/latest/alerting/fundamentals/alert-rules/annotation-label/
+description: Configure how often your alert is evaluated and organize it with labels.

--- a/infrastructure-alerting-lj/find-data-to-alert/website.yaml
+++ b/infrastructure-alerting-lj/find-data-to-alert/website.yaml
@@ -11,3 +11,4 @@ side_journeys:
     link: /docs/grafana-cloud/visualizations/simplified-exploration/metrics/
   - title: Explore logs using Logs Drilldown
     link: /docs/grafana-cloud/visualizations/simplified-exploration/logs/
+description: Use Grafana's exploration tools to discover metrics or logs for your alert.

--- a/infrastructure-alerting-lj/monitor-your-rule/website.yaml
+++ b/infrastructure-alerting-lj/monitor-your-rule/website.yaml
@@ -9,3 +9,4 @@ side_journeys:
   items:
   - title: View alert state and health
     link: /docs/grafana/latest/alerting/monitor-status/view-alert-state/
+description: Verify your alert rule is working and understand its states.

--- a/infrastructure-alerting-lj/notification-settings/website.yaml
+++ b/infrastructure-alerting-lj/notification-settings/website.yaml
@@ -11,3 +11,4 @@ side_journeys:
     link: /docs/grafana/latest/alerting/configure-notifications/
   - title: Manage contact points
     link: /docs/grafana/latest/alerting/configure-notifications/manage-contact-points/
+description: Set up basic notification delivery for your alert.

--- a/infrastructure-alerting-lj/planning-alerts/website.yaml
+++ b/infrastructure-alerting-lj/planning-alerts/website.yaml
@@ -9,3 +9,4 @@ side_journeys:
   items:
   - title: Alerting best practices
     link: /docs/grafana/latest/alerting/best-practices/
+description: Learn how to plan effective alert rules before creating them.

--- a/infrastructure-alerting-lj/save-and-activate/website.yaml
+++ b/infrastructure-alerting-lj/save-and-activate/website.yaml
@@ -9,3 +9,4 @@ side_journeys:
   items:
   - title: Manage alert rules
     link: /docs/grafana/latest/alerting/alerting-rules/manage-alerting-rules/
+description: Save your alert rule and make it active in your Grafana Cloud environment.

--- a/infrastructure-alerting-lj/set-conditions/website.yaml
+++ b/infrastructure-alerting-lj/set-conditions/website.yaml
@@ -9,3 +9,4 @@ side_journeys:
   items:
   - title: Configure alert rules
     link: /docs/grafana/latest/alerting/alerting-rules/
+description: Define the threshold and conditions that trigger your alert.

--- a/infrastructure-alerting-lj/value-of-alerting/website.yaml
+++ b/infrastructure-alerting-lj/value-of-alerting/website.yaml
@@ -9,3 +9,4 @@ side_journeys:
   items:
   - title: Introduction to Alerting
     link: /docs/grafana/latest/alerting/fundamentals/
+description: Understand why proactive alerting is essential for infrastructure monitoring.

--- a/infrastructure-alerting-lj/website.yaml
+++ b/infrastructure-alerting-lj/website.yaml
@@ -25,3 +25,4 @@ keywords:
 - logs
 - alert rules
 - infrastructure
+description: Learn how to create alert rules for your infrastructure metrics and logs in Grafana Cloud.

--- a/kafka-monitoring-lj/advantages-grafana-alloy/website.yaml
+++ b/kafka-monitoring-lj/advantages-grafana-alloy/website.yaml
@@ -9,3 +9,4 @@ keywords:
 - Kafka monitoring
 - JMX metrics
 - metrics collection
+description: Learn about the advantages of using Grafana Alloy for Kafka metrics collection.

--- a/kafka-monitoring-lj/configure-alloy-kafka-metrics/website.yaml
+++ b/kafka-monitoring-lj/configure-alloy-kafka-metrics/website.yaml
@@ -17,3 +17,4 @@ side_journeys:
     link: /docs/alloy/latest/configure/
   - title: Prometheus JMX receiver component reference
     link: /docs/alloy/latest/reference/components/prometheus/prometheus.exporter.jmx/
+description: Learn how to configure Grafana Alloy to collect metrics from your Kafka brokers.

--- a/kafka-monitoring-lj/configure-jmx-exporter/website.yaml
+++ b/kafka-monitoring-lj/configure-jmx-exporter/website.yaml
@@ -15,3 +15,4 @@ side_journeys:
   items:
   - title: Kafka JMX Metrics Reference
     link: /docs/grafana-cloud/monitor-infrastructure/integrations/integration-reference/integration-kafka/
+description: Learn how to configure JMX on your Kafka brokers to expose metrics.

--- a/kafka-monitoring-lj/end-journey/website.yaml
+++ b/kafka-monitoring-lj/end-journey/website.yaml
@@ -8,3 +8,5 @@ keywords:
 - Kafka monitoring
 - learning path completion
 - observability success
+description: Congratulations on completing the Kafka monitoring learning path. You've successfully implemented comprehensive
+  Kafka observability with Grafana Cloud.

--- a/kafka-monitoring-lj/explore-kafka-metrics/website.yaml
+++ b/kafka-monitoring-lj/explore-kafka-metrics/website.yaml
@@ -9,3 +9,4 @@ keywords:
 - dashboard interpretation
 - performance monitoring
 - cluster health
+description: Learn how to interpret key Kafka performance metrics in your dashboards.

--- a/kafka-monitoring-lj/install-dashboards/website.yaml
+++ b/kafka-monitoring-lj/install-dashboards/website.yaml
@@ -8,3 +8,4 @@ keywords:
 - dashboard
 - alert
 - integration
+description: Learn how to install Kafka integration pre-built dashboards and alerts

--- a/kafka-monitoring-lj/install-grafana-alloy/website.yaml
+++ b/kafka-monitoring-lj/install-grafana-alloy/website.yaml
@@ -16,3 +16,4 @@ side_journeys:
     link: /oss/alloy-opentelemetry-collector
   - title: Grafana Alloy configuration syntax and examples
     link: /docs/alloy/latest/reference/config-blocks/
+description: Install Grafana Alloy on your selected platform to begin collecting Kafka metrics.

--- a/kafka-monitoring-lj/understand-alerts/website.yaml
+++ b/kafka-monitoring-lj/understand-alerts/website.yaml
@@ -8,3 +8,4 @@ keywords:
 - Kafka
 - integration
 - alert
+description: Learn about the Kafka integration pre-built alerts and how to use them to troubleshoot your environment

--- a/kafka-monitoring-lj/understand-dashboards/website.yaml
+++ b/kafka-monitoring-lj/understand-dashboards/website.yaml
@@ -14,3 +14,4 @@ side_journeys:
   items:
   - title: Create custom dashboards and panels
     link: /docs/grafana/latest/dashboards/
+description: Learn about the Kafka integration pre-built dashboards and how to use them to troubleshoot your environment

--- a/kafka-monitoring-lj/value-kafka-monitoring/website.yaml
+++ b/kafka-monitoring-lj/value-kafka-monitoring/website.yaml
@@ -9,3 +9,4 @@ keywords:
 - observability
 - Apache Kafka
 - cluster health
+description: Learn about the value of Kafka monitoring and observability with Grafana Cloud.

--- a/kafka-monitoring-lj/verify-kafka-metrics/website.yaml
+++ b/kafka-monitoring-lj/verify-kafka-metrics/website.yaml
@@ -17,3 +17,4 @@ side_journeys:
     link: /docs/grafana/latest/explore/
   - title: Prometheus query basics
     link: /docs/grafana/latest/datasources/prometheus/query-editor/
+description: Learn how to verify that Kafka metrics are flowing to Grafana Cloud.

--- a/kafka-monitoring-lj/website.yaml
+++ b/kafka-monitoring-lj/website.yaml
@@ -22,3 +22,6 @@ keywords:
 - observability
 - Grafana Alloy
 - metrics
+description: Welcome to the Kafka monitoring learning path that shows you how to use Grafana Alloy to send Kafka metrics
+  to Grafana Cloud for comprehensive event streaming observability.
+show_play: false

--- a/linux-server-integration-lj/business-value/website.yaml
+++ b/linux-server-integration-lj/business-value/website.yaml
@@ -16,3 +16,4 @@ side_journeys:
   items:
   - title: What is observability?
     link: /docs/grafana-cloud/introduction/what-is-observability/
+description: Learn about observability and how it can help you solve real-world problems

--- a/linux-server-integration-lj/configure-alloy/website.yaml
+++ b/linux-server-integration-lj/configure-alloy/website.yaml
@@ -18,3 +18,4 @@ side_journeys:
     link: /docs/alloy/latest/configure
   - title: Logs and relabeling basics in Grafana Alloy (tutorial)
     link: /docs/alloy/latest/tutorials/logs-and-relabeling-basics
+description: Learn to configure the Linux server integration in Grafana Cloud

--- a/linux-server-integration-lj/end-linux-server/website.yaml
+++ b/linux-server-integration-lj/end-linux-server/website.yaml
@@ -18,3 +18,4 @@ side_journeys:
     link: /docs/grafana-cloud/alerting-and-irm/slo/set-up
   - title: Scale your deployment
     link: /docs/grafana-cloud/send-data/fleet-management
+description: Your journey concludes and it's time to learn about related paths you can take

--- a/linux-server-integration-lj/install-alloy/website.yaml
+++ b/linux-server-integration-lj/install-alloy/website.yaml
@@ -16,3 +16,4 @@ side_journeys:
     link: https://www.youtube.com/watch?v=NrnLyDXpfq0
   - title: Grafana Alloy on GitHub
     link: https://github.com/grafana/alloy
+description: Learn how to install Grafana Alloy

--- a/linux-server-integration-lj/install-dashboards-alerts/website.yaml
+++ b/linux-server-integration-lj/install-dashboards-alerts/website.yaml
@@ -8,3 +8,4 @@ keywords:
 - dashboard
 - alert
 - integration
+description: Learn how to install Linux server integration pre-built dashboards and alerts

--- a/linux-server-integration-lj/restart-test-connection/website.yaml
+++ b/linux-server-integration-lj/restart-test-connection/website.yaml
@@ -8,3 +8,4 @@ keywords:
 - Linux server
 - integration
 - Grafana Cloud
+description: Learn how to verify that Grafana Alloy is installed and configured correctly

--- a/linux-server-integration-lj/select-platform/website.yaml
+++ b/linux-server-integration-lj/select-platform/website.yaml
@@ -9,3 +9,4 @@ keywords:
 - integration
 - Linux distribution
 - platform
+description: Learn how to determine which platform and architecture to select

--- a/linux-server-integration-lj/understand-alerts/website.yaml
+++ b/linux-server-integration-lj/understand-alerts/website.yaml
@@ -8,3 +8,4 @@ keywords:
 - Linux server
 - integration
 - alert
+description: Learn about the Linux server integration pre-built alerts and how to use them to troubleshoot your environment

--- a/linux-server-integration-lj/understand-dashboards/website.yaml
+++ b/linux-server-integration-lj/understand-dashboards/website.yaml
@@ -14,3 +14,5 @@ side_journeys:
   items:
   - title: Build a dashboard
     link: /docs/grafana-cloud/visualizations/dashboards/build-dashboards
+description: Learn about the Linux server integration pre-built dashboards and how to use them to troubleshoot your
+  environment

--- a/linux-server-integration-lj/website.yaml
+++ b/linux-server-integration-lj/website.yaml
@@ -14,3 +14,6 @@ cta:
   type: start
   title: Are you ready?
   cta_text: Let's go!
+description: Welcome to the Grafana learning path that provides the best practice for setting up your Linux server
+  integration.
+show_play: false

--- a/macos-integration-lj/business-value/website.yaml
+++ b/macos-integration-lj/business-value/website.yaml
@@ -15,3 +15,4 @@ side_journeys:
   items:
   - title: What is observability?
     link: /docs/grafana-cloud/introduction/what-is-observability/
+description: Learn about observability and how it can help you solve real-world problems

--- a/macos-integration-lj/configure-alloy/website.yaml
+++ b/macos-integration-lj/configure-alloy/website.yaml
@@ -18,3 +18,4 @@ side_journeys:
     link: /docs/alloy/latest/configure
   - title: Logs and relabeling basics in Grafana Alloy (tutorial)
     link: /docs/alloy/latest/tutorials/logs-and-relabeling-basics
+description: Learn to configure the Grafana Alloy to send metrics and logs to Grafana Cloud

--- a/macos-integration-lj/end-macos/website.yaml
+++ b/macos-integration-lj/end-macos/website.yaml
@@ -18,3 +18,4 @@ side_journeys:
     link: /docs/grafana-cloud/alerting-and-irm/slo/set-up
   - title: Scale your deployment
     link: /docs/grafana-cloud/send-data/fleet-management
+description: Your journey concludes and it's time to learn about related paths you can take

--- a/macos-integration-lj/install-alloy/website.yaml
+++ b/macos-integration-lj/install-alloy/website.yaml
@@ -16,3 +16,4 @@ side_journeys:
     link: https://github.com/grafana/alloy
   - title: macOS Integration Reference
     link: /docs/grafana-cloud/monitor-infrastructure/integrations/integration-reference/integration-macos-node/
+description: Learn how to install Grafana Alloy

--- a/macos-integration-lj/install-dashboards-alerts/website.yaml
+++ b/macos-integration-lj/install-dashboards-alerts/website.yaml
@@ -8,3 +8,4 @@ keywords:
 - dashboard
 - alert
 - integration
+description: Learn how to install the macOS integration pre-built dashboards and alerts

--- a/macos-integration-lj/select-architecture/website.yaml
+++ b/macos-integration-lj/select-architecture/website.yaml
@@ -9,3 +9,4 @@ keywords:
 - integration
 - Linux distribution
 - platform
+description: Learn how to determine which macOS platform architecture to select

--- a/macos-integration-lj/test-connection/website.yaml
+++ b/macos-integration-lj/test-connection/website.yaml
@@ -8,3 +8,4 @@ keywords:
 - Linux server
 - integration
 - Grafana Cloud
+description: Learn how to verify that Grafana Alloy is installed and configured correctly

--- a/macos-integration-lj/understand-alerts/website.yaml
+++ b/macos-integration-lj/understand-alerts/website.yaml
@@ -8,3 +8,4 @@ keywords:
 - Linux server
 - integration
 - alert
+description: Learn about the macOS integration pre-built alerts and how to use them to troubleshoot your environment

--- a/macos-integration-lj/understand-dashboards/website.yaml
+++ b/macos-integration-lj/understand-dashboards/website.yaml
@@ -20,3 +20,4 @@ side_journeys:
     link: /tutorials/create-users-and-teams
   - title: 5 quick ways to uplevel your use of Grafana (conference lightning talk)
     link: /events/grafanacon/2021/advanced-grafana
+description: Learn about the macOS integration pre-built dashboards and how to use them to troubleshoot your environment

--- a/macos-integration-lj/website.yaml
+++ b/macos-integration-lj/website.yaml
@@ -14,3 +14,4 @@ cta:
   type: start
   title: Are you ready?
   cta_text: Let's go!
+description: Welcome to the Grafana learning path that provides the best practice for setting up your macOS integration.

--- a/mongodb-integration-lj/business-value/website.yaml
+++ b/mongodb-integration-lj/business-value/website.yaml
@@ -9,3 +9,4 @@ keywords:
 - database observability
 - performance optimization
 - operational efficiency
+description: Learn why MongoDB monitoring is essential for database performance, reliability, and operational efficiency.

--- a/mongodb-integration-lj/configure-alloy/website.yaml
+++ b/mongodb-integration-lj/configure-alloy/website.yaml
@@ -19,3 +19,4 @@ side_journeys:
     link: /docs/alloy/latest/tutorials/logs-and-relabeling-basics
   - title: MongoDB exporter configuration reference
     link: /docs/alloy/latest/reference/components/prometheus/prometheus.exporter.mongodb/
+description: Configure Grafana Alloy to collect MongoDB metrics using the MongoDB exporter component.

--- a/mongodb-integration-lj/end-journey/website.yaml
+++ b/mongodb-integration-lj/end-journey/website.yaml
@@ -8,3 +8,5 @@ keywords:
 - MongoDB monitoring
 - learning path completion
 - observability success
+description: Congratulations on completing the MongoDB monitoring learning path. You've successfully implemented comprehensive
+  MongoDB observability with Grafana Cloud.

--- a/mongodb-integration-lj/install-alloy/website.yaml
+++ b/mongodb-integration-lj/install-alloy/website.yaml
@@ -19,3 +19,4 @@ side_journeys:
     link: https://www.youtube.com/watch?v=NrnLyDXpfq0
   - title: Grafana Alloy on GitHub
     link: https://github.com/grafana/alloy
+description: Install Grafana Alloy on your selected platform to begin collecting MongoDB metrics.

--- a/mongodb-integration-lj/install-dashboards-alerts/website.yaml
+++ b/mongodb-integration-lj/install-dashboards-alerts/website.yaml
@@ -15,3 +15,4 @@ side_journeys:
   items:
   - title: Create custom dashboards and panels
     link: /docs/grafana/latest/dashboards/
+description: Install pre-built MongoDB dashboards and alert rules to monitor database performance and health.

--- a/mongodb-integration-lj/prepare-configuration/website.yaml
+++ b/mongodb-integration-lj/prepare-configuration/website.yaml
@@ -15,3 +15,4 @@ side_journeys:
   items:
   - title: MongoDB connection string format
     link: /docs/grafana-cloud/send-data/metrics/
+description: Set up MongoDB URI, authentication credentials, and security settings for monitoring access.

--- a/mongodb-integration-lj/select-platform/website.yaml
+++ b/mongodb-integration-lj/select-platform/website.yaml
@@ -15,3 +15,4 @@ side_journeys:
   items:
   - title: Grafana Alloy architecture and concepts
     link: /docs/alloy/latest/concepts/
+description: Choose the appropriate platform and architecture for installing Grafana Alloy to collect MongoDB metrics.

--- a/mongodb-integration-lj/test-connection/website.yaml
+++ b/mongodb-integration-lj/test-connection/website.yaml
@@ -9,3 +9,4 @@ keywords:
 - metrics verification
 - troubleshooting
 - Grafana Cloud
+description: Restart Grafana Alloy service and verify that MongoDB metrics are flowing to Grafana Cloud.

--- a/mongodb-integration-lj/understand-dashboards/website.yaml
+++ b/mongodb-integration-lj/understand-dashboards/website.yaml
@@ -15,3 +15,5 @@ side_journeys:
   items:
   - title: MongoDB performance optimization techniques
     link: /docs/grafana-cloud/knowledge-graph/enable-prom-metrics-collection/data-stores/mongodb/
+description: Explore the MongoDB monitoring dashboards and learn to interpret key performance metrics and operational
+  indicators.

--- a/mongodb-integration-lj/website.yaml
+++ b/mongodb-integration-lj/website.yaml
@@ -22,3 +22,6 @@ keywords:
 - observability
 - Grafana Alloy
 - metrics
+description: Welcome to the MongoDB monitoring learning path that shows you how to use Grafana Alloy to send MongoDB
+  metrics to Grafana Cloud for comprehensive database observability.
+show_play: false

--- a/mysql-data-source-lj/add-data-source/website.yaml
+++ b/mysql-data-source-lj/add-data-source/website.yaml
@@ -17,3 +17,4 @@ side_journeys:
     link: https://www.youtube.com/watch?v=cqHO0oYW6Ic&list=PLDGkOdUX1Ujo27m6qiTPPCpFHVfyKq9jT&index=8
   - title: Data source plugins for Grafana
     link: https://grafana.com/grafana/plugins/data-source-plugins/
+description: Learn how to navigate Grafana Cloud and add the MySQL data source.

--- a/mysql-data-source-lj/advantages-mysql/website.yaml
+++ b/mysql-data-source-lj/advantages-mysql/website.yaml
@@ -20,3 +20,4 @@ side_journeys:
     link: /docs/grafana/latest/datasources/mysql/#query-editor
   - title: MySQL performance monitoring best practices
     link: /docs/grafana-cloud/monitor-infrastructure/integrations/integration-reference/integration-mysql/
+description: Learn about the specific benefits of connecting MySQL databases to Grafana Cloud.

--- a/mysql-data-source-lj/business-value-mysql/website.yaml
+++ b/mysql-data-source-lj/business-value-mysql/website.yaml
@@ -20,3 +20,4 @@ side_journeys:
     link: /docs/grafana-cloud/send-data/metrics/metrics-mysql/
   - title: MySQL integration for Grafana Cloud
     link: /docs/grafana-cloud/monitor-infrastructure/integrations/integration-reference/integration-mysql/
+description: Learn about database observability and how monitoring MySQL databases can help solve real-world problems.

--- a/mysql-data-source-lj/configure-datasource/website.yaml
+++ b/mysql-data-source-lj/configure-datasource/website.yaml
@@ -20,3 +20,4 @@ side_journeys:
     link: /docs/grafana-cloud/connect-externally-hosted/data-sources/
   - title: Private data source connections
     link: /docs/grafana-cloud/connect-externally-hosted/private-data-source-connect/
+description: Learn how to configure the connection settings for your MySQL database.

--- a/mysql-data-source-lj/end-journey/website.yaml
+++ b/mysql-data-source-lj/end-journey/website.yaml
@@ -9,3 +9,4 @@ keywords:
 - data source
 - completion
 - next steps
+description: Congratulations on completing the MySQL data source learning path!

--- a/mysql-data-source-lj/prepare-configuration/website.yaml
+++ b/mysql-data-source-lj/prepare-configuration/website.yaml
@@ -17,3 +17,4 @@ side_journeys:
     link: https://www.youtube.com/watch?v=cqHO0oYW6Ic&list=PLDGkOdUX1Ujo27m6qiTPPCpFHVfyKq9jT&index=8
   - title: Data source plugins for Grafana
     link: https://grafana.com/grafana/plugins/data-source-plugins/
+description: Learn how to create a monitoring user account in MySQL and prepare the database connection details

--- a/mysql-data-source-lj/test-connection/website.yaml
+++ b/mysql-data-source-lj/test-connection/website.yaml
@@ -19,3 +19,4 @@ side_journeys:
     link: https://dev.mysql.com/doc/refman/8.0/en/optimization.html
   - title: Grafana alerting with MySQL data
     link: /docs/grafana/latest/alerting/
+description: Learn how to select a private data source connection

--- a/mysql-data-source-lj/verify-mysql-data/website.yaml
+++ b/mysql-data-source-lj/verify-mysql-data/website.yaml
@@ -19,3 +19,4 @@ side_journeys:
     link: /docs/grafana/latest/dashboards/
   - title: Creating alerts with MySQL queries
     link: /docs/grafana/latest/alerting/alerting-rules/create-grafana-managed-rule/
+description: Learn how to verify that your MySQL data is accessible and query-able in Grafana.

--- a/mysql-data-source-lj/website.yaml
+++ b/mysql-data-source-lj/website.yaml
@@ -29,3 +29,6 @@ related_journeys:
   items:
   - title: Create a private connection to a data source
     link: /docs/learning-paths/private-data-source-connect/
+description: Welcome to the Grafana learning path that provides the best practice for configuring a MySQL data source
+  plugin.
+show_play: false

--- a/mysql-db-olly-lj/business-value/website.yaml
+++ b/mysql-db-olly-lj/business-value/website.yaml
@@ -8,3 +8,5 @@ keywords:
 - mysql monitoring
 - database observability
 - query performance
+description: Understand how Database Observability goes beyond basic metric monitoring to provide query-level insights
+  for MySQL databases.

--- a/mysql-db-olly-lj/check-requirements/website.yaml
+++ b/mysql-db-olly-lj/check-requirements/website.yaml
@@ -8,3 +8,5 @@ keywords:
 - mysql requirements
 - database observability prerequisites
 - grafana alloy
+description: Verify that your MySQL database, Grafana Cloud account, and Alloy installation meet the requirements for
+  Database Observability.

--- a/mysql-db-olly-lj/configure-alloy/website.yaml
+++ b/mysql-db-olly-lj/configure-alloy/website.yaml
@@ -16,3 +16,4 @@ side_journeys:
     link: /docs/alloy/latest/get-started/install/
   - title: Database Observability MySQL component reference
     link: /docs/alloy/latest/reference/components/database_observability/database_observability.mysql/
+description: Install Grafana Alloy and add the Database Observability configuration blocks for MySQL telemetry collection.

--- a/mysql-db-olly-lj/end-journey/website.yaml
+++ b/mysql-db-olly-lj/end-journey/website.yaml
@@ -8,3 +8,4 @@ keywords:
 - mysql database observability complete
 - query monitoring
 - grafana cloud
+description: Congratulations on completing the MySQL Database Observability learning path.

--- a/mysql-db-olly-lj/explore-queries/website.yaml
+++ b/mysql-db-olly-lj/explore-queries/website.yaml
@@ -17,3 +17,5 @@ side_journeys:
     link: /docs/grafana-cloud/monitor-applications/database-observability/investigate/analyze-explain-plans/
   - title: Improve slow queries
     link: /docs/grafana-cloud/monitor-applications/database-observability/optimize/improve-slow-queries/
+description: Use the Queries Overview dashboard to find slow queries, understand execution patterns, and drill into
+  query details.

--- a/mysql-db-olly-lj/prepare-mysql/website.yaml
+++ b/mysql-db-olly-lj/prepare-mysql/website.yaml
@@ -14,3 +14,4 @@ side_journeys:
   items:
   - title: MySQL setup reference documentation
     link: /docs/grafana-cloud/monitor-applications/database-observability/set-up/mysql/mysql/
+description: Enable Performance Schema, create a monitoring user, and configure digest settings for Database Observability.

--- a/mysql-db-olly-lj/verify-telemetry/website.yaml
+++ b/mysql-db-olly-lj/verify-telemetry/website.yaml
@@ -8,3 +8,5 @@ keywords:
 - telemetry verification
 - database observability configuration
 - mysql status checks
+description: Navigate to the Database Observability Configuration page and verify that all status checks pass for your
+  MySQL instance.

--- a/mysql-db-olly-lj/website.yaml
+++ b/mysql-db-olly-lj/website.yaml
@@ -23,3 +23,5 @@ keywords:
 - query performance
 - explain plans
 - grafana alloy
+description: Set up Grafana Cloud Database Observability for MySQL to monitor query performance, explain plans, wait
+  events, and query samples.

--- a/mysql-integration-lj/business-value/website.yaml
+++ b/mysql-integration-lj/business-value/website.yaml
@@ -8,3 +8,5 @@ keywords:
 - mysql monitoring
 - database observability
 - performance monitoring
+description: Understand the importance of monitoring MySQL databases and how Grafana Cloud provides comprehensive observability
+  for database performance.

--- a/mysql-integration-lj/configure-alloy/website.yaml
+++ b/mysql-integration-lj/configure-alloy/website.yaml
@@ -20,3 +20,5 @@ side_journeys:
     link: /docs/alloy/latest/tutorials/logs-and-relabeling-basics
   - title: Grafana Alloy configuration reference
     link: /docs/alloy/latest/reference/
+description: Learn how to configure Grafana Alloy with the MySQL integration snippets to collect metrics and logs from
+  your MySQL database.

--- a/mysql-integration-lj/end-journey/website.yaml
+++ b/mysql-integration-lj/end-journey/website.yaml
@@ -8,3 +8,5 @@ keywords:
 - mysql monitoring complete
 - database observability
 - grafana cloud monitoring
+description: Congratulations on completing the MySQL monitoring learning path. You've successfully set up comprehensive
+  monitoring for your MySQL database.

--- a/mysql-integration-lj/install-alloy/website.yaml
+++ b/mysql-integration-lj/install-alloy/website.yaml
@@ -15,3 +15,4 @@ side_journeys:
   items:
   - title: Grafana Alloy configuration syntax and examples
     link: /docs/alloy/latest/reference/config-blocks/
+description: Install Grafana Alloy on your selected platform to begin collecting MySQL metrics.

--- a/mysql-integration-lj/install-dashboards-alerts/website.yaml
+++ b/mysql-integration-lj/install-dashboards-alerts/website.yaml
@@ -8,3 +8,5 @@ keywords:
 - mysql dashboards
 - mysql alerts
 - pre-built monitoring
+description: Learn how to install the pre-built MySQL dashboards and alert rules in your Grafana Cloud instance to
+  start monitoring your database.

--- a/mysql-integration-lj/prepare-configuration/website.yaml
+++ b/mysql-integration-lj/prepare-configuration/website.yaml
@@ -8,3 +8,5 @@ keywords:
 - mysql configuration
 - database user
 - monitoring setup
+description: Learn how to create a monitoring user account in MySQL and prepare the database connection details needed
+  for Grafana Alloy configuration.

--- a/mysql-integration-lj/select-platform/website.yaml
+++ b/mysql-integration-lj/select-platform/website.yaml
@@ -8,3 +8,4 @@ keywords:
 - Grafana Alloy
 - platform selection
 - grafana cloud
+description: Choose the appropriate platform and architecture for installing Grafana Alloy to collect MySQL metrics.

--- a/mysql-integration-lj/test-connection/website.yaml
+++ b/mysql-integration-lj/test-connection/website.yaml
@@ -8,3 +8,5 @@ keywords:
 - mysql connection test
 - data verification
 - metrics validation
+description: Learn how to verify that Grafana Alloy is successfully collecting MySQL metrics and logs and sending them
+  to Grafana Cloud.

--- a/mysql-integration-lj/understand-dashboards/website.yaml
+++ b/mysql-integration-lj/understand-dashboards/website.yaml
@@ -15,3 +15,5 @@ side_journeys:
   items:
   - title: Build a dashboard
     link: /docs/grafana-cloud/visualizations/dashboards/build-dashboards
+description: Explore the MySQL monitoring dashboards and learn to interpret key performance metrics and operational
+  indicators.

--- a/mysql-integration-lj/website.yaml
+++ b/mysql-integration-lj/website.yaml
@@ -22,3 +22,6 @@ keywords:
 - monitoring
 - grafana alloy
 - observability
+description: Welcome to the Grafana learning path that shows you how to monitor MySQL databases with Grafana Alloy
+  and use pre-built dashboards and alerts in Grafana Cloud.
+show_play: false

--- a/postgresql-db-olly-lj/business-value/website.yaml
+++ b/postgresql-db-olly-lj/business-value/website.yaml
@@ -8,3 +8,5 @@ keywords:
 - postgresql monitoring
 - database observability
 - query performance
+description: Understand how Database Observability goes beyond basic metric monitoring to provide query-level insights
+  for PostgreSQL databases.

--- a/postgresql-db-olly-lj/check-requirements/website.yaml
+++ b/postgresql-db-olly-lj/check-requirements/website.yaml
@@ -8,3 +8,5 @@ keywords:
 - postgresql requirements
 - database observability prerequisites
 - grafana alloy
+description: Verify that your PostgreSQL database, Grafana Cloud account, and Alloy installation meet the requirements
+  for Database Observability.

--- a/postgresql-db-olly-lj/configure-alloy/website.yaml
+++ b/postgresql-db-olly-lj/configure-alloy/website.yaml
@@ -16,3 +16,5 @@ side_journeys:
     link: /docs/alloy/latest/get-started/install/
   - title: Database Observability PostgreSQL component reference
     link: /docs/grafana-cloud/send-data/alloy/reference/components/database_observability/database_observability.postgres/
+description: Install Grafana Alloy and add the Database Observability configuration blocks for PostgreSQL telemetry
+  collection.

--- a/postgresql-db-olly-lj/end-journey/website.yaml
+++ b/postgresql-db-olly-lj/end-journey/website.yaml
@@ -8,3 +8,4 @@ keywords:
 - postgresql database observability complete
 - query monitoring
 - grafana cloud
+description: Congratulations on completing the PostgreSQL Database Observability learning path.

--- a/postgresql-db-olly-lj/explore-queries/website.yaml
+++ b/postgresql-db-olly-lj/explore-queries/website.yaml
@@ -17,3 +17,5 @@ side_journeys:
     link: /docs/grafana-cloud/monitor-applications/database-observability/investigate/analyze-explain-plans/
   - title: Improve slow queries
     link: /docs/grafana-cloud/monitor-applications/database-observability/optimize/improve-slow-queries/
+description: Use the Queries Overview dashboard to find slow queries, understand execution patterns, and drill into
+  query details.

--- a/postgresql-db-olly-lj/prepare-postgresql/website.yaml
+++ b/postgresql-db-olly-lj/prepare-postgresql/website.yaml
@@ -14,3 +14,5 @@ side_journeys:
   items:
   - title: PostgreSQL setup reference documentation
     link: /docs/grafana-cloud/monitor-applications/database-observability/set-up/postgres/postgres/
+description: Enable pg_stat_statements, create a monitoring user, and configure query tracking settings for Database
+  Observability.

--- a/postgresql-db-olly-lj/verify-telemetry/website.yaml
+++ b/postgresql-db-olly-lj/verify-telemetry/website.yaml
@@ -8,3 +8,5 @@ keywords:
 - telemetry verification
 - database observability configuration
 - postgresql status checks
+description: Navigate to the Database Observability Configuration page and verify that all status checks pass for your
+  PostgreSQL instance.

--- a/postgresql-db-olly-lj/website.yaml
+++ b/postgresql-db-olly-lj/website.yaml
@@ -23,3 +23,5 @@ keywords:
 - query performance
 - explain plans
 - grafana alloy
+description: Set up Grafana Cloud Database Observability for PostgreSQL to monitor query performance, explain plans,
+  wait events, and query samples.

--- a/postgresql-integration-lj/business-value/website.yaml
+++ b/postgresql-integration-lj/business-value/website.yaml
@@ -8,3 +8,5 @@ keywords:
 - postgresql monitoring
 - database observability
 - performance monitoring
+description: Understand the importance of monitoring PostgreSQL databases and how Grafana Cloud provides comprehensive
+  observability for database performance.

--- a/postgresql-integration-lj/configure-alloy/website.yaml
+++ b/postgresql-integration-lj/configure-alloy/website.yaml
@@ -14,3 +14,5 @@ side_journeys:
   items:
   - title: Grafana Alloy configuration reference
     link: /docs/alloy/latest/reference/
+description: Learn how to configure Grafana Alloy with the PostgreSQL integration snippets to collect metrics and logs
+  from your PostgreSQL database.

--- a/postgresql-integration-lj/end-journey/website.yaml
+++ b/postgresql-integration-lj/end-journey/website.yaml
@@ -8,3 +8,5 @@ keywords:
 - postgresql monitoring complete
 - database observability
 - grafana cloud monitoring
+description: Congratulations on completing the PostgreSQL monitoring learning path. You've successfully set up comprehensive
+  monitoring for your PostgreSQL database.

--- a/postgresql-integration-lj/install-alloy/website.yaml
+++ b/postgresql-integration-lj/install-alloy/website.yaml
@@ -21,3 +21,4 @@ side_journeys:
     link: https://www.youtube.com/watch?v=NrnLyDXpfq0
   - title: Grafana Alloy on GitHub
     link: https://github.com/grafana/alloy
+description: Install Grafana Alloy on your selected platform to begin collecting PostgreSQL metrics.

--- a/postgresql-integration-lj/install-dashboards-alerts/website.yaml
+++ b/postgresql-integration-lj/install-dashboards-alerts/website.yaml
@@ -8,3 +8,5 @@ keywords:
 - postgresql dashboards
 - postgresql alerts
 - pre-built monitoring
+description: Learn how to install the pre-built PostgreSQL dashboards and alert rules in your Grafana Cloud instance
+  to start monitoring your database.

--- a/postgresql-integration-lj/prepare-configuration/website.yaml
+++ b/postgresql-integration-lj/prepare-configuration/website.yaml
@@ -8,3 +8,5 @@ keywords:
 - postgresql configuration
 - database user
 - monitoring setup
+description: Learn how to create a monitoring user account in PostgreSQL and prepare the database connection details
+  needed for Grafana Alloy configuration.

--- a/postgresql-integration-lj/select-platform/website.yaml
+++ b/postgresql-integration-lj/select-platform/website.yaml
@@ -8,3 +8,4 @@ keywords:
 - Grafana Alloy
 - platform selection
 - grafana cloud
+description: Choose the appropriate platform and architecture for installing Grafana Alloy to collect PostgreSQL metrics.

--- a/postgresql-integration-lj/test-connection/website.yaml
+++ b/postgresql-integration-lj/test-connection/website.yaml
@@ -8,3 +8,5 @@ keywords:
 - postgresql connection test
 - data verification
 - metrics validation
+description: Learn how to verify that Grafana Alloy is successfully collecting PostgreSQL metrics and logs and sending
+  them to Grafana Cloud.

--- a/postgresql-integration-lj/understand-dashboards/website.yaml
+++ b/postgresql-integration-lj/understand-dashboards/website.yaml
@@ -9,3 +9,5 @@ keywords:
 - dashboard interpretation
 - performance analysis
 - database monitoring
+description: Explore the PostgreSQL monitoring dashboards and learn to interpret key performance metrics and operational
+  indicators.

--- a/postgresql-integration-lj/website.yaml
+++ b/postgresql-integration-lj/website.yaml
@@ -22,3 +22,6 @@ keywords:
 - monitoring
 - grafana alloy
 - observability
+description: Welcome to the Grafana learning path that shows you how to monitor PostgreSQL databases with Grafana Alloy
+  and use pre-built dashboards and alerts in Grafana Cloud.
+show_play: false

--- a/private-data-source-connect-lj/business-value-pdc/website.yaml
+++ b/private-data-source-connect-lj/business-value-pdc/website.yaml
@@ -10,3 +10,4 @@ keywords:
 - monitoring
 - data source
 - private data source connect
+description: Learn about observability and how it can help you solve real-world problems

--- a/private-data-source-connect-lj/business-value/website.yaml
+++ b/private-data-source-connect-lj/business-value/website.yaml
@@ -14,3 +14,4 @@ side_journeys:
   items:
   - title: What is observability?
     link: /docs/grafana-cloud/introduction/what-is-observability/
+description: Learn about observability and how it can help you solve real-world problems

--- a/private-data-source-connect-lj/deploy-pdc-agent/website.yaml
+++ b/private-data-source-connect-lj/deploy-pdc-agent/website.yaml
@@ -8,3 +8,4 @@ keywords:
 - private data source connect
 - deploy
 - test
+description: How to deploy private data source connect and test that the connection works

--- a/private-data-source-connect-lj/end-journey/website.yaml
+++ b/private-data-source-connect-lj/end-journey/website.yaml
@@ -4,3 +4,4 @@ step: 8
 layout: single-journey
 cta:
   type: conclusion
+description: Your journey concludes and it's time to learn about related paths you can take

--- a/private-data-source-connect-lj/generate-token/website.yaml
+++ b/private-data-source-connect-lj/generate-token/website.yaml
@@ -7,3 +7,4 @@ cta:
 keywords:
 - token
 - private data source connect
+description: Steps for how to generate a signing token used when installing private data source connect

--- a/private-data-source-connect-lj/install-pdc-binary/website.yaml
+++ b/private-data-source-connect-lj/install-pdc-binary/website.yaml
@@ -8,3 +8,4 @@ keywords:
 - install
 - private data source connect
 - binaries
+description: Learn how to install the private data source connect binaries on a Linux machine

--- a/private-data-source-connect-lj/select-installation-method/website.yaml
+++ b/private-data-source-connect-lj/select-installation-method/website.yaml
@@ -7,3 +7,4 @@ cta:
 keywords:
 - install
 - private data source connect
+description: Determine which approach to use to install private data source connect

--- a/private-data-source-connect-lj/website.yaml
+++ b/private-data-source-connect-lj/website.yaml
@@ -14,3 +14,5 @@ cta:
   type: start
   title: Are you ready?
   cta_text: Let's go!
+description: Learn how to send queries and return results over a private connection to Grafana Cloud.
+show_play: false

--- a/prom-remote-write-lj/business-value-olly/website.yaml
+++ b/prom-remote-write-lj/business-value-olly/website.yaml
@@ -9,3 +9,4 @@ keywords:
 - monitoring
 - Prometheus
 - remote write
+description: Learn about observability and how it can help you solve real-world problems

--- a/prom-remote-write-lj/business-value-prom/website.yaml
+++ b/prom-remote-write-lj/business-value-prom/website.yaml
@@ -16,3 +16,4 @@ side_journeys:
   items:
   - title: What is Prometheus?
     link: /docs/grafana-cloud/introduction/what-is-observability/prometheus/
+description: Learn about the advantages of remote write and when you should use it

--- a/prom-remote-write-lj/configure-prom-remote-write/website.yaml
+++ b/prom-remote-write-lj/configure-prom-remote-write/website.yaml
@@ -16,3 +16,4 @@ side_journeys:
     link: /docs/grafana-cloud/send-data/metrics/metrics-prometheus/#send-data-from-multiple-prometheus-instances
   - title: Send data from multiple high-availability Prometheus instances
     link: /docs/grafana-cloud/send-data/metrics/metrics-prometheus/#send-data-from-multiple-high-availability-prometheus-instances
+description: How to configure Prometheus to send metrics to Grafana Cloud

--- a/prom-remote-write-lj/end-remote-write/website.yaml
+++ b/prom-remote-write-lj/end-remote-write/website.yaml
@@ -16,3 +16,4 @@ side_journeys:
     link: /docs/grafana-cloud/alerting-and-irm/irm/irm-slack
   - title: Set up a Service Level Objective
     link: /docs/grafana-cloud/alerting-and-irm/slo/set-up
+description: Your journey concludes and it's time to learn about related paths you can take

--- a/prom-remote-write-lj/verify-metrics-query-works/website.yaml
+++ b/prom-remote-write-lj/verify-metrics-query-works/website.yaml
@@ -10,3 +10,4 @@ keywords:
 - Metrics
 - Explore
 - Query
+description: How to verify that a Prometheus data source query works

--- a/prom-remote-write-lj/verify-prom-data/website.yaml
+++ b/prom-remote-write-lj/verify-prom-data/website.yaml
@@ -8,3 +8,4 @@ keywords:
 - Prometheus
 - Grafana Cloud
 - Metrics
+description: How to verify that metrics are being written to an endpoint

--- a/prom-remote-write-lj/website.yaml
+++ b/prom-remote-write-lj/website.yaml
@@ -14,3 +14,5 @@ cta:
   type: start
   title: Are you ready?
   cta_text: Let's go!
+description: Welcome to the Grafana learning path that provides the best practice for configuring Prometheus remote
+  write to send metrics to Grafana Cloud.

--- a/prometheus-lj/add-data-source-url/website.yaml
+++ b/prometheus-lj/add-data-source-url/website.yaml
@@ -14,3 +14,4 @@ side_journeys:
   items:
   - title: Create a private connection to a data source
     link: /docs/learning-paths/private-data-source-connect
+description: Learn how to add the Prometheus server endpoint URL

--- a/prometheus-lj/add-data-source/website.yaml
+++ b/prometheus-lj/add-data-source/website.yaml
@@ -17,3 +17,4 @@ side_journeys:
     link: https://www.youtube.com/watch?v=cqHO0oYW6Ic&list=PLDGkOdUX1Ujo27m6qiTPPCpFHVfyKq9jT&index=8
   - title: Data source plugins for Grafana
     link: https://grafana.com/grafana/plugins/data-source-plugins/
+description: Learn how to navigate Grafana Cloud and add the Prometheus data source

--- a/prometheus-lj/business-value-olly/website.yaml
+++ b/prometheus-lj/business-value-olly/website.yaml
@@ -15,3 +15,4 @@ side_journeys:
   items:
   - title: What is observability?
     link: /docs/grafana-cloud/introduction/what-is-observability/
+description: Learn about observability and how it can help you solve real-world problems

--- a/prometheus-lj/business-value-prom/website.yaml
+++ b/prometheus-lj/business-value-prom/website.yaml
@@ -21,3 +21,4 @@ side_journeys:
     link: /docs/grafana-cloud/send-data/metrics/metrics-prometheus/#send-data-from-multiple-prometheus-instances
   - title: Send data from multiple high-availability Prometheus instances
     link: /docs/grafana-cloud/send-data/metrics/metrics-prometheus/#send-data-from-multiple-high-availability-prometheus-instances
+description: Learn about observability and how it can help you solve real-world problems

--- a/prometheus-lj/config-authentication/website.yaml
+++ b/prometheus-lj/config-authentication/website.yaml
@@ -17,3 +17,4 @@ side_journeys:
     link: /docs/grafana-cloud/connect-externally-hosted/data-sources/prometheus/configure-prometheus-data-source/#authentication-section
   - title: Advanced settings
     link: /docs/grafana-cloud/connect-externally-hosted/data-sources/prometheus/configure-prometheus-data-source/#advanced-settings
+description: Learn how to configure basic authentication to the Prometheus data source connection

--- a/prometheus-lj/end-journey/website.yaml
+++ b/prometheus-lj/end-journey/website.yaml
@@ -19,3 +19,4 @@ side_journeys:
     link: /docs/grafana-cloud/connect-externally-hosted/data-sources/graphite/
   - title: InfluxDB
     link: /docs/grafana-cloud/connect-externally-hosted/data-sources/influxdb/
+description: Your journey concludes and it's time to learn about related paths you can take

--- a/prometheus-lj/select-private-connection/website.yaml
+++ b/prometheus-lj/select-private-connection/website.yaml
@@ -14,3 +14,4 @@ side_journeys:
   items:
   - title: Create a private connection to a data source
     link: /docs/learning-paths/private-data-source-connect
+description: Learn how to select a private data source connection

--- a/prometheus-lj/verify-ds-connection/website.yaml
+++ b/prometheus-lj/verify-ds-connection/website.yaml
@@ -10,3 +10,4 @@ keywords:
 - Metrics
 - Explore
 - Query
+description: How to verify that a Prometheus data source query works

--- a/prometheus-lj/verify-prom-data/website.yaml
+++ b/prometheus-lj/verify-prom-data/website.yaml
@@ -18,3 +18,4 @@ side_journeys:
     link: /docs/grafana-cloud/send-data/metrics/metrics-prometheus/#send-data-from-multiple-prometheus-instances
   - title: Send data from multiple high-availability Prometheus instances
     link: /docs/grafana-cloud/send-data/metrics/metrics-prometheus/#send-data-from-multiple-high-availability-prometheus-instances
+description: How to verify that metrics are being written to an endpoint

--- a/prometheus-lj/website.yaml
+++ b/prometheus-lj/website.yaml
@@ -20,3 +20,6 @@ related_journeys:
   items:
   - title: Create a private connection to a data source
     link: /docs/learning-paths/private-data-source-connect/
+description: Welcome to the Grafana learning path that provides the best practice for configuring a Prometheus data
+  source plugin.
+show_play: false

--- a/run-first-k6-test-lj/analyze-results/website.yaml
+++ b/run-first-k6-test-lj/analyze-results/website.yaml
@@ -10,3 +10,4 @@ keywords:
 - test analysis
 - performance metrics
 - dashboards
+description: View and analyze your k6 test results in Grafana Cloud dashboards to understand performance metrics.

--- a/run-first-k6-test-lj/end-journey/website.yaml
+++ b/run-first-k6-test-lj/end-journey/website.yaml
@@ -9,3 +9,4 @@ keywords:
 - performance testing
 - completion
 - next steps
+description: Congratulations on completing your first k6 performance test journey.

--- a/run-first-k6-test-lj/install-k6/website.yaml
+++ b/run-first-k6-test-lj/install-k6/website.yaml
@@ -8,3 +8,4 @@ keywords:
 - k6
 - installation
 - setup
+description: Install k6 on your machine using your preferred package manager or download method.

--- a/run-first-k6-test-lj/run-locally/website.yaml
+++ b/run-first-k6-test-lj/run-locally/website.yaml
@@ -9,3 +9,4 @@ keywords:
 - run test
 - local execution
 - test results
+description: Execute your k6 test script locally and view the results in your terminal.

--- a/run-first-k6-test-lj/send-to-grafana-cloud/website.yaml
+++ b/run-first-k6-test-lj/send-to-grafana-cloud/website.yaml
@@ -9,3 +9,4 @@ keywords:
 - grafana cloud
 - cloud streaming
 - test results
+description: Stream your k6 test results to Grafana Cloud for real-time visualization and analysis.

--- a/run-first-k6-test-lj/understand-value/website.yaml
+++ b/run-first-k6-test-lj/understand-value/website.yaml
@@ -9,3 +9,4 @@ keywords:
 - performance testing
 - load testing
 - reliability
+description: Learn why performance testing with k6 helps you identify potential issues before they occur in production.

--- a/run-first-k6-test-lj/website.yaml
+++ b/run-first-k6-test-lj/website.yaml
@@ -20,3 +20,6 @@ keywords:
 - load testing
 - grafana cloud
 - observability
+description: Welcome to the Grafana learning path that shows you how to write, run, and analyze your first k6 performance
+  test, from installation to visualizing results in Grafana Cloud.
+show_play: false

--- a/run-first-k6-test-lj/write-test-script/website.yaml
+++ b/run-first-k6-test-lj/write-test-script/website.yaml
@@ -9,3 +9,4 @@ keywords:
 - test script
 - javascript
 - http requests
+description: Create a k6 test script that performs HTTP requests and measures response times.

--- a/send-logs-alloy-loki-lj/business-value-alloy/website.yaml
+++ b/send-logs-alloy-loki-lj/business-value-alloy/website.yaml
@@ -15,3 +15,4 @@ side_journeys:
     link: https://www.youtube.com/watch?v=d9zLeFuIFIk
   - title: Grafana Alloy for Beginners series
     link: https://www.youtube.com/playlist?list=PLDGkOdUX1UjoUmd6Z-lKgGaGzmZvYxRWs
+description: Understand the value of using Alloy in Grafana Cloud.

--- a/send-logs-alloy-loki-lj/choose-components/website.yaml
+++ b/send-logs-alloy-loki-lj/choose-components/website.yaml
@@ -12,3 +12,4 @@ side_journeys:
     link: /docs/alloy/latest/reference/components/
   - title: Choose a Grafana Alloy component
     link: /docs/alloy/latest/collect/choose-component/
+description: Learn about the components you are going to use to configure Grafana Alloy to collect system logs

--- a/send-logs-alloy-loki-lj/end-journey/website.yaml
+++ b/send-logs-alloy-loki-lj/end-journey/website.yaml
@@ -4,3 +4,4 @@ step: 9
 layout: single-journey
 cta:
   type: conclusion
+description: Your journey concludes and it's time to learn about related paths you can take

--- a/send-logs-alloy-loki-lj/inspect-configuration/website.yaml
+++ b/send-logs-alloy-loki-lj/inspect-configuration/website.yaml
@@ -10,3 +10,4 @@ side_journeys:
   items:
   - title: Debug Grafana Alloy
     link: /docs/alloy/latest/troubleshoot/debug/
+description: Learn how to inspect your configuration file in Alloy

--- a/send-logs-alloy-loki-lj/install-alloy/website.yaml
+++ b/send-logs-alloy-loki-lj/install-alloy/website.yaml
@@ -4,3 +4,4 @@ step: 4
 layout: single-journey
 cta:
   type: success
+description: Learn how to install Grafana Alloy

--- a/send-logs-alloy-loki-lj/send-logs-loki/website.yaml
+++ b/send-logs-alloy-loki-lj/send-logs-loki/website.yaml
@@ -4,3 +4,4 @@ step: 6
 layout: single-journey
 cta:
   type: continue
+description: Learn how to Configure Grafana Alloy to send system logs to Grafana Loki

--- a/send-logs-alloy-loki-lj/view-logs/website.yaml
+++ b/send-logs-alloy-loki-lj/view-logs/website.yaml
@@ -4,3 +4,4 @@ step: 8
 layout: single-journey
 cta:
   type: success
+description: Learn how to view logs using Grafana Logs Drilldown

--- a/send-logs-alloy-loki-lj/website.yaml
+++ b/send-logs-alloy-loki-lj/website.yaml
@@ -14,3 +14,5 @@ cta:
   type: start
   title: Are you ready?
   cta_text: Let's go!
+description: Welcome to the Grafana learning path that provides the best practice for configuring Alloy to send logs
+  to Grafana Cloud.

--- a/visualization-metrics-lj/add-visualization/website.yaml
+++ b/visualization-metrics-lj/add-visualization/website.yaml
@@ -12,3 +12,4 @@ side_journeys:
     link: /docs/grafana-cloud/introduction/what-is-observability/timeseries-dimensions/
   - title: Visualizations
     link: /docs/grafana/latest/panels-visualizations/visualizations/
+description: Learn how to start building your visualization

--- a/visualization-metrics-lj/business-value-visualizations/website.yaml
+++ b/visualization-metrics-lj/business-value-visualizations/website.yaml
@@ -12,3 +12,5 @@ side_journeys:
     link: /docs/grafana-cloud/introduction/dashboards/
   - title: Metrics and visualizations
     link: /docs/grafana-cloud/introduction/metrics-and-visualizations/
+description: Learn about observability and how you can harness the power of dashboards and visualizations to solve
+  problems

--- a/visualization-metrics-lj/end-journey/website.yaml
+++ b/visualization-metrics-lj/end-journey/website.yaml
@@ -16,3 +16,4 @@ side_journeys:
     link: /docs/grafana/latest/panels-visualizations/configure-thresholds/
   - title: Configure standard options
     link: /docs/grafana/latest/panels-visualizations/configure-standard-options/
+description: Your journey concludes and it's time to learn about related paths you can take

--- a/visualization-metrics-lj/plan-visualization/website.yaml
+++ b/visualization-metrics-lj/plan-visualization/website.yaml
@@ -10,3 +10,4 @@ side_journeys:
   items:
   - title: Grafana dashboard best practices
     link: /docs/grafana-cloud/visualizations/dashboards/build-dashboards/best-practices/
+description: Learn about the questions you should ask yourself as you prepare to build a dashboard

--- a/visualization-metrics-lj/save-dashboard/website.yaml
+++ b/visualization-metrics-lj/save-dashboard/website.yaml
@@ -12,3 +12,4 @@ side_journeys:
     link: /docs/grafana/latest/dashboards/share-dashboards-panels
   - title: Set up generative AI features for dashboards
     link: /docs/grafana/latest/visualizations/dashboards/manage-dashboards/#set-up-generative-ai-features-for-dashboards
+description: Learn how to save your dashboard so that other users can see it

--- a/visualization-metrics-lj/time-range-refresh/website.yaml
+++ b/visualization-metrics-lj/time-range-refresh/website.yaml
@@ -14,3 +14,5 @@ side_journeys:
     link: /docs/grafana-cloud/visualizations/dashboards/use-dashboards/#refresh-dashboard
   - title: Troubleshoot dashboards
     link: /docs/grafana-cloud/visualizations/dashboards/troubleshoot-dashboards
+description: Configure the time span for displayed data and set how frequently your visualization updates with refreshed
+  data

--- a/visualization-metrics-lj/website.yaml
+++ b/visualization-metrics-lj/website.yaml
@@ -23,3 +23,4 @@ related_journeys:
   items:
   - title: Explore data using Metrics Drilldown
     link: /docs/learning-paths/drilldown-metrics/
+description: Welcome to the Grafana learning path that shows you how to visualize CPU metrics in a dashboard.

--- a/visualization-metrics-lj/write-query/website.yaml
+++ b/visualization-metrics-lj/write-query/website.yaml
@@ -16,3 +16,4 @@ side_journeys:
     link: /docs/grafana-cloud/connect-externally-hosted/data-sources/prometheus/query-editor/#label-filters
   - title: Operations
     link: /docs/grafana-cloud/connect-externally-hosted/data-sources/prometheus/query-editor/#operations
+description: Learn how to use the Grafana query builder to write a PromQL query

--- a/visualization-traces-lj/add-traces-panel/website.yaml
+++ b/visualization-traces-lj/add-traces-panel/website.yaml
@@ -10,3 +10,4 @@ side_journeys:
   items:
   - title: Traces
     link: /docs/grafana-cloud/visualizations/panels-visualizations/visualizations/traces/
+description: Learn how to add the Traces panel to a dashboard

--- a/visualization-traces-lj/add-traces-table/website.yaml
+++ b/visualization-traces-lj/add-traces-table/website.yaml
@@ -14,3 +14,4 @@ side_journeys:
     link: /docs/grafana-cloud/connect-externally-hosted/data-sources/tempo/query-editor/traceql-search/
   - title: Query tracing data
     link: /docs/grafana-cloud/send-data/traces/traces-query-editor/
+description: Learn how to write a TraceQL query to visualize traces on a panel

--- a/visualization-traces-lj/add-variable/website.yaml
+++ b/visualization-traces-lj/add-variable/website.yaml
@@ -10,3 +10,4 @@ side_journeys:
   items:
   - title: Variables
     link: /docs/grafana-cloud/visualizations/dashboards/variables/
+description: Learn how to add a variable that will be used to filter trace dashboard results

--- a/visualization-traces-lj/add-visualization/website.yaml
+++ b/visualization-traces-lj/add-visualization/website.yaml
@@ -12,3 +12,4 @@ side_journeys:
     link: /docs/grafana-cloud/visualizations/dashboards/build-dashboards/best-practices/
   - title: Visualizations
     link: /docs/grafana/latest/panels-visualizations/visualizations/
+description: Learn how to start building your visualization

--- a/visualization-traces-lj/business-value-visualizations/website.yaml
+++ b/visualization-traces-lj/business-value-visualizations/website.yaml
@@ -12,3 +12,5 @@ side_journeys:
     link: /docs/grafana-cloud/introduction/dashboards/
   - title: Metrics and visualizations
     link: /docs/grafana-cloud/introduction/metrics-and-visualizations/
+description: Learn about observability and how you can harness the power of dashboards and visualizations to solve
+  problems

--- a/visualization-traces-lj/end-journey/website.yaml
+++ b/visualization-traces-lj/end-journey/website.yaml
@@ -16,3 +16,4 @@ side_journeys:
     link: /docs/grafana/latest/panels-visualizations/configure-thresholds/
   - title: Configure standard options
     link: /docs/grafana/latest/panels-visualizations/configure-standard-options/
+description: Your journey concludes and it's time to learn about related paths you can take

--- a/visualization-traces-lj/plan-visualization/website.yaml
+++ b/visualization-traces-lj/plan-visualization/website.yaml
@@ -4,3 +4,4 @@ step: 3
 layout: single-journey
 cta:
   type: continue
+description: Learn about the questions you should ask yourself as you prepare to build a dashboard

--- a/visualization-traces-lj/test-dashboard/website.yaml
+++ b/visualization-traces-lj/test-dashboard/website.yaml
@@ -4,3 +4,4 @@ step: 8
 layout: single-journey
 cta:
   type: continue
+description: Learn how to save your dashboard so that other user can see it

--- a/visualization-traces-lj/time-range-refresh/website.yaml
+++ b/visualization-traces-lj/time-range-refresh/website.yaml
@@ -14,3 +14,5 @@ side_journeys:
     link: /docs/grafana-cloud/visualizations/dashboards/use-dashboards/#refresh-dashboard
   - title: Troubleshoot dashboards
     link: /docs/grafana-cloud/visualizations/dashboards/troubleshoot-dashboards
+description: Configure the time span for displayed data and set how frequently your visualization updates with refreshed
+  data

--- a/visualization-traces-lj/website.yaml
+++ b/visualization-traces-lj/website.yaml
@@ -24,3 +24,4 @@ related_journeys:
   items:
   - title: Use Traces Drilldown to identify high latency service requests
     link: /docs/learning-paths/drilldown-traces/
+description: Welcome to the Grafana learning path that shows you how to visualize traces in a dashboard


### PR DESCRIPTION
Useful metadata present in website front matter that I'd like to source from the path package metadata now to fully realize the complete single-sourcing from this repo.

Related: https://github.com/grafana/website/pull/31372


Signed-off-by: Jack Baldry <jack.baldry@grafana.com>
