### PR TITLE
Add Attributions and Invoices milestones to billing-usage-lj

### DIFF
--- a/billing-usage-lj/attributions/content.json
+++ b/billing-usage-lj/attributions/content.json
@@ -11,14 +11,14 @@
       "content": "Attribution data appears only after someone configures cost attribution labels for your organization, and historical data starts from when attribution was first enabled. This milestone focuses on reading the Attributions tab; if your stack has no labels configured yet, the steps that highlight attribution data won't apply. To set up labels, refer to [Attribute costs](https://grafana.com/docs/grafana-cloud/cost-management-and-billing/cost-attributions/)."
     },
     {
+      "type": "markdown",
+      "content": "In this section, you'll open the Attributions tab and read how your spend is allocated across your configured labels."
+    },
+    {
       "type": "section",
       "id": "read-attributions",
       "title": "Read the Attributions tab",
       "blocks": [
-        {
-          "type": "markdown",
-          "content": "In this section, you'll open the Attributions tab and read how your spend is allocated across your configured labels."
-        },
         {
           "type": "interactive",
           "action": "navigate",

--- a/billing-usage-lj/attributions/content.json
+++ b/billing-usage-lj/attributions/content.json
@@ -1,0 +1,87 @@
+{
+  "id": "billing-usage-attributions",
+  "title": "Attribute spend to teams or services",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "Cost attribution breaks your Metrics, Logs, and Traces spend down by the labels you choose, so you can allocate observability costs to teams, services, or environments. The Attributions tab turns that label data into a per-owner cost breakdown you can review and export."
+    },
+    {
+      "type": "markdown",
+      "content": "Attribution data appears only after someone configures cost attribution labels for your organization, and historical data starts from when attribution was first enabled. This milestone focuses on reading the Attributions tab; if your stack has no labels configured yet, the steps that highlight attribution data won't apply. To set up labels, refer to [Attribute costs](https://grafana.com/docs/grafana-cloud/cost-management-and-billing/cost-attributions/)."
+    },
+    {
+      "type": "section",
+      "id": "read-attributions",
+      "title": "Read the Attributions tab",
+      "blocks": [
+        {
+          "type": "markdown",
+          "content": "In this section, you'll open the Attributions tab and read how your spend is allocated across your configured labels."
+        },
+        {
+          "type": "interactive",
+          "action": "navigate",
+          "reftarget": "/a/grafana-cmab-app/attributions/overview",
+          "content": "Open the **Attributions** tab of the Cost Management and Billing app.",
+          "verify": "on-page:/a/grafana-cmab-app/attributions"
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "button[data-testid='data-testid Tab Attributions']",
+          "content": "The **Attributions** tab shows usage and cost allocated to your configured attribution labels.",
+          "requirements": ["exists-reftarget", "on-page:/a/grafana-cmab-app/attributions"],
+          "doIt": false
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "h2:contains('Total Cost')",
+          "content": "The billing-period summary shows your **Total Cost** and a per-product breakdown across Metrics, Logs, Traces, and other products for the selected period.",
+          "requirements": ["exists-reftarget", "on-page:/a/grafana-cmab-app/attributions"],
+          "doIt": false,
+          "skippable": true
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "h3:contains('Telemetry Breakdown')",
+          "content": "The **Telemetry Breakdown** allocates cost to each label value, with an unattributed row for telemetry that's missing your labels. High unattributed cost points to gaps in your labeling.",
+          "requirements": ["exists-reftarget", "on-page:/a/grafana-cmab-app/attributions"],
+          "doIt": false,
+          "skippable": true
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "button:contains('Download (CSV)')",
+          "content": "Use **Download (CSV)** to export the breakdown for chargeback or financial reporting.",
+          "requirements": ["exists-reftarget", "on-page:/a/grafana-cmab-app/attributions"],
+          "doIt": false,
+          "skippable": true
+        },
+        {
+          "type": "markdown",
+          "content": "You opened the Attributions tab and read how your spend is allocated across teams or services."
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "To view attribution data, you need the permissions granted by the **Cost attribution reader** role. Refer to [Manage access to the Cost Management and Billing app](https://grafana.com/docs/grafana-cloud/cost-management-and-billing/set-up/cost-management-billing-rbac/)."
+    },
+    {
+      "type": "markdown",
+      "content": "When you read the breakdown, look for:\n\n- **Top spenders**: The teams or services with the highest attributed cost.\n- **Unattributed cost**: Telemetry without your labels, which hides who's responsible for that spend.\n- **Product mix**: Whether a team's cost comes mostly from metrics, logs, or traces.\n\nUse these insights to set budgets, route [usage alerts](https://grafana.com/docs/grafana-cloud/cost-management-and-billing/usage-cost-alerts/) to the responsible team, and improve labeling coverage."
+    },
+    {
+      "type": "markdown",
+      "content": "In the next milestone, you'll view and understand your Grafana Cloud invoice."
+    },
+    {
+      "type": "markdown",
+      "content": "---\n\n### More to explore (optional)\n\nAt this point in your journey, you can explore the following paths:\n\n- [Attribute costs](https://grafana.com/docs/grafana-cloud/cost-management-and-billing/cost-attributions/)\n- [View attribution reports](https://grafana.com/docs/grafana-cloud/cost-management-and-billing/cost-attributions/overview/)"
+    }
+  ]
+}

--- a/billing-usage-lj/attributions/content.json
+++ b/billing-usage-lj/attributions/content.json
@@ -1,87 +1,73 @@
 {
-  "id": "billing-usage-attributions",
-  "title": "Attribute spend to teams or services",
-  "blocks": [
-    {
-      "type": "markdown",
-      "content": "Cost attribution breaks your Metrics, Logs, and Traces spend down by the labels you choose, so you can allocate observability costs to teams, services, or environments. The Attributions tab turns that label data into a per-owner cost breakdown you can review and export."
-    },
-    {
-      "type": "markdown",
-      "content": "Attribution data appears only after someone configures cost attribution labels for your organization, and historical data starts from when attribution was first enabled. This milestone focuses on reading the Attributions tab; if your stack has no labels configured yet, the steps that highlight attribution data won't apply. To set up labels, refer to [Attribute costs](https://grafana.com/docs/grafana-cloud/cost-management-and-billing/cost-attributions/)."
-    },
-    {
-      "type": "markdown",
-      "content": "In this section, you'll open the Attributions tab and read how your spend is allocated across your configured labels."
-    },
-    {
-      "type": "section",
-      "id": "read-attributions",
-      "title": "Read the Attributions tab",
-      "blocks": [
-        {
-          "type": "interactive",
-          "action": "navigate",
-          "reftarget": "/a/grafana-cmab-app/attributions/overview",
-          "content": "Open the **Attributions** tab of the Cost Management and Billing app.",
-          "verify": "on-page:/a/grafana-cmab-app/attributions"
+    "id": "billing-usage-attributions",
+    "title": "Attribute spend to teams or services",
+    "blocks": [{
+            "type": "markdown",
+            "content": "Cost attribution breaks your Metrics, Logs, and Traces spend down by the labels you choose, so you can allocate observability costs to teams, services, or environments. The Attributions tab turns that label data into a per-owner cost breakdown you can review and export."
         },
         {
-          "type": "interactive",
-          "action": "highlight",
-          "reftarget": "button[data-testid='data-testid Tab Attributions']",
-          "content": "The **Attributions** tab shows usage and cost allocated to your configured attribution labels.",
-          "requirements": ["exists-reftarget", "on-page:/a/grafana-cmab-app/attributions"],
-          "doIt": false
+            "type": "markdown",
+            "content": "Attribution data appears only after someone configures cost attribution labels for your organization, and historical data starts from when attribution was first enabled. This milestone focuses on navigating the Attributions tab and reading how your spend is allocated across your configured labels; if your stack has no labels configured yet, the steps that highlight attribution data won't apply. To set up labels, refer to [Understand attribution labels](https://grafana.com/docs/grafana-cloud/cost-management-and-billing/cost-attributions/labels/)."
         },
         {
-          "type": "interactive",
-          "action": "highlight",
-          "reftarget": "h2:contains('Total Cost')",
-          "content": "The billing-period summary shows your **Total Cost** and a per-product breakdown across Metrics, Logs, Traces, and other products for the selected period.",
-          "requirements": ["exists-reftarget", "on-page:/a/grafana-cmab-app/attributions"],
-          "doIt": false,
-          "skippable": true
+            "type": "section",
+            "id": "read-attributions",
+            "title": "Read the Attributions tab",
+            "blocks": [{
+                    "type": "interactive",
+                    "action": "navigate",
+                    "reftarget": "/a/grafana-cmab-app/attributions/overview",
+                    "content": "Open the **Attributions** tab of the Cost Management and Billing app. The **Attributions** tab shows usage and cost allocated to your configured attribution labels.",
+                    "verify": "on-page:/a/grafana-cmab-app/attributions"
+                },
+                {
+                    "type": "interactive",
+                    "action": "highlight",
+                    "reftarget": "h2:contains('Total Cost')",
+                    "content": "The billing-period summary shows your **Total Cost** and a per-product breakdown across Metrics, Logs, Traces, and other products for the selected period.",
+                    "requirements": ["exists-reftarget", "on-page:/a/grafana-cmab-app/attributions"],
+                    "doIt": false,
+                    "skippable": true
+                },
+                {
+                    "type": "interactive",
+                    "action": "highlight",
+                    "reftarget": "h3:contains('Telemetry Breakdown')",
+                    "content": "The **Telemetry Breakdown** allocates cost to each label value, with an unattributed row for telemetry that's missing your labels. High unattributed cost points to gaps in your labeling.",
+                    "requirements": ["exists-reftarget", "on-page:/a/grafana-cmab-app/attributions"],
+                    "doIt": false,
+                    "skippable": true
+                },
+                {
+                    "type": "interactive",
+                    "action": "highlight",
+                    "reftarget": "button:contains('Download (CSV)')",
+                    "content": "Use **Download (CSV)** to export the breakdown for chargeback or financial reporting.",
+                    "requirements": ["exists-reftarget", "on-page:/a/grafana-cmab-app/attributions"],
+                    "doIt": false,
+                    "skippable": true
+                },
+                {
+                    "type": "markdown",
+                    "content": "You opened the Attributions tab and read how your spend is allocated across teams or services."
+                }
+            ]
         },
         {
-          "type": "interactive",
-          "action": "highlight",
-          "reftarget": "h3:contains('Telemetry Breakdown')",
-          "content": "The **Telemetry Breakdown** allocates cost to each label value, with an unattributed row for telemetry that's missing your labels. High unattributed cost points to gaps in your labeling.",
-          "requirements": ["exists-reftarget", "on-page:/a/grafana-cmab-app/attributions"],
-          "doIt": false,
-          "skippable": true
+            "type": "markdown",
+            "content": "To view attribution data, you need the permissions granted by the **Cost attribution reader** role. Refer to [Manage access to the Cost Management and Billing app](https://grafana.com/docs/grafana-cloud/cost-management-and-billing/set-up/cost-management-billing-rbac/)."
         },
         {
-          "type": "interactive",
-          "action": "highlight",
-          "reftarget": "button:contains('Download (CSV)')",
-          "content": "Use **Download (CSV)** to export the breakdown for chargeback or financial reporting.",
-          "requirements": ["exists-reftarget", "on-page:/a/grafana-cmab-app/attributions"],
-          "doIt": false,
-          "skippable": true
+            "type": "markdown",
+            "content": "When you read the breakdown, look for:\n\n- **Top spenders**: The teams or services with the highest attributed cost.\n- **Unattributed cost**: Telemetry without your labels, which hides who's responsible for that spend.\n- **Product mix**: Whether a team's cost comes mostly from metrics, logs, or traces.\n\nUse these insights to set budgets, route [usage alerts](https://grafana.com/docs/grafana-cloud/cost-management-and-billing/usage-cost-alerts/) to the responsible team, and improve labeling coverage."
         },
         {
-          "type": "markdown",
-          "content": "You opened the Attributions tab and read how your spend is allocated across teams or services."
+            "type": "markdown",
+            "content": "In the next milestone, you'll view and understand your Grafana Cloud invoice."
+        },
+        {
+            "type": "markdown",
+            "content": "---\n\n### More to explore (optional)\n\nAt this point in your journey, you can explore the following paths:\n\n- [Attribute costs](https://grafana.com/docs/grafana-cloud/cost-management-and-billing/cost-attributions/)\n- [View attribution reports](https://grafana.com/docs/grafana-cloud/cost-management-and-billing/cost-attributions/overview/)"
         }
-      ]
-    },
-    {
-      "type": "markdown",
-      "content": "To view attribution data, you need the permissions granted by the **Cost attribution reader** role. Refer to [Manage access to the Cost Management and Billing app](https://grafana.com/docs/grafana-cloud/cost-management-and-billing/set-up/cost-management-billing-rbac/)."
-    },
-    {
-      "type": "markdown",
-      "content": "When you read the breakdown, look for:\n\n- **Top spenders**: The teams or services with the highest attributed cost.\n- **Unattributed cost**: Telemetry without your labels, which hides who's responsible for that spend.\n- **Product mix**: Whether a team's cost comes mostly from metrics, logs, or traces.\n\nUse these insights to set budgets, route [usage alerts](https://grafana.com/docs/grafana-cloud/cost-management-and-billing/usage-cost-alerts/) to the responsible team, and improve labeling coverage."
-    },
-    {
-      "type": "markdown",
-      "content": "In the next milestone, you'll view and understand your Grafana Cloud invoice."
-    },
-    {
-      "type": "markdown",
-      "content": "---\n\n### More to explore (optional)\n\nAt this point in your journey, you can explore the following paths:\n\n- [Attribute costs](https://grafana.com/docs/grafana-cloud/cost-management-and-billing/cost-attributions/)\n- [View attribution reports](https://grafana.com/docs/grafana-cloud/cost-management-and-billing/cost-attributions/overview/)"
-    }
-  ]
+    ]
 }

--- a/billing-usage-lj/attributions/content.json
+++ b/billing-usage-lj/attributions/content.json
@@ -16,7 +16,7 @@
             "blocks": [{
                     "type": "interactive",
                     "action": "navigate",
-                    "reftarget": "/a/grafana-cmab-app/attributions/overview",
+                    "reftarget": "/a/grafana-cmab-app/attributions",
                     "content": "Open the **Attributions** tab of the Cost Management and Billing app. The **Attributions** tab shows usage and cost allocated to your configured attribution labels.",
                     "verify": "on-page:/a/grafana-cmab-app/attributions"
                 },

--- a/billing-usage-lj/attributions/manifest.json
+++ b/billing-usage-lj/attributions/manifest.json
@@ -1,0 +1,17 @@
+{
+  "id": "billing-usage-attributions",
+  "type": "guide",
+  "description": "Use the Attributions tab in the Cost Management and Billing app to allocate Grafana Cloud spend to teams, services, or environments.",
+  "category": "take-action",
+  "author": {
+    "name": "jtvdez",
+    "team": "Grafana Documentation"
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": ["billing-usage-identify-cost-sources"],
+  "recommends": ["billing-usage-invoices"],
+  "suggests": [],
+  "provides": []
+}

--- a/billing-usage-lj/attributions/website.yaml
+++ b/billing-usage-lj/attributions/website.yaml
@@ -1,0 +1,22 @@
+menuTitle: Attribute costs
+weight: 400
+step: 5
+layout: single-journey
+cta:
+  type: continue
+keywords:
+- billing
+- cost-attribution
+- cost-allocation
+- metrics
+- logs
+- traces
+side_journeys:
+  title: More to explore (optional)
+  heading: 'At this point in your journey, you can explore the following paths:'
+  items:
+  - title: Attribute costs
+    link: /docs/grafana-cloud/cost-management-and-billing/cost-attributions/
+  - title: View attribution reports
+    link: /docs/grafana-cloud/cost-management-and-billing/cost-attributions/overview/
+description: Learn how to use the Attributions tab to allocate your Grafana Cloud spend to teams, services, or environments using cost attribution labels.

--- a/billing-usage-lj/create-billing-alert/website.yaml
+++ b/billing-usage-lj/create-billing-alert/website.yaml
@@ -1,6 +1,6 @@
 menuTitle: Create alerts
-weight: 500
-step: 6
+weight: 700
+step: 8
 layout: single-journey
 cta:
   type: continue

--- a/billing-usage-lj/end-journey/website.yaml
+++ b/billing-usage-lj/end-journey/website.yaml
@@ -1,6 +1,6 @@
 menuTitle: Destination reached!
-weight: 600
-step: 7
+weight: 800
+step: 9
 layout: single-journey
 cta:
   type: conclusion

--- a/billing-usage-lj/identify-cost-sources/content.json
+++ b/billing-usage-lj/identify-cost-sources/content.json
@@ -1,77 +1,93 @@
 {
-  "id": "billing-usage-identify-cost-sources",
-  "title": "Identify the source of billable activity",
-  "blocks": [
-    {
-      "type": "markdown",
-      "content": "Understanding which products contribute to your monthly costs helps you make informed decisions about optimization and resource allocation. The Usage tab breaks your spend down by product so you can quickly find your largest cost drivers."
-    },
-    {
-      "type": "section",
-      "id": "find-cost-drivers",
-      "title": "Find your largest cost drivers",
-      "blocks": [
-        {
-          "type": "markdown",
-          "content": "In this section, you'll use the Usage tab to compare per-product cost and spot your biggest cost drivers."
+    "id": "billing-usage-identify-cost-sources",
+    "title": "Identify the source of billable activity",
+    "blocks": [{
+            "type": "markdown",
+            "content": "Understanding which products contribute to your monthly costs helps you make informed decisions about optimization and resource allocation. The Usage tab breaks your spend down by product so you can quickly find your largest cost drivers."
         },
         {
-          "type": "interactive",
-          "action": "navigate",
-          "reftarget": "/a/grafana-cmab-app/usage",
-          "content": "Open the **Usage** tab of the Cost Management and Billing app.",
-          "verify": "on-page:/a/grafana-cmab-app/usage"
+            "type": "section",
+            "id": "find-cost-drivers",
+            "title": "Find your largest cost drivers",
+            "blocks": [{
+                    "type": "markdown",
+                    "content": "In this section, you'll use the Usage tab to compare per-product cost and spot your biggest cost drivers."
+                },
+                {
+                    "type": "interactive",
+                    "action": "navigate",
+                    "reftarget": "/a/grafana-cmab-app/usage",
+                    "content": "Open the **Usage** tab of the Cost Management and Billing app.",
+                    "verify": "on-page:/a/grafana-cmab-app/usage"
+                },
+                {
+                    "type": "interactive",
+                    "action": "highlight",
+                    "reftarget": "h2:contains('Product Breakdown')",
+                    "content": "Scroll to the **Product Breakdown** section. It lists each billable product, such as Metrics, Logs, Traces, Profiles, and k6, with its current usage and cost. Compare the costs to find which products consume most of your budget. You can also compare the selected period against an earlier one to see how each product's spend is trending.",
+                    "requirements": ["exists-reftarget", "on-page:/a/grafana-cmab-app/usage"],
+                    "doIt": false
+                },
+                {
+                    "type": "interactive",
+                    "action": "highlight",
+                    "reftarget": "button[id='dropdown-trigger-month-to-date']",
+                    "content": "Use the **for** dropdown to choose the billing period you want to view, such as the current month to date.",
+                    "requirements": ["exists-reftarget", "on-page:/a/grafana-cmab-app/usage"],
+                    "doIt": false,
+                    "skippable": true
+                },
+                {
+                    "type": "interactive",
+                    "action": "highlight",
+                    "reftarget": "button[id='dropdown-trigger-month-to-date-last-month']",
+                    "content": "In the **compared with** dropdown, pick an a period to compare against. Each product row then shows its change versus that period, so you can spot where spend is rising or falling.",
+                    "requirements": ["exists-reftarget", "on-page:/a/grafana-cmab-app/usage"],
+                    "doIt": false,
+                    "skippable": true
+                },
+                {
+                    "type": "interactive",
+                    "action": "highlight",
+                    "reftarget": "button[data-testid='data-testid Tab Attributions']",
+                    "content": "Use the **Attributions** tab to break usage down by team or service, once you've configured cost attribution labels.",
+                    "requirements": ["exists-reftarget", "on-page:/a/grafana-cmab-app/usage"],
+                    "doIt": false
+                },
+                {
+                    "type": "interactive",
+                    "action": "highlight",
+                    "reftarget": "button[data-testid='data-testid Tab Cardinality']",
+                    "content": "Use the **Cardinality** tab to find high-cardinality metrics that inflate your metrics cost.",
+                    "requirements": ["exists-reftarget", "on-page:/a/grafana-cmab-app/usage"],
+                    "doIt": false
+                },
+                {
+                    "type": "markdown",
+                    "content": "You compared per-product cost in the Product Breakdown and found where to dig deeper with attributions and cardinality."
+                }
+            ]
         },
         {
-          "type": "interactive",
-          "action": "highlight",
-          "reftarget": "h2:contains('Product Breakdown')",
-          "content": "Scroll to the **Product Breakdown** section. It lists each billable product, such as Metrics, Logs, Traces, Profiles, and k6, with its current usage and cost. Compare the costs to find which products consume most of your budget.",
-          "requirements": ["exists-reftarget", "on-page:/a/grafana-cmab-app/usage"],
-          "doIt": false
+            "type": "image",
+            "src": "https://grafana.com/media/docs/learning-journey/billing-usage/product-breakdown.png",
+            "alt": "The Product Breakdown section of the Usage tab, showing overage and usage for each Grafana Cloud product"
         },
         {
-          "type": "interactive",
-          "action": "highlight",
-          "reftarget": "button[data-testid='data-testid Tab Attributions']",
-          "content": "Use the **Attributions** tab to break usage down by team or service, once you've configured cost attribution labels.",
-          "requirements": ["exists-reftarget", "on-page:/a/grafana-cmab-app/usage"],
-          "doIt": false
+            "type": "markdown",
+            "content": "When you compare products, look for:\n\n- **Primary cost drivers**: The products that consume most of your budget.\n- **Usage patterns**: Whether costs are steady or fluctuate significantly.\n- **Growth trends**: The products whose cost is increasing over time.\n\nFor example, a team running large load tests might find that k6 Virtual User Hours (VUh) is its primary cost driver, while a logging-heavy team sees Logs at the top."
         },
         {
-          "type": "interactive",
-          "action": "highlight",
-          "reftarget": "button[data-testid='data-testid Tab Cardinality']",
-          "content": "Use the **Cardinality** tab to find high-cardinality metrics that inflate your metrics cost.",
-          "requirements": ["exists-reftarget", "on-page:/a/grafana-cmab-app/usage"],
-          "doIt": false
+            "type": "markdown",
+            "content": "To attribute spend to teams or services, configure attribution labels first; refer to [Attribute costs](https://grafana.com/docs/grafana-cloud/cost-management-and-billing/cost-attributions/)."
         },
         {
-          "type": "markdown",
-          "content": "You compared per-product cost in the Product Breakdown and found where to dig deeper with attributions and cardinality."
+            "type": "markdown",
+            "content": "In the next milestone, you'll attribute this spend to the teams or services responsible for it."
+        },
+        {
+            "type": "markdown",
+            "content": "---\n\n### More to explore (optional)\n\nAt this point in your journey, you can explore the following paths:\n\n- [Attribute costs](https://grafana.com/docs/grafana-cloud/cost-management-and-billing/cost-attributions/)\n- [Analyze and reduce costs](https://grafana.com/docs/grafana-cloud/cost-management-and-billing/analyze-costs/)"
         }
-      ]
-    },
-    {
-      "type": "image",
-      "src": "https://grafana.com/media/docs/learning-journey/billing-usage/product-breakdown.png",
-      "alt": "The Product Breakdown section of the Usage tab, showing overage and usage for each Grafana Cloud product"
-    },
-    {
-      "type": "markdown",
-      "content": "When you compare products, look for:\n\n- **Primary cost drivers**: The products that consume most of your budget.\n- **Usage patterns**: Whether costs are steady or fluctuate significantly.\n- **Growth trends**: The products whose cost is increasing over time.\n\nFor example, a team running large load tests might find that k6 Virtual User Hours (VUh) is its primary cost driver, while a logging-heavy team sees Logs at the top."
-    },
-    {
-      "type": "markdown",
-      "content": "To attribute spend to teams or services, configure attribution labels first; refer to [Attribute costs](https://grafana.com/docs/grafana-cloud/cost-management-and-billing/cost-attributions/)."
-    },
-    {
-      "type": "markdown",
-      "content": "In the next milestone, you'll attribute this spend to the teams or services responsible for it."
-    },
-    {
-      "type": "markdown",
-      "content": "---\n\n### More to explore (optional)\n\nAt this point in your journey, you can explore the following paths:\n\n- [Attribute costs](https://grafana.com/docs/grafana-cloud/cost-management-and-billing/cost-attributions/)\n- [Analyze and reduce costs](https://grafana.com/docs/grafana-cloud/cost-management-and-billing/analyze-costs/)"
-    }
-  ]
+    ]
 }

--- a/billing-usage-lj/identify-cost-sources/content.json
+++ b/billing-usage-lj/identify-cost-sources/content.json
@@ -6,14 +6,14 @@
             "content": "Understanding which products contribute to your monthly costs helps you make informed decisions about optimization and resource allocation. The Usage tab breaks your spend down by product so you can quickly find your largest cost drivers."
         },
         {
+            "type": "markdown",
+            "content": "In this section, you'll use the Usage tab to compare per-product cost and spot your biggest cost drivers."
+        },
+        {
             "type": "section",
             "id": "find-cost-drivers",
             "title": "Find your largest cost drivers",
             "blocks": [{
-                    "type": "markdown",
-                    "content": "In this section, you'll use the Usage tab to compare per-product cost and spot your biggest cost drivers."
-                },
-                {
                     "type": "interactive",
                     "action": "navigate",
                     "reftarget": "/a/grafana-cmab-app/usage",
@@ -41,7 +41,7 @@
                     "type": "interactive",
                     "action": "highlight",
                     "reftarget": "button[id='dropdown-trigger-month-to-date-last-month']",
-                    "content": "In the **compared with** dropdown, pick an a period to compare against. Each product row then shows its change versus that period, so you can spot where spend is rising or falling.",
+                    "content": "In the **compared with** dropdown, pick a period to compare against. Each product row then shows its change versus that period, so you can spot where spend is rising or falling.",
                     "requirements": ["exists-reftarget", "on-page:/a/grafana-cmab-app/usage"],
                     "doIt": false,
                     "skippable": true

--- a/billing-usage-lj/identify-cost-sources/content.json
+++ b/billing-usage-lj/identify-cost-sources/content.json
@@ -87,7 +87,7 @@
         },
         {
             "type": "markdown",
-            "content": "---\n\n### More to explore (optional)\n\nAt this point in your journey, you can explore the following paths:\n\n- [Attribute costs](https://grafana.com/docs/grafana-cloud/cost-management-and-billing/cost-attributions/)\n- [Analyze and reduce costs](https://grafana.com/docs/grafana-cloud/cost-management-and-billing/analyze-costs/)"
+            "content": "---\n\n### More to explore (optional)\n\nAt this point in your journey, you can explore the following topics:\n\n- [Attribute costs](https://grafana.com/docs/grafana-cloud/cost-management-and-billing/cost-attributions/)\n- [Analyze and reduce costs](https://grafana.com/docs/grafana-cloud/cost-management-and-billing/analyze-costs/)"
         }
     ]
 }

--- a/billing-usage-lj/identify-cost-sources/content.json
+++ b/billing-usage-lj/identify-cost-sources/content.json
@@ -67,7 +67,7 @@
     },
     {
       "type": "markdown",
-      "content": "In the next milestone, you'll learn how these costs are calculated so you can make informed optimization decisions."
+      "content": "In the next milestone, you'll attribute this spend to the teams or services responsible for it."
     },
     {
       "type": "markdown",

--- a/billing-usage-lj/identify-cost-sources/manifest.json
+++ b/billing-usage-lj/identify-cost-sources/manifest.json
@@ -11,7 +11,7 @@
     "tier": "cloud"
   },
   "depends": ["billing-usage-navigate-to-billing-dashboard"],
-  "recommends": ["billing-usage-learn-cost-calculations"],
+  "recommends": ["billing-usage-attributions"],
   "suggests": [],
   "provides": []
 }

--- a/billing-usage-lj/invoices/content.json
+++ b/billing-usage-lj/invoices/content.json
@@ -53,7 +53,7 @@
         },
         {
             "type": "markdown",
-            "content": "---\n\n### More to explore (optional)\n\nAt this point in your journey, you can explore the following paths:\n\n- [Manage invoices](https://grafana.com/docs/grafana-cloud/cost-management-and-billing/manage-invoices/)\n- [Understand your Grafana Cloud invoice](https://grafana.com/docs/grafana-cloud/cost-management-and-billing/manage-invoices/understand-your-invoice/)"
+            "content": "---\n\n### More to explore (optional)\n\nAt this point in your journey, you can explore the following topics:\n\n- [Manage invoices](https://grafana.com/docs/grafana-cloud/cost-management-and-billing/manage-invoices/)\n- [Understand your Grafana Cloud invoice](https://grafana.com/docs/grafana-cloud/cost-management-and-billing/manage-invoices/understand-your-invoice/)"
         }
     ]
 }

--- a/billing-usage-lj/invoices/content.json
+++ b/billing-usage-lj/invoices/content.json
@@ -37,16 +37,8 @@
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "h2:contains('Invoices')",
-          "content": "Each row is one billing period. The columns show the invoice **ID**, **Amount**, **Amount Unpaid**, and the **Date Sent**, **Date Due**, and **Date Paid**. Check **Amount Unpaid** to spot invoices that still need payment.",
-          "requirements": ["exists-reftarget", "on-page:/a/grafana-cmab-app/invoices"],
-          "doIt": false
-        },
-        {
-          "type": "interactive",
-          "action": "highlight",
           "reftarget": "button:contains('Export usage data')",
-          "content": "Use **Export usage data (FOCUS)** to download usage data in the FinOps FOCUS format for external cost tooling.",
+          "content": "Each row is one billing period. The columns show the invoice **ID**, **Amount**, **Amount Unpaid**, and the **Date Sent**, **Date Due**, and **Date Paid**. Check **Amount Unpaid** to spot invoices that still need payment. Use **Export usage data (FOCUS)** to download usage data in the FinOps FOCUS format for external cost tooling.",
           "requirements": ["exists-reftarget", "on-page:/a/grafana-cmab-app/invoices"],
           "doIt": false,
           "skippable": true

--- a/billing-usage-lj/invoices/content.json
+++ b/billing-usage-lj/invoices/content.json
@@ -1,0 +1,77 @@
+{
+  "id": "billing-usage-invoices",
+  "title": "View and understand your invoice",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "The Invoices tab is a complete historical record of your Grafana Cloud billing. From one place you can review each monthly invoice, track what's paid, and download a PDF for your records."
+    },
+    {
+      "type": "markdown",
+      "content": "The invoices you see reflect your organization's real billing history, so a new or trial account may show few or no invoices. This milestone focuses on finding your way around the tab; the numbers you see depend on your own account."
+    },
+    {
+      "type": "section",
+      "id": "read-invoices",
+      "title": "Read your invoice history",
+      "blocks": [
+        {
+          "type": "markdown",
+          "content": "In this section, you'll open the Invoices tab and read your billing history."
+        },
+        {
+          "type": "interactive",
+          "action": "navigate",
+          "reftarget": "/a/grafana-cmab-app/invoices",
+          "content": "Open the **Invoices** tab of the Cost Management and Billing app.",
+          "verify": "on-page:/a/grafana-cmab-app/invoices"
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "button[data-testid='data-testid Tab Invoices']",
+          "content": "The **Invoices** tab lists your past and current invoices with their payment status.",
+          "requirements": ["exists-reftarget", "on-page:/a/grafana-cmab-app/invoices"],
+          "doIt": false
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "h2:contains('Invoices')",
+          "content": "Each row is one billing period. The columns show the invoice **ID**, **Amount**, **Amount Unpaid**, and the **Date Sent**, **Date Due**, and **Date Paid**. Check **Amount Unpaid** to spot invoices that still need payment.",
+          "requirements": ["exists-reftarget", "on-page:/a/grafana-cmab-app/invoices"],
+          "doIt": false
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "button:contains('Export usage data')",
+          "content": "Use **Export usage data (FOCUS)** to download usage data in the FinOps FOCUS format for external cost tooling.",
+          "requirements": ["exists-reftarget", "on-page:/a/grafana-cmab-app/invoices"],
+          "doIt": false,
+          "skippable": true
+        },
+        {
+          "type": "markdown",
+          "content": "You opened the Invoices tab and read your billing history and payment status."
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "To view invoices, you need the permissions granted by the **Invoice reader** role. Refer to [Manage access to the Cost Management and Billing app](https://grafana.com/docs/grafana-cloud/cost-management-and-billing/set-up/cost-management-billing-rbac/)."
+    },
+    {
+      "type": "markdown",
+      "content": "To download an invoice, find its row and click the link in the **Download** column. The invoice downloads as a PDF. Amounts shown for the current month are an estimate until the billing period closes."
+    },
+    {
+      "type": "markdown",
+      "content": "In the next milestone, you'll learn how your cost is calculated so the numbers on your invoice make sense."
+    },
+    {
+      "type": "markdown",
+      "content": "---\n\n### More to explore (optional)\n\nAt this point in your journey, you can explore the following paths:\n\n- [Manage invoices](https://grafana.com/docs/grafana-cloud/cost-management-and-billing/manage-invoices/)\n- [Understand your Grafana Cloud invoice](https://grafana.com/docs/grafana-cloud/cost-management-and-billing/manage-invoices/understand-your-invoice/)"
+    }
+  ]
+}

--- a/billing-usage-lj/invoices/content.json
+++ b/billing-usage-lj/invoices/content.json
@@ -10,14 +10,14 @@
             "content": "The invoices you see reflect your organization's real billing history, so a new or trial account may show few or no invoices. This milestone focuses on finding your way around the tab; the numbers you see depend on your own account."
         },
         {
+            "type": "markdown",
+            "content": "In this section, you'll open the Invoices tab and read your billing history."
+        },
+        {
             "type": "section",
             "id": "read-invoices",
             "title": "Read your invoice history",
             "blocks": [{
-                    "type": "markdown",
-                    "content": "In this section, you'll open the Invoices tab and read your billing history."
-                },
-                {
                     "type": "interactive",
                     "action": "navigate",
                     "reftarget": "/a/grafana-cmab-app/invoices",

--- a/billing-usage-lj/invoices/content.json
+++ b/billing-usage-lj/invoices/content.json
@@ -1,69 +1,59 @@
 {
-  "id": "billing-usage-invoices",
-  "title": "View and understand your invoice",
-  "blocks": [
-    {
-      "type": "markdown",
-      "content": "The Invoices tab is a complete historical record of your Grafana Cloud billing. From one place you can review each monthly invoice, track what's paid, and download a PDF for your records."
-    },
-    {
-      "type": "markdown",
-      "content": "The invoices you see reflect your organization's real billing history, so a new or trial account may show few or no invoices. This milestone focuses on finding your way around the tab; the numbers you see depend on your own account."
-    },
-    {
-      "type": "section",
-      "id": "read-invoices",
-      "title": "Read your invoice history",
-      "blocks": [
-        {
-          "type": "markdown",
-          "content": "In this section, you'll open the Invoices tab and read your billing history."
+    "id": "billing-usage-invoices",
+    "title": "View and understand your invoice",
+    "blocks": [{
+            "type": "markdown",
+            "content": "The Invoices tab is a complete historical record of your Grafana Cloud billing. From one place you can review each monthly invoice, track what's paid, and download a PDF for your records."
         },
         {
-          "type": "interactive",
-          "action": "navigate",
-          "reftarget": "/a/grafana-cmab-app/invoices",
-          "content": "Open the **Invoices** tab of the Cost Management and Billing app.",
-          "verify": "on-page:/a/grafana-cmab-app/invoices"
+            "type": "markdown",
+            "content": "The invoices you see reflect your organization's real billing history, so a new or trial account may show few or no invoices. This milestone focuses on finding your way around the tab; the numbers you see depend on your own account."
         },
         {
-          "type": "interactive",
-          "action": "highlight",
-          "reftarget": "button[data-testid='data-testid Tab Invoices']",
-          "content": "The **Invoices** tab lists your past and current invoices with their payment status.",
-          "requirements": ["exists-reftarget", "on-page:/a/grafana-cmab-app/invoices"],
-          "doIt": false
+            "type": "section",
+            "id": "read-invoices",
+            "title": "Read your invoice history",
+            "blocks": [{
+                    "type": "markdown",
+                    "content": "In this section, you'll open the Invoices tab and read your billing history."
+                },
+                {
+                    "type": "interactive",
+                    "action": "navigate",
+                    "reftarget": "/a/grafana-cmab-app/invoices",
+                    "content": "Open the **Invoices** tab of the Cost Management and Billing app. The **Invoices** tab lists your past and current invoices with their payment status",
+                    "verify": "on-page:/a/grafana-cmab-app/invoices"
+                },
+                {
+                    "type": "interactive",
+                    "action": "highlight",
+                    "reftarget": "button:contains('Export usage data')",
+                    "content": "Each row is one billing period. The columns show the invoice **ID**, **Amount**, **Amount Unpaid**, and the **Date Sent**, **Date Due**, and **Date Paid**. Check **Amount Unpaid** to spot invoices that still need payment. Use **Export usage data (FOCUS)** to download usage data in the FinOps FOCUS format for external cost tooling.",
+                    "requirements": ["exists-reftarget", "on-page:/a/grafana-cmab-app/invoices"],
+                    "doIt": false,
+                    "skippable": true
+                },
+                {
+                    "type": "markdown",
+                    "content": "You opened the Invoices tab and read your billing history and payment status."
+                }
+            ]
         },
         {
-          "type": "interactive",
-          "action": "highlight",
-          "reftarget": "button:contains('Export usage data')",
-          "content": "Each row is one billing period. The columns show the invoice **ID**, **Amount**, **Amount Unpaid**, and the **Date Sent**, **Date Due**, and **Date Paid**. Check **Amount Unpaid** to spot invoices that still need payment. Use **Export usage data (FOCUS)** to download usage data in the FinOps FOCUS format for external cost tooling.",
-          "requirements": ["exists-reftarget", "on-page:/a/grafana-cmab-app/invoices"],
-          "doIt": false,
-          "skippable": true
+            "type": "markdown",
+            "content": "To view invoices, you need the permissions granted by the **Invoice reader** role. Refer to [Manage access to the Cost Management and Billing app](https://grafana.com/docs/grafana-cloud/cost-management-and-billing/set-up/cost-management-billing-rbac/)."
         },
         {
-          "type": "markdown",
-          "content": "You opened the Invoices tab and read your billing history and payment status."
+            "type": "markdown",
+            "content": "To download an invoice, find its row and click the link in the **Download** column. The invoice downloads as a PDF. Amounts shown for the current month are an estimate until the billing period closes."
+        },
+        {
+            "type": "markdown",
+            "content": "In the next milestone, you'll learn how your cost is calculated so the numbers on your invoice make sense."
+        },
+        {
+            "type": "markdown",
+            "content": "---\n\n### More to explore (optional)\n\nAt this point in your journey, you can explore the following paths:\n\n- [Manage invoices](https://grafana.com/docs/grafana-cloud/cost-management-and-billing/manage-invoices/)\n- [Understand your Grafana Cloud invoice](https://grafana.com/docs/grafana-cloud/cost-management-and-billing/manage-invoices/understand-your-invoice/)"
         }
-      ]
-    },
-    {
-      "type": "markdown",
-      "content": "To view invoices, you need the permissions granted by the **Invoice reader** role. Refer to [Manage access to the Cost Management and Billing app](https://grafana.com/docs/grafana-cloud/cost-management-and-billing/set-up/cost-management-billing-rbac/)."
-    },
-    {
-      "type": "markdown",
-      "content": "To download an invoice, find its row and click the link in the **Download** column. The invoice downloads as a PDF. Amounts shown for the current month are an estimate until the billing period closes."
-    },
-    {
-      "type": "markdown",
-      "content": "In the next milestone, you'll learn how your cost is calculated so the numbers on your invoice make sense."
-    },
-    {
-      "type": "markdown",
-      "content": "---\n\n### More to explore (optional)\n\nAt this point in your journey, you can explore the following paths:\n\n- [Manage invoices](https://grafana.com/docs/grafana-cloud/cost-management-and-billing/manage-invoices/)\n- [Understand your Grafana Cloud invoice](https://grafana.com/docs/grafana-cloud/cost-management-and-billing/manage-invoices/understand-your-invoice/)"
-    }
-  ]
+    ]
 }

--- a/billing-usage-lj/invoices/manifest.json
+++ b/billing-usage-lj/invoices/manifest.json
@@ -1,0 +1,17 @@
+{
+  "id": "billing-usage-invoices",
+  "type": "guide",
+  "description": "Use the Invoices tab in the Cost Management and Billing app to review your billing history, track payment status, and download invoices.",
+  "category": "take-action",
+  "author": {
+    "name": "jtvdez",
+    "team": "Grafana Documentation"
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": ["billing-usage-attributions"],
+  "recommends": ["billing-usage-learn-cost-calculations"],
+  "suggests": [],
+  "provides": []
+}

--- a/billing-usage-lj/invoices/website.yaml
+++ b/billing-usage-lj/invoices/website.yaml
@@ -1,0 +1,21 @@
+menuTitle: View invoices
+weight: 500
+step: 6
+layout: single-journey
+cta:
+  type: continue
+keywords:
+- billing
+- invoices
+- billing-history
+- payment-status
+- Grafana Cloud
+side_journeys:
+  title: More to explore (optional)
+  heading: 'At this point in your journey, you can explore the following paths:'
+  items:
+  - title: Manage invoices
+    link: /docs/grafana-cloud/cost-management-and-billing/manage-invoices/
+  - title: Understand your Grafana Cloud invoice
+    link: /docs/grafana-cloud/cost-management-and-billing/manage-invoices/understand-your-invoice/
+description: Learn how to use the Invoices tab to review your Grafana Cloud billing history, track payment status, and download invoices.

--- a/billing-usage-lj/learn-cost-calculations/content.json
+++ b/billing-usage-lj/learn-cost-calculations/content.json
@@ -1,42 +1,41 @@
 {
-  "id": "billing-usage-learn-cost-calculations",
-  "title": "Learn how your cost is calculated",
-  "blocks": [
-    {
-      "type": "markdown",
-      "content": "Grafana Cloud uses different billing methodologies depending on the product to offer predictable pricing. Understanding these methods helps you read the Usage tab and decide where to optimize."
-    },
-    {
-      "type": "markdown",
-      "content": "## 95th percentile billing for metrics\n\nGrafana Cloud meters metrics on two components:\n\n- **Active series**: Unique time series that have received a data point within the last 20 minutes.\n- **Data points per minute (DPM)**: How frequently data is sent to Grafana Cloud.\n\nYour billable metrics usage is the maximum of either active series or total DPM normalized by the included DPM per series:\n\n`usage = max(active_series, total_dpm / included_dpm)`\n\nGrafana Cloud Pro includes 1 DPM per active series. If your average DPM per active series exceeds that, billing is based on total DPM."
-    },
-    {
-      "type": "markdown",
-      "content": "### The 95th percentile advantage\n\nGrafana Cloud bills metrics on the 95th percentile of usage across the billing period, which:\n\n- Forgives temporary spikes during incidents or deployments.\n- Provides predictable monthly costs based on typical usage.\n- Ignores the top 5% of usage time each month (approximately 36 hours).\n\nSo if you normally run 6,000 active series but spike to 30,000 for 24 hours in a month, you're still billed near the 6,000 series rate."
-    },
-    {
-      "type": "markdown",
-      "content": "### Scrape interval impact on costs\n\nYour scrape interval directly affects DPM and cost:\n\n- **15-second interval**: 4 data points per minute (higher cost)\n- **30-second interval**: 2 data points per minute (medium cost)\n- **60-second interval**: 1 data point per minute (lower cost)\n\nA common approach is to use a 1-minute scrape interval as the global default and only increase frequency for jobs that need higher resolution. Refer to [Reduce metrics costs by adjusting your data points per minute (DPM)](https://grafana.com/docs/grafana-cloud/cost-management-and-billing/analyze-costs/reduce-costs/metrics-costs/adjust-data-points-per-minute/)."
-    },
-    {
-      "type": "markdown",
-      "content": "## Volume-based billing for logs, traces, and profiles\n\nGrafana Cloud Logs, Traces, and Profiles share a usage model based on the volume of data, measured across three units:\n\n- **Process**: Data received and optimized as it arrives.\n- **Write**: Data ingested and stored.\n- **Retain**: Data kept beyond the included retention window.\n\nFor the full breakdown, refer to [Understand your Grafana Cloud Logs, Traces, and Profiles invoices](https://grafana.com/docs/grafana-cloud/cost-management-and-billing/manage-invoices/understand-your-invoice/logs-invoice/)."
-    },
-    {
-      "type": "markdown",
-      "content": "## Specialized product billing\n\nOther products have tailored billing models:\n\n- **Application Observability**: Billed by host hours. Refer to [Understand your Application Observability invoice](https://grafana.com/docs/grafana-cloud/cost-management-and-billing/manage-invoices/understand-your-invoice/application-observability-invoice/).\n- **Frontend Observability**: Billed by ingested sessions. Refer to [Understand your Frontend Observability invoice](https://grafana.com/docs/grafana-cloud/cost-management-and-billing/manage-invoices/understand-your-invoice/frontend-observability-invoice/).\n- **Incident Response & Management (IRM)**: Billed by monthly active users. Refer to [Understand your Grafana Cloud IRM invoice](https://grafana.com/docs/grafana-cloud/cost-management-and-billing/manage-invoices/understand-your-invoice/irm-invoice/).\n- **Kubernetes Monitoring**: Billed by host hours and container hours. Refer to [Understand your Kubernetes Monitoring invoice](https://grafana.com/docs/grafana-cloud/cost-management-and-billing/manage-invoices/understand-your-invoice/kubernetes-monitoring-invoice/).\n- **Synthetic Monitoring**: Billed by test executions. Refer to [Understand your Synthetic Monitoring invoice](https://grafana.com/docs/grafana-cloud/cost-management-and-billing/manage-invoices/understand-your-invoice/synthetic-monitoring-invoice/).\n- **Performance Testing (k6)**: Billed by Virtual User Hours (VUh). Refer to [Understand your Performance Testing invoice](https://grafana.com/docs/grafana-cloud/cost-management-and-billing/manage-invoices/understand-your-invoice/performance-testing-invoice/)."
-    },
-    {
-      "type": "markdown",
-      "content": "## Optimization strategies\n\nUnderstanding billing helps you optimize cost:\n\n- Apply Adaptive Telemetry recommendations to drop low-value data.\n- Use the **Cardinality** tab to find high-cost metrics.\n- Adjust scrape intervals based on actual monitoring needs.\n- Review unused metrics for potential removal.\n\nFor more, refer to [Adaptive Telemetry](https://grafana.com/docs/grafana-cloud/adaptive-telemetry/) and [Analyze and reduce costs](https://grafana.com/docs/grafana-cloud/cost-management-and-billing/analyze-costs/)."
-    },
-    {
-      "type": "markdown",
-      "content": "In the next milestone, you'll create a usage alert to proactively monitor your Grafana Cloud costs."
-    },
-    {
-      "type": "markdown",
-      "content": "---\n\n### More to explore (optional)\n\nAt this point in your journey, you can explore the following paths:\n\n- [Reduce metrics costs by adjusting your data points per minute (DPM)](https://grafana.com/docs/grafana-cloud/cost-management-and-billing/analyze-costs/reduce-costs/metrics-costs/adjust-data-points-per-minute/)\n- [Analyze metrics usage with cardinality management dashboards](https://grafana.com/docs/grafana-cloud/cost-management-and-billing/analyze-costs/metrics-costs/prometheus-metrics-costs/cardinality-management/)\n- [Understand your Grafana Cloud Metrics invoice](https://grafana.com/docs/grafana-cloud/cost-management-and-billing/manage-invoices/understand-your-invoice/metrics-invoice/)\n- [Understand your Grafana Cloud Logs, Traces, and Profiles invoices](https://grafana.com/docs/grafana-cloud/cost-management-and-billing/manage-invoices/understand-your-invoice/logs-invoice/)"
-    }
-  ]
+    "id": "billing-usage-learn-cost-calculations",
+    "title": "Learn how your cost is calculated",
+    "blocks": [{
+            "type": "markdown",
+            "content": "Grafana Cloud uses different billing methodologies depending on the product to offer predictable pricing. Understanding these methods helps you read the Usage tab and decide where to optimize."
+        },
+        {
+            "type": "markdown",
+            "content": "## 95th percentile billing for metrics\n\nGrafana Cloud meters metrics on two components:\n\n- **Active series**: Unique time series that have received a data point within the last 20 minutes.\n- **Data points per minute (DPM)**: How frequently data is sent to Grafana Cloud.\n\nYour billable metrics usage is the maximum of either active series or total DPM normalized by the included DPM per series:\n\n`usage = max(active_series, total_dpm / included_dpm)`\n\nGrafana Cloud Pro includes 1 DPM per active series. If your average DPM per active series exceeds that, billing is based on total DPM."
+        },
+        {
+            "type": "markdown",
+            "content": "### The 95th percentile advantage\n\nGrafana Cloud bills metrics on the 95th percentile of usage across the billing period, which:\n\n- Forgives temporary spikes during incidents or deployments.\n- Provides predictable monthly costs based on typical usage.\n- Ignores the top 5% of usage time each month (approximately 36 hours).\n\nSo if you normally run 6,000 active series but spike to 30,000 for 24 hours in a month, you're still billed near the 6,000 series rate."
+        },
+        {
+            "type": "markdown",
+            "content": "### Scrape interval impact on costs\n\nYour scrape interval directly affects DPM and cost:\n\n- **15-second interval**: 4 data points per minute (higher cost)\n- **30-second interval**: 2 data points per minute (medium cost)\n- **60-second interval**: 1 data point per minute (lower cost)\n\nA common approach is to use a 1-minute scrape interval as the global default and only increase frequency for jobs that need higher resolution. Refer to [Reduce metrics costs by adjusting your data points per minute (DPM)](https://grafana.com/docs/grafana-cloud/cost-management-and-billing/analyze-costs/reduce-costs/metrics-costs/adjust-data-points-per-minute/)."
+        },
+        {
+            "type": "markdown",
+            "content": "## Volume-based billing for logs, traces, and profiles\n\nGrafana Cloud Logs, Traces, and Profiles share a usage model based on the volume of data, measured across three units:\n\n- **Process**: Data received and optimized as it arrives.\n- **Write**: Data ingested and stored.\n- **Retain**: Data kept beyond the included retention window.\n\nFor the full breakdown, refer to [Understand your Grafana Cloud Logs, Traces, and Profiles invoices](https://grafana.com/docs/grafana-cloud/cost-management-and-billing/manage-invoices/understand-your-invoice/logs-invoice/)."
+        },
+        {
+            "type": "markdown",
+            "content": "## Specialized product billing\n\nOther products have tailored billing models:\n\n- **Application Observability**: Billed by host hours. Refer to [Understand your Application Observability invoice](https://grafana.com/docs/grafana-cloud/cost-management-and-billing/manage-invoices/understand-your-invoice/application-observability-invoice/).\n- **Frontend Observability**: Billed by ingested sessions. Refer to [Understand your Frontend Observability invoice](https://grafana.com/docs/grafana-cloud/cost-management-and-billing/manage-invoices/understand-your-invoice/frontend-observability-invoice/).\n- **Incident Response & Management (IRM)**: Billed by monthly active users. Refer to [Understand your Grafana Cloud IRM invoice](https://grafana.com/docs/grafana-cloud/cost-management-and-billing/manage-invoices/understand-your-invoice/irm-invoice/).\n- **Kubernetes Monitoring**: Billed by host hours and container hours. Refer to [Understand your Kubernetes Monitoring invoice](https://grafana.com/docs/grafana-cloud/cost-management-and-billing/manage-invoices/understand-your-invoice/kubernetes-monitoring-invoice/).\n- **Synthetic Monitoring**: Billed by test executions. Refer to [Understand your Synthetic Monitoring invoice](https://grafana.com/docs/grafana-cloud/cost-management-and-billing/manage-invoices/understand-your-invoice/synthetic-monitoring-invoice/).\n- **Performance Testing (k6)**: Billed by Virtual User Hours (VUh). Refer to [Understand your Performance Testing invoice](https://grafana.com/docs/grafana-cloud/cost-management-and-billing/manage-invoices/understand-your-invoice/performance-testing-invoice/)."
+        },
+        {
+            "type": "markdown",
+            "content": "## Optimization strategies\n\nUnderstanding billing helps you optimize cost:\n\n- Apply Adaptive Telemetry recommendations to drop low-value data.\n- Use the **Cardinality** tab to find high-cost metrics.\n- Adjust scrape intervals based on actual monitoring needs.\n- Review unused metrics for potential removal.\n\nFor more, refer to [Adaptive Telemetry](https://grafana.com/docs/grafana-cloud/adaptive-telemetry/) and [Analyze and reduce costs](https://grafana.com/docs/grafana-cloud/cost-management-and-billing/analyze-costs/)."
+        },
+        {
+            "type": "markdown",
+            "content": "In the next milestone, you'll create a usage alert to proactively monitor your Grafana Cloud costs."
+        },
+        {
+            "type": "markdown",
+            "content": "---\n\n### More to explore (optional)\n\nAt this point in your journey, you can explore the following topics:\n\n- [Reduce metrics costs by adjusting your data points per minute (DPM)](https://grafana.com/docs/grafana-cloud/cost-management-and-billing/analyze-costs/reduce-costs/metrics-costs/adjust-data-points-per-minute/)\n- [Analyze metrics usage with cardinality management dashboards](https://grafana.com/docs/grafana-cloud/cost-management-and-billing/analyze-costs/metrics-costs/prometheus-metrics-costs/cardinality-management/)\n- [Understand your Grafana Cloud Metrics invoice](https://grafana.com/docs/grafana-cloud/cost-management-and-billing/manage-invoices/understand-your-invoice/metrics-invoice/)\n- [Understand your Grafana Cloud Logs, Traces, and Profiles invoices](https://grafana.com/docs/grafana-cloud/cost-management-and-billing/manage-invoices/understand-your-invoice/logs-invoice/)"
+        }
+    ]
 }

--- a/billing-usage-lj/learn-cost-calculations/manifest.json
+++ b/billing-usage-lj/learn-cost-calculations/manifest.json
@@ -10,7 +10,7 @@
   "testEnvironment": {
     "tier": "cloud"
   },
-  "depends": ["billing-usage-identify-cost-sources"],
+  "depends": ["billing-usage-invoices"],
   "recommends": ["billing-usage-create-billing-alert"],
   "suggests": [],
   "provides": []

--- a/billing-usage-lj/learn-cost-calculations/website.yaml
+++ b/billing-usage-lj/learn-cost-calculations/website.yaml
@@ -1,6 +1,6 @@
 menuTitle: Learn cost calculations
-weight: 400
-step: 5
+weight: 600
+step: 7
 layout: single-journey
 cta:
   type: continue

--- a/billing-usage-lj/manifest.json
+++ b/billing-usage-lj/manifest.json
@@ -29,7 +29,6 @@
     "tier": "cloud"
   },
   "milestones": [
-    "billing-usage-business-value",
     "billing-usage-navigate-to-billing-dashboard",
     "billing-usage-identify-cost-sources",
     "billing-usage-attributions",

--- a/billing-usage-lj/manifest.json
+++ b/billing-usage-lj/manifest.json
@@ -29,14 +29,17 @@
     "tier": "cloud"
   },
   "milestones": [
+    "billing-usage-business-value",
     "billing-usage-navigate-to-billing-dashboard",
     "billing-usage-identify-cost-sources",
+    "billing-usage-attributions",
+    "billing-usage-invoices",
     "billing-usage-learn-cost-calculations",
     "billing-usage-create-billing-alert",
     "billing-usage-end-journey"
   ],
   "depends": [],
   "recommends": [],
-  "suggests": [],
+  "suggests": ["adaptive-metrics-lj"],
   "provides": []
 }


### PR DESCRIPTION
TEST IN OPS or another stack that has labels configured for attribution (or test in learn and Ops to get both uses cases)

Adds two new milestones to the billing and usage learning journey to match the current Cost Management and Billing app: Attributions and Invoices. Closes https://github.com/grafana/interactive-tutorials/issues/401.

Attribute spend to teams or services. opens the Attributions tab and walks through reading the cost breakdown. label/data dependent steps are skippable so the guide degrades gracefully on stacks without attribution labels configured.

View and understand your invoice opens the Invoices tab and covers reading invoice history (ID, Amount, Amount Unpaid, and date columns), spotting unpaid invoices, and the Export usage data (FOCUS) button.

Both milestones slot in after Identify cost sources, with dependency chains, step numbers, and website weights updated across the path. All selectors were verified against a live stack via the PR tester.


I think this is correct: this intentionally does not add `billing-usage-business-value` to the manifest `milestones` array because per `docs/website-yaml-reference.md` intro pages are deliberately website-only and excluded from the in-product Pathfinder milestones

