### PR TITLE
Add interactive Pathfinder content for RCA Workbench investigation learning path

### DIFF
--- a/.github/workflows/validate-json.yml
+++ b/.github/workflows/validate-json.yml
@@ -73,7 +73,7 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
-        node-version: '22'
+        node-version: '24'
         cache: 'npm'
         cache-dependency-path: pathfinder-app/package-lock.json
 

--- a/rca-workbench-investigation-lj/add-entities/content.json
+++ b/rca-workbench-investigation-lj/add-entities/content.json
@@ -12,10 +12,6 @@
       "title": "Add entities from the Entity catalog",
       "blocks": [
         {
-          "type": "markdown",
-          "content": "You'll open the Entity catalog, filter for relevant entities, and add them to RCA Workbench."
-        },
-        {
           "type": "interactive",
           "action": "navigate",
           "reftarget": "/a/grafana-asserts-app/catalog",
@@ -23,8 +19,7 @@
           "verify": "on-page:/a/grafana-asserts-app/catalog"
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Filter entities by **Type** to focus on services, pods, or nodes relevant to your incident."
         },
         {
@@ -38,36 +33,26 @@
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "button[data-testid='catalog-entity-name-btn']",
-          "content": "Click an entity you want to investigate.",
+          "reftarget": "button[data-testid='catalog-entity-name-btn']:first-of-type",
+          "content": "Pick an entity row to investigate.",
           "requirements": ["exists-reftarget"],
           "doIt": false
         },
         {
-          "type": "interactive",
-          "action": "noop",
-          "content": "In the entity details panel, click **Add to RCA workbench**."
-        },
-        {
-          "type": "interactive",
-          "action": "noop",
-          "content": "Repeat for each entity you want to investigate. Focus on entities directly involved in the incident or those showing insights during the incident timeframe."
-        },
-        {
           "type": "markdown",
-          "content": "You added entities from the catalog to RCA Workbench."
+          "content": "In the entity details panel, click **Add to RCA workbench**. Repeat for each entity involved in the incident or showing insights during the incident timeframe."
         }
       ]
