### PR TITLE
Align LP review skill with documented :contains() fallback

### DIFF
--- a/.cursor/skills/audit-guide/severity-rubric.md
+++ b/.cursor/skills/audit-guide/severity-rubric.md
@@ -12,7 +12,8 @@ A blocking finding means the guide either **fails at runtime** or **violates a c
 |-------|----------|
 | Structural | Invalid JSON; unknown block type; unknown action; missing required field (`reftarget` on non-noop/non-popout, `targetvalue` on `popout`); `popout` `targetvalue` not `"sidebar"` or `"floating"`; `schemaVersion` set to something other than `"1.1.0"` |
 | Structural | Critical rules 4, 17, 19, 21 violations (multistep singleton, focus-before-formfill, `popout` validation, lazy-render missing) |
-| Semantic | Critical rules 1, 2, 3, 6, 7, 13 violations (missing `navmenu-open`, fragile selectors, leading markdown title, markdown headers in place of sections, missing page requirements, `doIt: true` on secret fields) |
+| Semantic | Critical rules 1, 3, 6, 7, 13 violations (missing `navmenu-open`, leading markdown title, markdown headers in place of sections, missing page requirements, `doIt: true` on secret fields) |
+| Semantic | Rule 2 — CSS-class-only or auto-generated class selectors with no semantic fallback |
 | Semantic | Dangling `section-completed:<id>` (referenced section does not exist) |
 | Semantic | Dangling `var-<name>` requirement (no upstream `input` block defines the variable) |
 | Semantic | First-action page anchor missing — first interactive step has no `on-page` requirement and is not a `navigate` action |
@@ -33,6 +34,7 @@ A warning finding means the guide **degrades user experience** but does not hard
 | Structural | `validateInput: true` without `formHint` (silent rejection on bad input) |
 | Structural | Missing `verify` on a state-changing action (save, create, navigate) |
 | Semantic | Critical rules 8, 9, 10, 11, 12, 14, 15, 16 violations (missing verify on state changes, prose verbosity, button word usage, weak requirement→objective chain, tooltip naming the element, no section bookends, button-word bolding, non-skippable conditional steps) |
+| Semantic | Rule 2 — `:contains()` / `:has()` text-match selectors when [docs/selectors-and-testids.md](../../../docs/selectors-and-testids.md) priority 3–4 is the appropriate fallback (no stable `data-testid` in context). LP review skill may downgrade further when Pathfinder passes. |
 | Semantic | Tooltip > 250 chars or multi-sentence |
 | Semantic | Tooltip names the highlighted element (e.g., "Click the **Save** button" when the button is already highlighted) |
 | Semantic | Code smell from best-practices.mdc §6 not already covered above |

