### PR TITLE
fix(deploy): match integrity gate to repository.json schema

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -262,10 +262,15 @@ jobs:
 
           echo "── packages/ ────────────────────────────────────────────────"
           test -f packages/repository.json || { echo "❌ packages/repository.json missing"; exit 1; }
-          jq -e 'type == "object" and (.packages | type == "array") and (.packages | length > 0)' \
+          # build-repository emits a flat object keyed by package name, e.g.
+          #   { "adaptive-logs-lj": { "path": "adaptive-logs-lj/", ... }, ... }
+          # NOT a { "packages": [...] } wrapper. Require a non-empty object whose
+          # every entry is itself an object carrying a "path" (the field that
+          # makes a CDN sibling resolve), which keeps this a tampering tripwire.
+          jq -e 'type == "object" and (length > 0) and (all(.[]; type == "object" and has("path")))' \
             packages/repository.json > /dev/null \
-            || { echo "❌ packages/repository.json malformed or empty .packages array"; exit 1; }
-          echo "✅ repository.json well-formed with $(jq '.packages | length' packages/repository.json) packages"
+            || { echo "❌ packages/repository.json malformed or empty"; exit 1; }
+          echo "✅ repository.json well-formed with $(jq 'length' packages/repository.json) packages"
 
           # Optional graph.json: if present, must parse.
           if [ -f packages/graph.json ]; then


### PR DESCRIPTION
## What

The `publish-packages` integrity gate validates the wrong schema for `packages/repository.json`, failing **every** push to `main` since PR #368 merged on 2026-06-09. The prod CDN deploy has been red for ~2.5 weeks for all authors.

## Root cause

`build-repository` emits a **flat object keyed by package name**:

```json
{
  "adaptive-logs-lj": { "path": "adaptive-logs-lj/", "title": "…", "type": "path", … },
  …  // 376 entries
}
```

But the gate (introduced in #368) checked for a `{ "packages": [...] }` array:

```bash
jq -e 'type == "object" and (.packages | type == "array") and (.packages | length > 0)'
```

`.packages` is `null` → the check fails with `❌ packages/repository.json malformed or empty .packages array`, even though the artifact is valid. The `build-packages` job succeeds (`✅ Wrote repository.json … (376 packages)`); only the downstream gate rejects it.

## Fix

Validate the actual shape: a non-empty object whose every entry is an object carrying a `path`. This restores the deploy and preserves the gate's tampering-tripwire intent (rejects empty `{}`, the stale `{ "packages": [] }` shape, and entries missing `path`).

```bash
jq -e 'type == "object" and (length > 0) and (all(.[]; type == "object" and has("path")))'
```

Tested locally against good / missing-path / empty / old-schema inputs: PASS / FAIL / FAIL / FAIL respectively.

## Evidence

- Last green deploy: 2026-06-09 09:47 (before #368).
- First red deploy: 2026-06-09 16:21 — the same minute #368 (`9fcf7d2`) merged.
- Every deploy since (run `28252778365` and prior) fails with the identical error.