+    },
+    {
+      "type": "markdown",
+      "content": "You added entities from the catalog to RCA Workbench."
     },
     {
       "type": "section",
       "id": "set-time-range",
       "title": "Set the investigation time range",
       "blocks": [
-        {
-          "type": "markdown",
-          "content": "You'll set a time range that covers the incident window."
-        },
         {
           "type": "interactive",
           "action": "navigate",
@@ -84,15 +69,14 @@
           "doIt": false
         },
         {
-          "type": "interactive",
-          "action": "noop",
-          "content": "Select a time range that starts slightly before the incident symptoms appeared and extends past when the incident resolved (or to the current time if ongoing)."
-        },
-        {
           "type": "markdown",
-          "content": "A focused time range makes it easier to identify patterns and correlations on the timeline.\n\n**Tip:** If you added too many entities, hover over an entity in the Timeline view's left panel and click the **X** icon to remove it from the workbench.\n\nYou set the investigation time range."
+          "content": "Select a time range that starts slightly before the incident symptoms appeared and extends past when the incident resolved (or to the current time if ongoing). A focused time range makes it easier to identify patterns and correlations on the timeline.\n\n**Tip:** If you added too many entities, hover over an entity in the Timeline view's left panel and click the **X** icon to remove it from the workbench."
         }
       ]
+    },
+    {
+      "type": "markdown",
+      "content": "You set the investigation time range."
     },
     {
       "type": "markdown",

--- a/rca-workbench-investigation-lj/add-entities/content.json
+++ b/rca-workbench-investigation-lj/add-entities/content.json
@@ -1,0 +1,102 @@
+{
+  "id": "rca-workbench-investigation-add-entities",
+  "title": "Add entities and set time range",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "In this milestone, you add specific entities to RCA Workbench and configure the time range for your investigation.\n\nRCA Workbench becomes powerful when you populate it with the services and infrastructure components involved in your incident. By adding relevant entities and setting the appropriate time range, you can see how insights correlate across your environment and identify the root cause."
+    },
+    {
+      "type": "section",
+      "id": "add-from-catalog",
+      "title": "Add entities from the Entity catalog",
+      "blocks": [
+        {
+          "type": "markdown",
+          "content": "You'll open the Entity catalog, filter for relevant entities, and add them to RCA Workbench."
+        },
+        {
+          "type": "interactive",
+          "action": "navigate",
+          "reftarget": "/a/grafana-asserts-app/catalog",
+          "content": "Navigate to the **Entity catalog**.",
+          "verify": "on-page:/a/grafana-asserts-app/catalog"
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Filter entities by **Type** to focus on services, pods, or nodes relevant to your incident."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "div[data-testid='insights-circle']",
+          "content": "Use the **Insight Rings** to identify entities with active issues.",
+          "requirements": ["exists-reftarget"],
+          "doIt": false
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "button[data-testid='catalog-entity-name-btn']",
+          "content": "Click an entity you want to investigate.",
+          "requirements": ["exists-reftarget"],
+          "doIt": false
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "In the entity details panel, click **Add to RCA workbench**."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Repeat for each entity you want to investigate. Focus on entities directly involved in the incident or those showing insights during the incident timeframe."
+        },
+        {
+          "type": "markdown",
+          "content": "You added entities from the catalog to RCA Workbench."
+        }
+      ]
+    },
+    {
+      "type": "section",
+      "id": "set-time-range",
+      "title": "Set the investigation time range",
+      "blocks": [
+        {
+          "type": "markdown",
+          "content": "You'll set a time range that covers the incident window."
+        },
+        {
+          "type": "interactive",
+          "action": "navigate",
+          "reftarget": "/a/grafana-asserts-app/assertions",
+          "content": "Return to **RCA Workbench**.",
+          "verify": "on-page:/a/grafana-asserts-app/assertions"
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "button[data-testid='data-testid TimePicker Open Button']",
+          "content": "Use the time picker in the upper right corner to set the investigation time window.",
+          "requirements": ["exists-reftarget"],
+          "doIt": false
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Select a time range that starts slightly before the incident symptoms appeared and extends past when the incident resolved (or to the current time if ongoing)."
+        },
+        {
+          "type": "markdown",
+          "content": "A focused time range makes it easier to identify patterns and correlations on the timeline.\n\n**Tip:** If you added too many entities, hover over an entity in the Timeline view's left panel and click the **X** icon to remove it from the workbench.\n\nYou set the investigation time range."
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "In the next milestone, you'll explore the timeline to understand the sequence of events during the incident."
+    }
+  ]
+}

--- a/rca-workbench-investigation-lj/add-entities/manifest.json
+++ b/rca-workbench-investigation-lj/add-entities/manifest.json
@@ -1,0 +1,20 @@
+{
+  "id": "rca-workbench-investigation-add-entities",
+  "type": "guide",
+  "description": "Add relevant services and infrastructure to RCA Workbench and configure the investigation time window.",
+  "category": "take-action",
+  "author": {
+    "team": "Grafana Documentation"
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": [
+    "rca-workbench-investigation-navigate-to-workbench"
+  ],
+  "recommends": [
+    "rca-workbench-investigation-explore-timeline"
+  ],
+  "suggests": [],
+  "provides": []
+}

--- a/rca-workbench-investigation-lj/add-entities/website.yaml
+++ b/rca-workbench-investigation-lj/add-entities/website.yaml
@@ -1,0 +1,7 @@
+menuTitle: Add entities and set time range
+weight: 300
+step: 4
+layout: single-journey
+cta:
+  type: continue
+description: Add specific entities from the Entity catalog to RCA Workbench and configure the investigation time range.

--- a/rca-workbench-investigation-lj/analyze-metrics/content.json
+++ b/rca-workbench-investigation-lj/analyze-metrics/content.json
@@ -13,47 +13,29 @@
       "blocks": [
         {
           "type": "markdown",
-          "content": "You'll drill into insight metrics to identify performance anomalies."
-        },
-        {
-          "type": "interactive",
-          "action": "noop",
-          "content": "In RCA Workbench Timeline view, click an insight in the left panel to view its associated metrics."
-        },
-        {
-          "type": "interactive",
-          "action": "noop",
-          "content": "Examine the metric graph that appears in the timeline for spikes, drops, or unusual patterns."
+          "content": "In RCA Workbench Timeline view, click an insight in the left panel to view its associated metrics. Examine the metric graph that appears in the timeline for spikes, drops, or unusual patterns."
         },
         {
           "type": "markdown",
           "content": "Look for sudden spikes, sustained plateaus above normal, or drops to zero. A gradual increase over hours may indicate a resource leak, while a sharp spike suggests a sudden load change or failure."
         },
         {
-          "type": "interactive",
-          "action": "noop",
-          "content": "Click **Open chart in metrics** to see the metric in a dedicated dashboard."
-        },
-        {
-          "type": "interactive",
-          "action": "noop",
-          "content": "Compare metric values during the incident to baseline values before the incident."
-        },
-        {
-          "type": "interactive",
-          "action": "noop",
-          "content": "Click the **KPI** icon next to an entity to navigate to associated dashboards for comprehensive metric views."
-        },
-        {
-          "type": "interactive",
-          "action": "noop",
-          "content": "Note any metrics that show significant deviation from normal behavior."
+          "type": "markdown",
+          "content": "Click **Open chart in metrics** to see the metric in a dedicated dashboard. Compare metric values during the incident to baseline values before the incident."
         },
         {
           "type": "markdown",
-          "content": "For example, you might see CPU usage spike to 95% when the baseline is typically 30%.\n\nYou analyzed correlated metrics to identify performance anomalies."
+          "content": "Click the **KPI** icon next to an entity to navigate to associated dashboards for comprehensive metric views. Note any metrics that show significant deviation from normal behavior."
+        },
+        {
+          "type": "markdown",
+          "content": "For example, you might see CPU usage spike to 95% when the baseline is typically 30%."
         }
       ]
+    },
+    {
+      "type": "markdown",
+      "content": "You analyzed correlated metrics to identify performance anomalies."
     },
     {
       "type": "markdown",

--- a/rca-workbench-investigation-lj/analyze-metrics/content.json
+++ b/rca-workbench-investigation-lj/analyze-metrics/content.json
@@ -1,0 +1,63 @@
+{
+  "id": "rca-workbench-investigation-analyze-metrics",
+  "title": "Analyze correlated metrics",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "In this milestone, you examine metrics associated with insights to identify performance issues.\n\nRCA Workbench automatically displays metrics for insights that have fired. By analyzing these metric visualizations, you can understand the magnitude of performance degradation, resource exhaustion, or unusual patterns that contributed to the incident."
+    },
+    {
+      "type": "section",
+      "id": "analyze-metrics",
+      "title": "Analyze correlated metrics",
+      "blocks": [
+        {
+          "type": "markdown",
+          "content": "You'll drill into insight metrics to identify performance anomalies."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "In RCA Workbench Timeline view, click an insight in the left panel to view its associated metrics."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Examine the metric graph that appears in the timeline for spikes, drops, or unusual patterns."
+        },
+        {
+          "type": "markdown",
+          "content": "Look for sudden spikes, sustained plateaus above normal, or drops to zero. A gradual increase over hours may indicate a resource leak, while a sharp spike suggests a sudden load change or failure."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Click **Open chart in metrics** to see the metric in a dedicated dashboard."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Compare metric values during the incident to baseline values before the incident."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Click the **KPI** icon next to an entity to navigate to associated dashboards for comprehensive metric views."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Note any metrics that show significant deviation from normal behavior."
+        },
+        {
+          "type": "markdown",
+          "content": "For example, you might see CPU usage spike to 95% when the baseline is typically 30%.\n\nYou analyzed correlated metrics to identify performance anomalies."
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "In the next milestone, you'll review related logs to identify error messages and patterns."
+    }
+  ]
+}

--- a/rca-workbench-investigation-lj/analyze-metrics/manifest.json
+++ b/rca-workbench-investigation-lj/analyze-metrics/manifest.json
@@ -1,0 +1,20 @@
+{
+  "id": "rca-workbench-investigation-analyze-metrics",
+  "type": "guide",
+  "description": "Examine metrics visualizations to identify performance degradation or anomalies.",
+  "category": "take-action",
+  "author": {
+    "team": "Grafana Documentation"
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": [
+    "rca-workbench-investigation-explore-timeline"
+  ],
+  "recommends": [
+    "rca-workbench-investigation-review-logs"
+  ],
+  "suggests": [],
+  "provides": []
+}

--- a/rca-workbench-investigation-lj/analyze-metrics/website.yaml
+++ b/rca-workbench-investigation-lj/analyze-metrics/website.yaml
@@ -1,0 +1,7 @@
+menuTitle: Analyze correlated metrics
+weight: 500
+step: 6
+layout: single-journey
+cta:
+  type: continue
+description: Examine metrics associated with insights to identify performance degradation and resource exhaustion patterns.

--- a/rca-workbench-investigation-lj/business-value/content.json
+++ b/rca-workbench-investigation-lj/business-value/content.json
@@ -1,0 +1,18 @@
+{
+  "id": "rca-workbench-investigation-business-value",
+  "title": "The value of RCA Workbench",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "RCA Workbench is a unified investigation interface that accelerates incident resolution by automatically correlating metrics, logs, and traces. It eliminates the manual effort of switching between multiple dashboards and tools to piece together incident context.\n\nConsider a scenario where a user-facing checkout service starts returning errors. Without RCA Workbench, an on-call engineer might spend 20 minutes switching between a metrics dashboard to spot the CPU spike, a log viewer to find the `connection refused` errors, and a trace explorer to confirm the database dependency is the bottleneck. With RCA Workbench, all three signals appear in one timeline, correlated by entity and timeframe, so the engineer can identify the database connection pool exhaustion in minutes."
+    },
+    {
+      "type": "markdown",
+      "content": "RCA Workbench provides the following advantages over manual investigation methods:\n\n- Automatically correlates metrics, logs, and traces within the incident timeframe\n- Eliminates context switching between multiple Grafana dashboards and tools\n- Surfaces relevant telemetry data without requiring complex queries\n- Provides a timeline view of events, alerts, and changes during the incident\n- Accelerates root cause identification through intelligent data relationships\n- Enables team collaboration with shareable investigation workspaces"
+    },
+    {
+      "type": "markdown",
+      "content": "In the next milestone, you'll navigate to RCA Workbench in Grafana Cloud and prepare your investigation workspace."
+    }
+  ]
+}