--- a/.cursor/skills/review-learning-path/SKILL.md
+++ b/.cursor/skills/review-learning-path/SKILL.md
@@ -278,7 +278,8 @@ If `.cursor/pr-review-state/pr-{n}.json` exists, read `phase` and `status`. Tell
 
 Write `pr-{n}-findings.md` using [finding severity routing](reference-checks.md#finding-severity-routing):
 
-- **Merge blockers (always inline)** — dedupe by root cause; static + any Phase 5–6 failures if live testing already ran
+- **Runtime blockers (always inline)** — dedupe by root cause; Phase 5–6 failures; manifest/depends/framing breaks; selector fails live
+- **Selector notes** — audit rule 2 / `:contains()` findings; apply [selector decision tree](reference-checks.md#selector-decision-tree) — body-only when Pathfinder passed and fallback is justified
 - **Live-test candidates** — selectors and milestones for Playwright + Pathfinder
 - **Defer until after Pathfinder** — findings in the **Defer** column only
 - **Review body only** — companion website, CODEOWNERS, editorial, passed-milestone notes
@@ -445,16 +446,31 @@ Start only after setup **ready**. For each milestone in path `milestones` (skip 
 
 1. Re-fetch PR HEAD if author may have pushed; reconcile resolved threads.
 2. From `pr-{n}-findings.md`, promote **Defer** items to inline only if Phase 5–6 failed; drop deferred items Pathfinder passed.
-3. Dedupe to [one comment per root cause](reference-checks.md#one-comment-per-root-cause) before posting.
-4. Add inline comments via GraphQL `addPullRequestReviewComment` — **Always inline** + runtime failures only.
-5. Merge Playwright + Pathfinder evidence, and merge code fix + runtime symptom when they share a root cause (never two inline threads on the same file for the same bug).
-6. Write `.cursor/pr-review-state/pr-{n}-review-body.md` with **Review body only** findings, passed milestones, and retest notes. List all merge blockers under one **Must fix before merge** section (no split "should fix" tier for **Always inline** items). Apply the [generated-file frontmatter](SKILL.md#generated-files).
-7. Recommend a default [verdict](reference-checks.md#verdict-selection-phases-89) from findings (`REQUEST_CHANGES`, `COMMENT`, or `APPROVE`) with a one-sentence reason. Store in state: `"recommended_verdict"`.
-8. Update state: `comment_count`, `"phase": 7`.
+3. Re-tag audit-only `:contains()` findings with the [selector decision tree](reference-checks.md#selector-decision-tree) — do **not** inline when Pathfinder passed and no stable selector exists in DOM.
+4. Dedupe to [one comment per root cause](reference-checks.md#one-comment-per-root-cause) before posting.
+5. Add inline comments via GraphQL `addPullRequestReviewComment` — **Always inline** + runtime failures only. **Ask the reviewer to confirm** before inlining any finding that is audit-only (no live failure).
+6. Merge Playwright + Pathfinder evidence, and merge code fix + runtime symptom when they share a root cause (never two inline threads on the same file for the same bug).
+7. Write `.cursor/pr-review-state/pr-{n}-review-body.md` with **Review body only** findings, passed milestones, and retest notes. List runtime merge blockers under **Must fix before merge**; put justified `:contains()` fallbacks and selector polish under **Optional follow-ups**. Apply the [generated-file frontmatter](SKILL.md#generated-files).
+8. Recommend a default [verdict](reference-checks.md#verdict-selection-phases-89) from findings (`REQUEST_CHANGES`, `COMMENT`, or `APPROVE`) with a one-sentence reason. If all Pathfinder milestones passed and no runtime blockers remain, default to **COMMENT** or **APPROVE**, not REQUEST_CHANGES. Store in state: `"recommended_verdict"`.
+9. Update state: `comment_count`, `"phase": 7`.
 
-**Example inline tone:**
+### Comment tone (required)
 
-> **Blocker** — verified on `learn.grafana.net` @ `{sha}` (Playwright DOM + Pathfinder PR review tool). …
+Write like a human reviewer, not an audit dump.
+
+- Lead with what you tested and the outcome (pass/fail), not rule numbers.
+- Use **Blocker** only for runtime failures or broken manifest/depends/framing — not for audit-only `:contains()` when Pathfinder passed.
+- For selector polish: one plain sentence; link [docs/selectors-and-testids.md](../../../docs/selectors-and-testids.md) when relevant; default to **review body**, not inline, when the step passed live.
+- Do **not** use a fixed template such as `verified on learn.grafana.net @ {sha} (Playwright DOM + Pathfinder PR review tool)` on every comment — mention the host/sha once in the review body if useful.
+- Acknowledge author context when known (e.g. test IDs tried first and failed).
+
+**Bad (canned):**
+
+> **Blocker** — verified on `learn.grafana.net` @ `934a2c3` (Playwright DOM + Pathfinder PR review tool). Replace `h2:contains('Total Cost')`…
+
+**Good (human):**
+
+> This step passed on learn, but if you have a `data-testid` on this heading from Block Editor, prefer that over `:contains()` — otherwise the current selector matches our fallback order in the selectors doc.
 
 ### Checkpoint
 

--- a/.cursor/skills/review-learning-path/reference-checks.md
+++ b/.cursor/skills/review-learning-path/reference-checks.md
@@ -4,6 +4,8 @@ Detailed checklists referenced from [SKILL.md](SKILL.md). The agent uses these d
 
 **Note:** [finding severity routing](#finding-severity-routing) supersedes [audit-guide/severity-rubric.md](../audit-guide/severity-rubric.md) for this workflow. audit-guide blocking/warning/info labels from Phase 1 are inputs only — re-tag before Phase 7.
 
+**Selector authority for LP reviews:** Follow [docs/selectors-and-testids.md](../../../docs/selectors-and-testids.md) priority order (`data-testid` > semantic > `:contains()` > `:has()` > CSS classes). Do **not** apply [build-interactive-lj/reference/selector-patterns.md](../../commands/build-interactive-lj/reference/selector-patterns.md) autogen rules ("never `:contains()`") when reviewing hand-authored or live-captured guides — that workflow targets source-to-guide generation, not PR review.
+
 ---
 
 ## Finding severity routing
@@ -14,18 +16,42 @@ Use this table when writing `pr-{n}-findings.md` (Phase 3) and when deciding inl
 |---|---|---|
 | Playwright / Pathfinder runtime fail | Section bookends (rule 14) | Companion website drift |
 | Outdated `data-testid` / UI label (valid pattern, wrong target) | `on-page` when step might still run | Passed milestones + deferred nits |
-| Broken `depends` chain or framing in path `milestones` | `lazyRender` when target might scroll into view | Fresh-stack retest notes (N/A on credentialed stack) |
-| First hands-on `depends` references framing ID | Skippable flag when step is permission-gated and passed | Pathfinder app shell UX |
+| `:contains()` when stable `data-testid` or semantic attr verified in DOM | `lazyRender` when target might scroll into view | `:contains()` fallback per [selectors doc](../../../docs/selectors-and-testids.md) when Pathfinder passed and no stable selector exists |
+| Broken `depends` chain or framing in path `milestones` | Skippable flag when step is permission-gated and passed | Fresh-stack retest notes (N/A on credentialed stack) |
+| First hands-on `depends` references framing ID | Admin-only steps without `skippable` if step passed | Pathfinder app shell UX |
 | Missing `exists-reftarget`, `navmenu-open` | Missing `verify` if save step passed live | Editorial / tooltip / vocabulary |
-| Fragile selectors | Admin-only steps without `skippable` if step passed | CODEOWNERS reminder |
-| `noop` misuse, multistep singleton, focus-before-formfill | — | — |
-| Missing `startingLocation` on interactive milestone | Missing objectives when resource already exists | Audit-guide warnings with no runtime impact |
-| Pathfinder CLI validate failure | — | Product UX not fixable in JSON |
+| CSS-class-only or auto-generated class selectors | — | Audit-guide warnings with no runtime impact |
+| `noop` misuse, multistep singleton, focus-before-formfill | — | CODEOWNERS reminder |
+| Missing `startingLocation` on interactive milestone | Missing objectives when resource already exists | Product UX not fixable in JSON |
+| Pathfinder CLI validate failure | — | — |
 | `index.json` modified, invalid `testEnvironment.tier` | — | — |
 | Secrets auto-filled (`doIt: true`) | — | — |
 | Path root / manifest `id` mismatch | — | — |
 
-**After Pathfinder:** promote deferred items to inline only if live test failed or static issue is clearly wrong regardless of runtime (e.g. fragile selector that happened to match today).
+**After Pathfinder:** promote deferred items to inline only if live test failed or static issue is clearly wrong regardless of runtime (e.g. author used `:contains()` when Playwright confirmed a `data-testid` on the same element).
+
+### Selector decision tree
+
+Apply after Phase 5–6 when re-tagging audit-guide rule 2 / "fragile selector" findings:
+
+```
+Selector finding from audit
+  │
+  ├─ Pathfinder or Playwright fail on this step? → Always inline
+  │
+  ├─ Stable data-testid or semantic attr available in DOM
+  │    and author used :contains() instead? → Always inline
+  │
+  ├─ :contains() on heading/button per docs/selectors-and-testids.md
+  │    priority 3, Pathfinder passed, no stable selector in DOM? → Review body only
+  │
+  ├─ :contains() in virtualised/below-fold context (rule 21)? → Defer;
+  │    promote to inline only if Pathfinder fails
+  │
+  └─ CSS class / nth-only selector? → Defer; promote if Pathfinder fails
+```
+
+When the author notes test IDs were tried first and failed, treat `:contains()` as justified fallback unless live testing or DOM inspection proves otherwise.
 
 ---
 
@@ -196,7 +222,7 @@ Dedupe before posting. Apply these rules in order:
 | One comment per root cause (rules above) | Passed milestones, deferred nits, companion website, retest notes | Follow-up issue tracking |
 | Code fix in PR (`depends`, manifest, noop, framing) | No fixed template | — |
 
-**Never inline:** pass-only, N/A-only, `FROM AUDIT:` dumps, duplicate threads for the same root cause on the same file, items still in **Defer** that Pathfinder passed.
+**Never inline:** pass-only, N/A-only, `FROM AUDIT:` dumps, duplicate threads for the same root cause on the same file, items still in **Defer** that Pathfinder passed, audit-only `:contains()` fallback findings when Pathfinder passed (see [selector decision tree](#selector-decision-tree)).
 
 ---
 
@@ -209,9 +235,11 @@ The reviewer chooses the GitHub review event at Phase 8. The agent **recommends*
 ```
 After Phase 7 — any Always inline finding OR Phase 5–6 runtime failure with inline comment?
   Yes → recommend REQUEST_CHANGES
-  No  → any Review body only items (companion website, retest notes, deferred nits, shell UX)?
-          Yes → recommend COMMENT
-          No  → recommend APPROVE
+  No  → all Pathfinder milestones passed AND remaining findings are audit-only selector warnings or body-only nits?
+          Yes → recommend COMMENT (or APPROVE if nothing worth saying)
+          No  → any Review body only items (companion website, retest notes, deferred nits, shell UX)?
+                  Yes → recommend COMMENT
+                  No  → recommend APPROVE
 ```
 
 ### When to use each verdict


### PR DESCRIPTION
Aligns the review-learning-path skill with docs/selectors-and-testids.md so :contains() is not auto-flagged as a merge blocker when Pathfinder passes and no stable testid exists.


Made with [Cursor](https://cursor.com)