--- a/rca-workbench-investigation-lj/business-value/manifest.json
+++ b/rca-workbench-investigation-lj/business-value/manifest.json
@@ -1,0 +1,18 @@
+{
+  "id": "rca-workbench-investigation-business-value",
+  "type": "guide",
+  "description": "Understand how RCA Workbench accelerates incident investigation by correlating telemetry data.",
+  "category": "take-action",
+  "author": {
+    "team": "Grafana Documentation"
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": [],
+  "recommends": [
+    "rca-workbench-investigation-navigate-to-workbench"
+  ],
+  "suggests": [],
+  "provides": []
+}

--- a/rca-workbench-investigation-lj/business-value/website.yaml
+++ b/rca-workbench-investigation-lj/business-value/website.yaml
@@ -1,0 +1,13 @@
+menuTitle: Value of RCA Workbench
+weight: 100
+step: 2
+layout: single-journey
+cta:
+  type: continue
+side_journeys:
+  title: More to explore (optional)
+  heading: 'At this point in your journey, you can explore the following paths:'
+  items:
+  - title: About the knowledge graph
+    link: /docs/grafana-cloud/knowledge-graph/
+description: Understand the value of using RCA Workbench to accelerate incident investigation by correlating telemetry signals.

--- a/rca-workbench-investigation-lj/content.json
+++ b/rca-workbench-investigation-lj/content.json
@@ -1,0 +1,18 @@
+{
+  "id": "rca-workbench-investigation-lj",
+  "title": "Investigate incidents using RCA Workbench",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "Welcome to the Grafana learning path that shows you how to use RCA Workbench to investigate incidents by correlating metrics, logs, and traces.\n\nRCA Workbench is a unified investigation interface designed to accelerate incident resolution by automatically correlating telemetry data. It eliminates the need to manually switch between multiple dashboards and tools, providing investigators with all relevant context in one place."
+    },
+    {
+      "type": "markdown",
+      "content": "When you complete this path, you'll be able to:\n\n- Understand the value of RCA Workbench for accelerating incident investigation\n- Navigate to RCA Workbench in Grafana Cloud\n- Add entities from the entity catalog to investigate\n- Set appropriate time ranges for incident investigation\n- Explore the investigation timeline to identify event correlations\n- Analyze correlated metrics to spot performance degradation\n- Review related logs to find error patterns and messages\n- Trace service dependencies to understand incident impact scope\n- Use Grafana Assistant to get AI-powered insights and root cause recommendations"
+    },
+    {
+      "type": "markdown",
+      "content": "## Before you begin\n\nBefore you use RCA Workbench, ensure that you have:\n\n- Services instrumented with OpenTelemetry, Application Observability, or Kubernetes monitoring.\n- The knowledge graph enabled in your Grafana Cloud stack with entities discovered from your environment. To enable the Knowledge Graph, refer to [Get started with the knowledge graph](/docs/grafana-cloud/knowledge-graph/get-started/).\n- An active incident or performance issue to investigate."
+    }
+  ]
+}

--- a/rca-workbench-investigation-lj/content.json
+++ b/rca-workbench-investigation-lj/content.json
@@ -12,7 +12,7 @@
     },
     {
       "type": "markdown",
-      "content": "## Before you begin\n\nBefore you use RCA Workbench, ensure that you have:\n\n- Services instrumented with OpenTelemetry, Application Observability, or Kubernetes monitoring.\n- The knowledge graph enabled in your Grafana Cloud stack with entities discovered from your environment. To enable the Knowledge Graph, refer to [Get started with the knowledge graph](/docs/grafana-cloud/knowledge-graph/get-started/).\n- An active incident or performance issue to investigate."
+      "content": "## Before you begin\n\nBefore you use RCA Workbench, ensure that you have:\n\n- Services instrumented with OpenTelemetry, Application Observability, or Kubernetes monitoring.\n- The knowledge graph enabled in your Grafana Cloud stack with entities discovered from your environment. To enable the Knowledge Graph, refer to [Get started with the knowledge graph](https://grafana.com/docs/grafana-cloud/knowledge-graph/get-started/).\n- An active incident or performance issue to investigate."
     }
   ]
 }

--- a/rca-workbench-investigation-lj/end-journey/content.json
+++ b/rca-workbench-investigation-lj/end-journey/content.json
@@ -1,0 +1,14 @@
+{
+  "id": "rca-workbench-investigation-end-journey",
+  "title": "Destination reached!",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "Congratulations on completing this path! Job well done!\n\nWe hope you've enjoyed traveling with us as you:\n\n- Understood the value of RCA Workbench for accelerating incident investigation\n- Navigated to RCA Workbench in Grafana Cloud\n- Added entities from the entity catalog to investigate\n- Set appropriate time ranges for incident investigation\n- Explored the investigation timeline to identify event correlations\n- Analyzed correlated metrics to spot performance degradation\n- Reviewed related logs to find error patterns and messages\n- Traced service dependencies to understand incident impact scope\n- Used Grafana Assistant to get AI-powered insights and root cause recommendations"
+    },
+    {
+      "type": "markdown",
+      "content": "---\n\n### Related paths\n\nConsider taking the following paths after you complete this path.\n\n- [Use Traces Drilldown to identify high latency service requests](/docs/learning-paths/drilldown-traces/)\n- [Use Logs Drilldown to investigate application errors](/docs/learning-paths/drilldown-logs/)\n- [Use Metrics Drilldown to identify anomalous metrics](/docs/learning-paths/drilldown-metrics/)\n- [Create infrastructure alerts in Grafana Cloud](/docs/learning-paths/infrastructure-alerting/)"
+    }
+  ]
+}

--- a/rca-workbench-investigation-lj/end-journey/content.json
+++ b/rca-workbench-investigation-lj/end-journey/content.json
@@ -8,7 +8,7 @@
     },
     {
       "type": "markdown",
-      "content": "---\n\n### Related paths\n\nConsider taking the following paths after you complete this path.\n\n- [Use Traces Drilldown to identify high latency service requests](/docs/learning-paths/drilldown-traces/)\n- [Use Logs Drilldown to investigate application errors](/docs/learning-paths/drilldown-logs/)\n- [Use Metrics Drilldown to identify anomalous metrics](/docs/learning-paths/drilldown-metrics/)\n- [Create infrastructure alerts in Grafana Cloud](/docs/learning-paths/infrastructure-alerting/)"
+      "content": "---\n\n### Related paths\n\nConsider taking the following paths after you complete this path.\n\n- [Use Traces Drilldown to identify high latency service requests](https://grafana.com/docs/learning-paths/drilldown-traces/)\n- [Use Logs Drilldown to investigate application errors](https://grafana.com/docs/learning-paths/drilldown-logs/)\n- [Use Metrics Drilldown to identify anomalous metrics](https://grafana.com/docs/learning-paths/drilldown-metrics/)\n- [Create infrastructure alerts in Grafana Cloud](https://grafana.com/docs/learning-paths/infrastructure-alerting/)"
     }
   ]
 }

--- a/rca-workbench-investigation-lj/end-journey/manifest.json
+++ b/rca-workbench-investigation-lj/end-journey/manifest.json
@@ -1,0 +1,23 @@
+{
+  "id": "rca-workbench-investigation-end-journey",
+  "type": "guide",
+  "description": "Congratulations on completing the RCA Workbench investigation learning path.",
+  "category": "take-action",
+  "author": {
+    "team": "Grafana Documentation"
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": [
+    "rca-workbench-investigation-use-assistant"
+  ],
+  "recommends": [],
+  "suggests": [
+    "drilldown-traces-lj",
+    "drilldown-logs-lj",
+    "drilldown-metrics-lj",
+    "infrastructure-alerting-lj"
+  ],
+  "provides": []
+}

--- a/rca-workbench-investigation-lj/end-journey/website.yaml
+++ b/rca-workbench-investigation-lj/end-journey/website.yaml
@@ -1,0 +1,19 @@
+menuTitle: Destination reached!
+weight: 900
+step: 10
+layout: single-journey
+cta:
+  type: conclusion
+side_journeys:
+  title: More to explore (optional)
+  heading: 'The world is your oyster! Read more about how you can:'
+  items:
+  - title: Use Traces Drilldown to identify high latency service requests
+    link: /docs/learning-paths/drilldown-traces/
+  - title: Use Logs Drilldown to investigate application errors
+    link: /docs/learning-paths/drilldown-logs/
+  - title: Use Metrics Drilldown to identify anomalous metrics
+    link: /docs/learning-paths/drilldown-metrics/
+  - title: Create infrastructure alerts in Grafana Cloud
+    link: /docs/learning-paths/infrastructure-alerting/
+description: Your journey concludes and it's time to learn about related paths you can take.

--- a/rca-workbench-investigation-lj/explore-timeline/content.json
+++ b/rca-workbench-investigation-lj/explore-timeline/content.json
@@ -1,0 +1,73 @@
+{
+  "id": "rca-workbench-investigation-explore-timeline",
+  "title": "Explore the investigation timeline",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "In this milestone, you explore the RCA Workbench timeline to understand the sequence of insights and events during the incident.\n\nThe timeline provides a chronological view of insights firing across your selected entities. This helps you identify the first failure, trace cascading effects, and understand how issues propagated through your system."
+    },
+    {
+      "type": "section",
+      "id": "explore-timeline",
+      "title": "Explore the timeline",
+      "blocks": [
+        {
+          "type": "markdown",
+          "content": "You'll use the Timeline view to identify the sequence of events during the incident."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "button[data-testid='assertions-timeline-tab']",
+          "content": "In RCA Workbench, ensure you're in the **Timeline** view.",
+          "requirements": ["on-page:/a/grafana-asserts-app/assertions", "exists-reftarget"]
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Expand the entities on the left panel to show individual insights."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Scan the timeline from left to right to identify the earliest insight that fired."
+        },
+        {
+          "type": "markdown",
+          "content": "Look for:\n\n- **Amend insights** (blue) — Deployments or configuration changes\n- **Failure insights** (red) — Service or infrastructure failures\n- **Saturation insights** (yellow/red) — Resources approaching limits\n\nStart with blue amend insights. A recent deployment or config change that immediately precedes red failure insights is one of the most common root causes. If no amend insights appear, look for the earliest saturation insight, which may indicate gradual resource exhaustion that eventually triggered failures."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Note the time of the first insight, as this is often the root cause or trigger."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Look for cascading failures by examining insights that fired shortly after the first one."
+        },
+        {
+          "type": "markdown",
+          "content": "For example, if a saturation insight fires on a database node at 14:02 and failure insights begin appearing on upstream API services at 14:04, the database is likely the origin. A gap of seconds to a few minutes between the first insight and downstream failures is a common cascading pattern."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Click and drag on the timeline to zoom into specific time periods for detailed analysis."
+        },
+        {
+          "type": "markdown",
+          "content": "You explored the timeline to identify the sequence of events and potential cascading failures."
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "In the next milestone, you'll analyze correlated metrics to identify performance degradation."
+    },
+    {
+      "type": "markdown",
+      "content": "---\n\n### Troubleshooting\n\nExplore the following troubleshooting topics if you need help:\n\n- [RCA workbench](/docs/grafana-cloud/knowledge-graph/troubleshoot-infra-apps/workbench/)\n- [Insights reference](/docs/grafana-cloud/knowledge-graph/reference/about-base-insights/)"
+    }
+  ]
+}

--- a/rca-workbench-investigation-lj/explore-timeline/content.json
+++ b/rca-workbench-investigation-lj/explore-timeline/content.json
@@ -67,7 +67,7 @@
     },
     {
       "type": "markdown",
-      "content": "---\n\n### Troubleshooting\n\nExplore the following troubleshooting topics if you need help:\n\n- [RCA workbench](/docs/grafana-cloud/knowledge-graph/troubleshoot-infra-apps/workbench/)\n- [Insights reference](/docs/grafana-cloud/knowledge-graph/reference/about-base-insights/)"
+      "content": "---\n\n### Troubleshooting\n\nExplore the following troubleshooting topics if you need help:\n\n- [RCA workbench](https://grafana.com/docs/grafana-cloud/knowledge-graph/troubleshoot-infra-apps/workbench/)\n- [Insights reference](https://grafana.com/docs/grafana-cloud/knowledge-graph/reference/about-base-insights/)"
     }
   ]
 }

--- a/rca-workbench-investigation-lj/explore-timeline/content.json
+++ b/rca-workbench-investigation-lj/explore-timeline/content.json
@@ -12,10 +12,6 @@
       "title": "Explore the timeline",
       "blocks": [
         {
-          "type": "markdown",
-          "content": "You'll use the Timeline view to identify the sequence of events during the incident."
-        },
-        {
           "type": "interactive",
           "action": "highlight",
           "reftarget": "button[data-testid='assertions-timeline-tab']",
@@ -23,43 +19,26 @@
           "requirements": ["on-page:/a/grafana-asserts-app/assertions", "exists-reftarget"]
         },
         {
-          "type": "interactive",
-          "action": "noop",
-          "content": "Expand the entities on the left panel to show individual insights."
-        },
-        {
-          "type": "interactive",
-          "action": "noop",
-          "content": "Scan the timeline from left to right to identify the earliest insight that fired."
+          "type": "markdown",
+          "content": "Expand the entities on the left panel to show individual insights. Scan the timeline from left to right to identify the earliest insight that fired."
         },
         {
           "type": "markdown",
           "content": "Look for:\n\n- **Amend insights** (blue) — Deployments or configuration changes\n- **Failure insights** (red) — Service or infrastructure failures\n- **Saturation insights** (yellow/red) — Resources approaching limits\n\nStart with blue amend insights. A recent deployment or config change that immediately precedes red failure insights is one of the most common root causes. If no amend insights appear, look for the earliest saturation insight, which may indicate gradual resource exhaustion that eventually triggered failures."
         },
         {
-          "type": "interactive",
-          "action": "noop",
-          "content": "Note the time of the first insight, as this is often the root cause or trigger."
-        },
-        {
-          "type": "interactive",
-          "action": "noop",
-          "content": "Look for cascading failures by examining insights that fired shortly after the first one."
+          "type": "markdown",
+          "content": "Note the time of the first insight, as this is often the root cause or trigger. Look for cascading failures by examining insights that fired shortly after the first one."
         },
         {
           "type": "markdown",
-          "content": "For example, if a saturation insight fires on a database node at 14:02 and failure insights begin appearing on upstream API services at 14:04, the database is likely the origin. A gap of seconds to a few minutes between the first insight and downstream failures is a common cascading pattern."
-        },
-        {
-          "type": "interactive",
-          "action": "noop",
-          "content": "Click and drag on the timeline to zoom into specific time periods for detailed analysis."
-        },
-        {
-          "type": "markdown",
-          "content": "You explored the timeline to identify the sequence of events and potential cascading failures."
+          "content": "For example, if a saturation insight fires on a database node at 14:02 and failure insights begin appearing on upstream API services at 14:04, the database is likely the origin. A gap of seconds to a few minutes between the first insight and downstream failures is a common cascading pattern.\n\nClick and drag on the timeline to zoom into specific time periods for detailed analysis."
         }
       ]
+    },
+    {
+      "type": "markdown",
+      "content": "You explored the timeline to identify the sequence of events and potential cascading failures."
     },
     {
       "type": "markdown",

--- a/rca-workbench-investigation-lj/explore-timeline/manifest.json
+++ b/rca-workbench-investigation-lj/explore-timeline/manifest.json
@@ -1,0 +1,20 @@
+{
+  "id": "rca-workbench-investigation-explore-timeline",
+  "type": "guide",
+  "description": "Review the timeline view showing insights and changes during the incident window.",
+  "category": "take-action",
+  "author": {
+    "team": "Grafana Documentation"
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": [
+    "rca-workbench-investigation-add-entities"
+  ],
+  "recommends": [
+    "rca-workbench-investigation-analyze-metrics"
+  ],
+  "suggests": [],
+  "provides": []
+}

--- a/rca-workbench-investigation-lj/explore-timeline/website.yaml
+++ b/rca-workbench-investigation-lj/explore-timeline/website.yaml
@@ -1,0 +1,7 @@
+menuTitle: Explore the investigation timeline
+weight: 400
+step: 5
+layout: single-journey
+cta:
+  type: continue
+description: Use the RCA Workbench timeline to identify the sequence of insights, cascading failures, and root cause triggers.

--- a/rca-workbench-investigation-lj/manifest.json
+++ b/rca-workbench-investigation-lj/manifest.json
@@ -23,7 +23,6 @@
     "tier": "cloud"
   },
   "milestones": [
-    "rca-workbench-investigation-business-value",
     "rca-workbench-investigation-navigate-to-workbench",
     "rca-workbench-investigation-add-entities",
     "rca-workbench-investigation-explore-timeline",

--- a/rca-workbench-investigation-lj/manifest.json
+++ b/rca-workbench-investigation-lj/manifest.json
@@ -1,0 +1,45 @@
+{
+  "id": "rca-workbench-investigation-lj",
+  "type": "path",
+  "description": "Step-by-step guide: Investigate incidents using RCA Workbench by correlating metrics, logs, and traces.",
+  "category": "take-action",
+  "author": {
+    "team": "Grafana Documentation"
+  },
+  "startingLocation": "/a/grafana-asserts-app/assertions",
+  "targeting": {
+    "match": {
+      "and": [
+        {
+          "urlPrefixIn": ["/a/grafana-asserts-app/assertions", "/a/grafana-asserts-app/catalog"]
+        },
+        {
+          "targetPlatform": "cloud"
+        }
+      ]
+    }
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "milestones": [
+    "rca-workbench-investigation-business-value",
+    "rca-workbench-investigation-navigate-to-workbench",
+    "rca-workbench-investigation-add-entities",
+    "rca-workbench-investigation-explore-timeline",
+    "rca-workbench-investigation-analyze-metrics",
+    "rca-workbench-investigation-review-logs",
+    "rca-workbench-investigation-trace-dependencies",
+    "rca-workbench-investigation-use-assistant",
+    "rca-workbench-investigation-end-journey"
+  ],
+  "depends": [],
+  "recommends": [],
+  "suggests": [
+    "drilldown-traces-lj",
+    "drilldown-logs-lj",
+    "drilldown-metrics-lj",
+    "infrastructure-alerting-lj"
+  ],
+  "provides": []
+}

--- a/rca-workbench-investigation-lj/navigate-to-workbench/content.json
+++ b/rca-workbench-investigation-lj/navigate-to-workbench/content.json
@@ -52,7 +52,7 @@
     },
     {
       "type": "markdown",
-      "content": "---\n\n### Troubleshooting\n\nExplore the following troubleshooting topics if you need help:\n\n- [RCA workbench](/docs/grafana-cloud/knowledge-graph/troubleshoot-infra-apps/workbench/)\n- [Entity catalog](/docs/grafana-cloud/knowledge-graph/troubleshoot-infra-apps/explore-entity-catalog/)"
+      "content": "---\n\n### Troubleshooting\n\nExplore the following troubleshooting topics if you need help:\n\n- [RCA workbench](https://grafana.com/docs/grafana-cloud/knowledge-graph/troubleshoot-infra-apps/workbench/)\n- [Entity catalog](https://grafana.com/docs/grafana-cloud/knowledge-graph/troubleshoot-infra-apps/explore-entity-catalog/)"
     }
   ]
 }

--- a/rca-workbench-investigation-lj/navigate-to-workbench/content.json
+++ b/rca-workbench-investigation-lj/navigate-to-workbench/content.json
@@ -13,11 +13,6 @@
       "blocks": [
         {
           "type": "markdown",
-          "content": "You'll navigate to RCA Workbench and populate it with entities to investigate."
-        },
-        {
-          "type": "interactive",
-          "action": "noop",
           "content": "Sign in to your Grafana Cloud environment, for example `mystack.grafana.net`."
         },
         {
@@ -39,12 +34,12 @@
           "reftarget": "Show all Services",
           "content": "Click **Show all Services** under **Frequently used** to add all discovered services to the workbench.",
           "requirements": ["exists-reftarget"]
-        },
-        {
-          "type": "markdown",
-          "content": "RCA Workbench displays with a timeline ready to show insights across your selected entities.\n\nYou navigated to RCA Workbench and populated it with entities."
         }
       ]
+    },
+    {
+      "type": "markdown",
+      "content": "You navigated to RCA Workbench and populated it with entities."
     },
     {
       "type": "markdown",

--- a/rca-workbench-investigation-lj/navigate-to-workbench/content.json
+++ b/rca-workbench-investigation-lj/navigate-to-workbench/content.json
@@ -1,0 +1,58 @@
+{
+  "id": "rca-workbench-investigation-navigate-to-workbench",
+  "title": "Navigate to RCA Workbench",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "In this milestone, you access RCA Workbench to begin investigating incidents in Grafana Cloud.\n\nRCA Workbench provides a centralized interface for investigating incidents by correlating insights across multiple services and infrastructure components. The workbench displays a timeline view where you can see all insights firing across different entities, helping you identify root causes and understand the sequence of events."
+    },
+    {
+      "type": "section",
+      "id": "navigate-to-rca",
+      "title": "Navigate to RCA Workbench",
+      "blocks": [
+        {
+          "type": "markdown",
+          "content": "You'll navigate to RCA Workbench and populate it with entities to investigate."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Sign in to your Grafana Cloud environment, for example `mystack.grafana.net`."
+        },
+        {
+          "type": "multistep",
+          "content": "Navigate to **Observability** > **RCA workbench**.",
+          "requirements": ["navmenu-open"],
+          "steps": [
+            { "action": "highlight", "reftarget": "a[data-testid='data-testid Nav menu item'][href='/observability']" },
+            { "action": "highlight", "reftarget": "a[data-testid='data-testid Nav menu item'][href='/a/grafana-asserts-app/assertions']" }
+          ]
+        },
+        {
+          "type": "markdown",
+          "content": "RCA Workbench opens with an empty workspace."
+        },
+        {
+          "type": "interactive",
+          "action": "button",
+          "reftarget": "Show all Services",
+          "content": "Click **Show all Services** under **Frequently used** to add all discovered services to the workbench.",
+          "requirements": ["exists-reftarget"]
+        },
+        {
+          "type": "markdown",
+          "content": "RCA Workbench displays with a timeline ready to show insights across your selected entities.\n\nYou navigated to RCA Workbench and populated it with entities."
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "In the next milestone, you'll add specific entities to investigate and set the appropriate time range for your incident."
+    },
+    {
+      "type": "markdown",
+      "content": "---\n\n### Troubleshooting\n\nExplore the following troubleshooting topics if you need help:\n\n- [RCA workbench](/docs/grafana-cloud/knowledge-graph/troubleshoot-infra-apps/workbench/)\n- [Entity catalog](/docs/grafana-cloud/knowledge-graph/troubleshoot-infra-apps/explore-entity-catalog/)"
+    }
+  ]
+}

--- a/rca-workbench-investigation-lj/navigate-to-workbench/manifest.json
+++ b/rca-workbench-investigation-lj/navigate-to-workbench/manifest.json
@@ -1,0 +1,20 @@
+{
+  "id": "rca-workbench-investigation-navigate-to-workbench",
+  "type": "guide",
+  "description": "Access RCA Workbench from Grafana Cloud and populate it with entities.",
+  "category": "take-action",
+  "author": {
+    "team": "Grafana Documentation"
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": [
+    "rca-workbench-investigation-business-value"
+  ],
+  "recommends": [
+    "rca-workbench-investigation-add-entities"
+  ],
+  "suggests": [],
+  "provides": []
+}

--- a/rca-workbench-investigation-lj/navigate-to-workbench/manifest.json
+++ b/rca-workbench-investigation-lj/navigate-to-workbench/manifest.json
@@ -9,9 +9,7 @@
   "testEnvironment": {
     "tier": "cloud"
   },
-  "depends": [
-    "rca-workbench-investigation-business-value"
-  ],
+  "depends": [],
   "recommends": [
     "rca-workbench-investigation-add-entities"
   ],

--- a/rca-workbench-investigation-lj/navigate-to-workbench/website.yaml
+++ b/rca-workbench-investigation-lj/navigate-to-workbench/website.yaml
@@ -1,0 +1,7 @@
+menuTitle: Navigate to RCA Workbench
+weight: 200
+step: 3
+layout: single-journey
+cta:
+  type: continue
+description: Access RCA Workbench from Grafana Cloud and populate it with entities to begin an investigation.

--- a/rca-workbench-investigation-lj/review-logs/content.json
+++ b/rca-workbench-investigation-lj/review-logs/content.json
@@ -1,0 +1,77 @@
+{
+  "id": "rca-workbench-investigation-review-logs",
+  "title": "Review related logs",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "In this milestone, you examine log data from the incident timeframe to identify error messages and patterns.\n\nIn RCA Workbench, logs are accessed through the Timeline view, providing instant log context for any point in your investigation. The logs are automatically pre-filtered by the selected entity and timestamp, with full Logs Drilldown capabilities that don't require writing LogQL queries."
+    },
+    {
+      "type": "section",
+      "id": "review-logs",
+      "title": "Review related logs",
+      "blocks": [
+        {
+          "type": "markdown",
+          "content": "You'll access logs from the Timeline view and investigate error patterns."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "In RCA Workbench, locate the Timeline view."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Click a specific point in time on the Timeline where you want to investigate logs."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "In the popup that appears, click **Logs**."
+        },
+        {
+          "type": "markdown",
+          "content": "A drawer opens with the Logs tab showing contextualized Logs Drilldown. The logs view includes:\n\n- Pre-filtered by the selected entity using labels like cluster, job, and namespace\n- Filtered to the selected timestamp for focused investigation\n- Full Logs Drilldown capabilities without requiring LogQL queries\n- Search, filter, and pattern detection features"
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Review the log entries automatically filtered to the selected timeframe and entity."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Examine the log level distribution to identify error and warning concentrations."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Click on a log entry to view the full message and associated metadata."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Use the search field to filter logs for specific error codes or keywords, for example `error` or `timeout`."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Note any error patterns or repeated messages that coincide with the incident."
+        },
+        {
+          "type": "markdown",
+          "content": "You reviewed logs from the incident period and identified error patterns."
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "In the next milestone, you'll trace service dependencies to understand the impact scope."
+    },
+    {
+      "type": "markdown",
+      "content": "---\n\n### Troubleshooting\n\nExplore the following troubleshooting topics if you need help:\n\n- [RCA workbench](/docs/grafana-cloud/knowledge-graph/troubleshoot-infra-apps/workbench/)\n- [Logs Drilldown](/docs/grafana-cloud/visualizations/simplified-exploration/logs/)"
+    }
+  ]
+}

--- a/rca-workbench-investigation-lj/review-logs/content.json
+++ b/rca-workbench-investigation-lj/review-logs/content.json
@@ -71,7 +71,7 @@
     },
     {
       "type": "markdown",
-      "content": "---\n\n### Troubleshooting\n\nExplore the following troubleshooting topics if you need help:\n\n- [RCA workbench](/docs/grafana-cloud/knowledge-graph/troubleshoot-infra-apps/workbench/)\n- [Logs Drilldown](/docs/grafana-cloud/visualizations/simplified-exploration/logs/)"
+      "content": "---\n\n### Troubleshooting\n\nExplore the following troubleshooting topics if you need help:\n\n- [RCA workbench](https://grafana.com/docs/grafana-cloud/knowledge-graph/troubleshoot-infra-apps/workbench/)\n- [Logs Drilldown](https://grafana.com/docs/grafana-cloud/visualizations/simplified-exploration/logs/)"
     }
   ]
 }

--- a/rca-workbench-investigation-lj/review-logs/content.json
+++ b/rca-workbench-investigation-lj/review-logs/content.json
@@ -13,57 +13,29 @@
       "blocks": [
         {
           "type": "markdown",
-          "content": "You'll access logs from the Timeline view and investigate error patterns."
-        },
-        {
-          "type": "interactive",
-          "action": "noop",
-          "content": "In RCA Workbench, locate the Timeline view."
-        },
-        {
-          "type": "interactive",
-          "action": "noop",
-          "content": "Click a specific point in time on the Timeline where you want to investigate logs."
-        },
-        {
-          "type": "interactive",
-          "action": "noop",
-          "content": "In the popup that appears, click **Logs**."
+          "content": "In RCA Workbench, locate the Timeline view. Click a specific point in time on the Timeline where you want to investigate logs. In the popup that appears, click **Logs**."
         },
         {
           "type": "markdown",
           "content": "A drawer opens with the Logs tab showing contextualized Logs Drilldown. The logs view includes:\n\n- Pre-filtered by the selected entity using labels like cluster, job, and namespace\n- Filtered to the selected timestamp for focused investigation\n- Full Logs Drilldown capabilities without requiring LogQL queries\n- Search, filter, and pattern detection features"
         },
         {
-          "type": "interactive",
-          "action": "noop",
-          "content": "Review the log entries automatically filtered to the selected timeframe and entity."
-        },
-        {
-          "type": "interactive",
-          "action": "noop",
-          "content": "Examine the log level distribution to identify error and warning concentrations."
-        },
-        {
-          "type": "interactive",
-          "action": "noop",
-          "content": "Click on a log entry to view the full message and associated metadata."
-        },
-        {
-          "type": "interactive",
-          "action": "noop",
-          "content": "Use the search field to filter logs for specific error codes or keywords, for example `error` or `timeout`."
-        },
-        {
-          "type": "interactive",
-          "action": "noop",
-          "content": "Note any error patterns or repeated messages that coincide with the incident."
+          "type": "markdown",
+          "content": "Review the log entries automatically filtered to the selected timeframe and entity. Examine the log level distribution to identify error and warning concentrations."
         },
         {
           "type": "markdown",
-          "content": "You reviewed logs from the incident period and identified error patterns."
+          "content": "Click on a log entry to view the full message and associated metadata. Use the search field to filter logs for specific error codes or keywords, for example `error` or `timeout`."
+        },
+        {
+          "type": "markdown",
+          "content": "Note any error patterns or repeated messages that coincide with the incident."
         }
       ]
+    },
+    {
+      "type": "markdown",
+      "content": "You reviewed logs from the incident period and identified error patterns."
     },
     {
       "type": "markdown",

--- a/rca-workbench-investigation-lj/review-logs/manifest.json
+++ b/rca-workbench-investigation-lj/review-logs/manifest.json
@@ -1,0 +1,20 @@
+{
+  "id": "rca-workbench-investigation-review-logs",
+  "type": "guide",
+  "description": "Investigate log patterns and errors that occurred during the incident timeframe.",
+  "category": "take-action",
+  "author": {
+    "team": "Grafana Documentation"
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": [
+    "rca-workbench-investigation-analyze-metrics"
+  ],
+  "recommends": [
+    "rca-workbench-investigation-trace-dependencies"
+  ],
+  "suggests": [],
+  "provides": []
+}

--- a/rca-workbench-investigation-lj/review-logs/website.yaml
+++ b/rca-workbench-investigation-lj/review-logs/website.yaml
@@ -1,0 +1,7 @@
+menuTitle: Review related logs
+weight: 600
+step: 7
+layout: single-journey
+cta:
+  type: continue
+description: Access contextualized logs from the Timeline view and investigate error patterns during the incident.

--- a/rca-workbench-investigation-lj/trace-dependencies/content.json
+++ b/rca-workbench-investigation-lj/trace-dependencies/content.json
@@ -13,65 +13,37 @@
       "blocks": [
         {
           "type": "markdown",
-          "content": "You'll access traces from the Timeline view and analyze service dependencies."
-        },
-        {
-          "type": "interactive",
-          "action": "noop",
-          "content": "In RCA Workbench, locate the Timeline view."
-        },
-        {
-          "type": "interactive",
-          "action": "noop",
-          "content": "Click a specific point in time on the Timeline where you want to investigate traces."
-        },
-        {
-          "type": "interactive",
-          "action": "noop",
-          "content": "In the popup that appears, click **Traces**."
+          "content": "In RCA Workbench, locate the Timeline view. Click a specific point in time on the Timeline where you want to investigate traces. In the popup that appears, click **Traces**."
         },
         {
           "type": "markdown",
           "content": "A drawer opens showing traces associated with that timestamp. The traces view includes:\n\n- Pre-filtered traces for the selected entity and time\n- Ability to click any trace to view details\n- Option to open Traces Drilldown for deeper analysis"
         },
         {
-          "type": "interactive",
-          "action": "noop",
-          "content": "Review the service dependency map showing affected services."
-        },
-        {
-          "type": "interactive",
-          "action": "noop",
-          "content": "Examine trace spans to identify services with increased latency or errors."
+          "type": "markdown",
+          "content": "Review the service dependency map showing affected services. Examine trace spans to identify services with increased latency or errors."
         },
         {
           "type": "markdown",
           "content": "In a healthy trace, spans complete in milliseconds with no error tags. During an incident, look for spans that are significantly longer than their neighbours — a single span consuming 80% of the total trace duration usually points to the bottleneck. Also look for spans marked with error tags (often shown in red), which indicate where requests are actively failing rather than just slow."
         },
         {
-          "type": "interactive",
-          "action": "noop",
-          "content": "Click on a trace to view the detailed span timeline."
-        },
-        {
-          "type": "interactive",
-          "action": "noop",
-          "content": "Identify services where requests failed or experienced unusual delays."
+          "type": "markdown",
+          "content": "Click on a trace to view the detailed span timeline. Identify services where requests failed or experienced unusual delays."
         },
         {
           "type": "markdown",
           "content": "If a single downstream service shows errors while its callers show increased latency but no errors, the downstream service is likely the root cause — callers are slow because they're waiting on or retrying requests to the failing dependency. If errors appear across multiple services at the same level, look for a shared dependency such as a database, cache, or message queue that connects them."
         },
         {
-          "type": "interactive",
-          "action": "noop",
-          "content": "Note the error rate and latency changes for each service during the incident."
-        },
-        {
           "type": "markdown",
-          "content": "You traced service dependencies and identified affected services."
+          "content": "Note the error rate and latency changes for each service during the incident."
         }
       ]
+    },
+    {
+      "type": "markdown",
+      "content": "You traced service dependencies and identified affected services."
     },
     {
       "type": "markdown",

--- a/rca-workbench-investigation-lj/trace-dependencies/content.json
+++ b/rca-workbench-investigation-lj/trace-dependencies/content.json
@@ -1,0 +1,81 @@
+{
+  "id": "rca-workbench-investigation-trace-dependencies",
+  "title": "Trace service dependencies",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "In this milestone, you use distributed trace data to map service dependencies and identify affected services.\n\nIn RCA Workbench, traces are accessed through the Timeline view, providing instant trace context at any point in your investigation timeline. This helps you understand request flows and identify performance bottlenecks by analyzing trace spans for slow or failing requests."
+    },
+    {
+      "type": "section",
+      "id": "trace-dependencies",
+      "title": "Trace service dependencies",
+      "blocks": [
+        {
+          "type": "markdown",
+          "content": "You'll access traces from the Timeline view and analyze service dependencies."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "In RCA Workbench, locate the Timeline view."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Click a specific point in time on the Timeline where you want to investigate traces."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "In the popup that appears, click **Traces**."
+        },
+        {
+          "type": "markdown",
+          "content": "A drawer opens showing traces associated with that timestamp. The traces view includes:\n\n- Pre-filtered traces for the selected entity and time\n- Ability to click any trace to view details\n- Option to open Traces Drilldown for deeper analysis"
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Review the service dependency map showing affected services."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Examine trace spans to identify services with increased latency or errors."
+        },
+        {
+          "type": "markdown",
+          "content": "In a healthy trace, spans complete in milliseconds with no error tags. During an incident, look for spans that are significantly longer than their neighbours — a single span consuming 80% of the total trace duration usually points to the bottleneck. Also look for spans marked with error tags (often shown in red), which indicate where requests are actively failing rather than just slow."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Click on a trace to view the detailed span timeline."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Identify services where requests failed or experienced unusual delays."
+        },
+        {
+          "type": "markdown",
+          "content": "If a single downstream service shows errors while its callers show increased latency but no errors, the downstream service is likely the root cause — callers are slow because they're waiting on or retrying requests to the failing dependency. If errors appear across multiple services at the same level, look for a shared dependency such as a database, cache, or message queue that connects them."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Note the error rate and latency changes for each service during the incident."
+        },
+        {
+          "type": "markdown",
+          "content": "You traced service dependencies and identified affected services."
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "In the next milestone, you'll use Grafana Assistant to get AI-powered insights for root cause analysis."
+    }
+  ]
+}

--- a/rca-workbench-investigation-lj/trace-dependencies/manifest.json
+++ b/rca-workbench-investigation-lj/trace-dependencies/manifest.json
@@ -1,0 +1,20 @@
+{
+  "id": "rca-workbench-investigation-trace-dependencies",
+  "type": "guide",
+  "description": "Use trace data to identify which services were affected and potential failure points.",
+  "category": "take-action",
+  "author": {
+    "team": "Grafana Documentation"
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": [
+    "rca-workbench-investigation-review-logs"
+  ],
+  "recommends": [
+    "rca-workbench-investigation-use-assistant"
+  ],
+  "suggests": [],
+  "provides": []
+}

--- a/rca-workbench-investigation-lj/trace-dependencies/website.yaml
+++ b/rca-workbench-investigation-lj/trace-dependencies/website.yaml
@@ -1,0 +1,7 @@
+menuTitle: Trace service dependencies
+weight: 700
+step: 8
+layout: single-journey
+cta:
+  type: continue
+description: Use distributed trace data to map service dependencies and identify the scope of incident impact.

--- a/rca-workbench-investigation-lj/use-assistant/content.json
+++ b/rca-workbench-investigation-lj/use-assistant/content.json
@@ -12,10 +12,6 @@
       "title": "Use Grafana Assistant",
       "blocks": [
         {
-          "type": "markdown",
-          "content": "You'll open Grafana Assistant and use it to analyze the incident."
-        },
-        {
           "type": "interactive",
           "action": "highlight",
           "reftarget": "button[data-testid='assistant-button']",
@@ -23,34 +19,22 @@
           "requirements": ["on-page:/a/grafana-asserts-app/assertions", "exists-reftarget"]
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Ask Assistant to analyze the incident data. For example, type: \"What caused this incident?\" or \"Summarize the correlated metrics\"."
         },
         {
-          "type": "interactive",
-          "action": "noop",
-          "content": "Review the AI-generated insights and recommendations provided by Assistant."
-        },
-        {
-          "type": "interactive",
-          "action": "noop",
-          "content": "Ask follow-up questions to dive deeper into specific aspects of the investigation."
+          "type": "markdown",
+          "content": "Review the AI-generated insights and recommendations provided by Assistant. Ask follow-up questions to dive deeper into specific aspects of the investigation."
         },
         {
           "type": "markdown",
-          "content": "For example, if Assistant identifies a database issue, ask \"Show me the database connection metrics during this time.\""
-        },
-        {
-          "type": "interactive",
-          "action": "noop",
-          "content": "Use Assistant's insights to validate your investigation findings and identify areas that need further examination."
-        },
-        {
-          "type": "markdown",
-          "content": "You used Grafana Assistant to get AI-powered analysis of the incident."
+          "content": "For example, if Assistant identifies a database issue, ask \"Show me the database connection metrics during this time.\"\n\nUse Assistant's insights to validate your investigation findings and identify areas that need further examination."
         }
       ]
+    },
+    {
+      "type": "markdown",
+      "content": "You used Grafana Assistant to get AI-powered analysis of the incident."
     },
     {
       "type": "markdown",

--- a/rca-workbench-investigation-lj/use-assistant/content.json
+++ b/rca-workbench-investigation-lj/use-assistant/content.json
@@ -1,0 +1,60 @@
+{
+  "id": "rca-workbench-investigation-use-assistant",
+  "title": "Use Grafana Assistant for investigation",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "In this milestone, you use Grafana Assistant to analyze incident data and receive AI-powered insights for root cause analysis.\n\nGrafana Assistant is an AI-powered tool integrated into RCA Workbench that helps accelerate incident investigation by analyzing correlated telemetry data and providing intelligent insights. Instead of manually piecing together metrics, logs, and traces, you can ask Assistant natural language questions to quickly identify patterns and potential root causes."
+    },
+    {
+      "type": "section",
+      "id": "use-assistant",
+      "title": "Use Grafana Assistant",
+      "blocks": [
+        {
+          "type": "markdown",
+          "content": "You'll open Grafana Assistant and use it to analyze the incident."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "button[data-testid='assistant-button']",
+          "content": "In RCA Workbench, click **Analyze RCA Workbench** in the lower right corner to open the Grafana Assistant chat interface.",
+          "requirements": ["on-page:/a/grafana-asserts-app/assertions", "exists-reftarget"]
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Ask Assistant to analyze the incident data. For example, type: \"What caused this incident?\" or \"Summarize the correlated metrics\"."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Review the AI-generated insights and recommendations provided by Assistant."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Ask follow-up questions to dive deeper into specific aspects of the investigation."
+        },
+        {
+          "type": "markdown",
+          "content": "For example, if Assistant identifies a database issue, ask \"Show me the database connection metrics during this time.\""
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Use Assistant's insights to validate your investigation findings and identify areas that need further examination."
+        },
+        {
+          "type": "markdown",
+          "content": "You used Grafana Assistant to get AI-powered analysis of the incident."
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "In the next milestone, you celebrate completing the RCA Workbench investigation workflow."
+    }
+  ]
+}

--- a/rca-workbench-investigation-lj/use-assistant/manifest.json
+++ b/rca-workbench-investigation-lj/use-assistant/manifest.json
@@ -1,0 +1,20 @@
+{
+  "id": "rca-workbench-investigation-use-assistant",
+  "type": "guide",
+  "description": "Use Grafana Assistant to analyze incident data and get AI-powered root cause insights.",
+  "category": "take-action",
+  "author": {
+    "team": "Grafana Documentation"
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": [
+    "rca-workbench-investigation-trace-dependencies"
+  ],
+  "recommends": [
+    "rca-workbench-investigation-end-journey"
+  ],
+  "suggests": [],
+  "provides": []
+}

--- a/rca-workbench-investigation-lj/use-assistant/website.yaml
+++ b/rca-workbench-investigation-lj/use-assistant/website.yaml
@@ -1,0 +1,7 @@
+menuTitle: Use Grafana Assistant
+weight: 800
+step: 9
+layout: single-journey
+cta:
+  type: continue
+description: Use Grafana Assistant to get AI-powered insights and root cause recommendations for your investigation.

--- a/rca-workbench-investigation-lj/website.yaml
+++ b/rca-workbench-investigation-lj/website.yaml
@@ -1,7 +1,7 @@
 menuTitle: Investigate incidents with RCA Workbench
 weight: 1100
 journey:
-  group: troubleshoot
+  group: take-action
   skill: Intermediate
   source: Docs & blog posts
   logo:

--- a/rca-workbench-investigation-lj/website.yaml
+++ b/rca-workbench-investigation-lj/website.yaml
@@ -1,0 +1,30 @@
+menuTitle: Investigate incidents with RCA Workbench
+weight: 1100
+journey:
+  group: troubleshoot
+  skill: Intermediate
+  source: Docs & blog posts
+  logo:
+    src: /static/img/menu/asserts_icon.svg
+    background: '#FFFFFF'
+    width: 46
+    height: 55
+step: 1
+layout: single-journey
+cascade:
+  layout: single-journey
+cta:
+  type: start
+  title: Are you ready?
+  cta_text: Let's go!
+related_journeys:
+  title: Related paths
+  heading: 'RCA Workbench correlates metrics, logs, and traces. Complete the following paths to learn more about each signal type:'
+  items:
+  - title: Use Traces Drilldown to identify high latency service requests
+    link: /docs/learning-paths/drilldown-traces/
+  - title: Use Logs Drilldown to investigate application errors
+    link: /docs/learning-paths/drilldown-logs/
+  - title: Use Metrics Drilldown to identify anomalous metrics
+    link: /docs/learning-paths/drilldown-metrics/
+description: Learn how to use RCA Workbench to investigate incidents by correlating metrics, logs, and traces across your services and infrastructure.


### PR DESCRIPTION
Adds content.json and manifest.json files for all 9 milestones of the RCA Workbench investigation learning path, with verified selectors from the Grafana Asserts app UI. 

Companion PR: https://github.com/grafana/website/pull/31737 — adds pathfinder_data front matter to the website milestone markdown files. Both PRs must merge for the interactive learning path to function.