### PR TITLE
fix(docs): correct and complete authoring reference — 9 discrepancies vs. pathfinder-app

### DIFF
--- a/.cursor/best-practices.mdc
+++ b/.cursor/best-practices.mdc
@@ -237,7 +237,7 @@ Run through this before opening the PR.
 - [ ] `id`, `title`, `blocks` present at root
 - [ ] Sections grouped via `section` blocks, not markdown `##`
 - [ ] All `section` / `input` ids are unique kebab-case
-- [ ] `schemaVersion` is `"1.1.0"` if set (or omitted)
+- [ ] `schemaVersion` is optional; any string is accepted at runtime (`"1.0.0"` and `"1.1.0"` are both valid; prefer `"1.1.0"` for new guides)
 - [ ] Each section has 1-sentence "what you'll do" intro markdown and "what you learned" summary markdown
 - [ ] No leading markdown title that duplicates the guide title
 

--- a/.cursor/commands/build-interactive-lj/reference/json-schema.md
+++ b/.cursor/commands/build-interactive-lj/reference/json-schema.md
@@ -1,33 +1,36 @@
-# JSON Schema Requirements
+# JSON Schema Reference for Learning-Path Guides
 
-This document defines the structure and field requirements for `content.json` files.
+> **Canonical reference:** For the full block type catalog, action types, and properties, see
+> [`docs/json-guide-reference.md`](../../../../docs/json-guide-reference.md).
+> For all requirement types (fixed and parameterized), see
+> [`docs/requirements-reference.md`](../../../../docs/requirements-reference.md).
+>
+> This file documents only the **LJ-specific content rules** that differ from or extend the
+> canonical reference — root-level field conventions, milestone scaffolding requirements,
+> block selection guidance for LJ content, and the supplementary content pattern.
 
 ---
 
-## Root-Level Schema (REQUIRED)
+## Root-Level Schema
 
-**CRITICAL:** Every `content.json` file MUST include these top-level fields:
+Every `content.json` in a learning path must include these top-level fields:
 
 ```json
 {
   "id": "[learning-path-slug]-[milestone-slug]",
   "title": "[Milestone Title]",
-  "blocks": [
-    // ... content blocks here
-  ]
+  "blocks": []
 }
 ```
 
-### Field Specifications:
-
 | Field | Type | Required | Description | Example |
 |-------|------|----------|-------------|---------|
-| `schemaVersion` | string | Optional | Omit it and the parser defaults to `"1.1.0"`. If you include it, the value MUST be `"1.1.0"` — any other value (for example `"1.0.0"`) fails validation. | `"1.1.0"` |
+| `schemaVersion` | string | Optional | Advisory field; not validated against a specific value. Current recommended value is `"1.1.0"`, but `"1.0.0"` and any other string are accepted at runtime. Omit if uncertain — the manifest defaults apply. | `"1.1.0"` |
 | `id` | string | ✅ Yes | Format: `[learning-path-slug]-[milestone-slug]` (kebab-case) | `"billing-usage-navigate-to-billing-dashboard"` |
 | `title` | string | ✅ Yes | Human-readable milestone title from source markdown | `"Navigate to the billing dashboard"` |
-| `blocks` | array | ✅ Yes | Array of content blocks (see below) | `[{...}, {...}]` |
+| `blocks` | array | ✅ Yes | Array of content blocks — see [docs/json-guide-reference.md](../../../../docs/json-guide-reference.md) for all block types | `[{...}, {...}]` |
 
-### Complete Example:
+### Complete Example
 
 ```json
 {
@@ -54,19 +57,25 @@ This document defines the structure and field requirements for `content.json` fi
 
 ---
 
-## Block Types
+## Block Types for LJ Content
 
-| Type | Purpose | Has "Do it"? | When to Use |
-|------|---------|--------------|-------------|
-| `markdown` | Explanatory text, instructions | No | Conceptual content, external actions, conditional UI |
-| `interactive` | Automated actions with "Show me" / "Do it" | Yes | Single UI interactions (click, fill, hover) |
-| `multistep` | Sequential navigation (shows "▶ Run N steps") | Yes | Multi-step navigation through menus |
-| `section` | Groups steps for sequential numbering | N/A | Wrap related interactive/noop steps so they render as numbered steps |
-| `guided` | User performs manually, no automation | No | Manual actions that can't be automated |
+See [`docs/json-guide-reference.md`](../../../../docs/json-guide-reference.md) for the complete reference. The most common blocks in learning-path guides are:
+
+| Type | Purpose | When to Use |
+|------|---------|-------------|
+| `markdown` | Explanatory text, instructions | Conceptual content, external actions, conditional UI |
+| `interactive` | Automated actions with "Show me" / "Do it" | Single UI interactions (click, fill, hover) |
+| `multistep` | Sequential navigation (shows "▶ Run N steps") | Multi-step navigation through menus |
+| `section` | Groups steps for sequential numbering | Wrap related interactive/noop steps |
+| `guided` | User performs manually, no automation | Manual actions that can't be automated |
+
+For all 17 registered block types (plus the runtime-only `challenge` block), see the canonical reference.
 
 ---
 
 ## Interactive Action Types
+
+See [`docs/interactive-actions.md`](../../../../docs/interactive-actions.md) for the full reference including `popout`. The most common actions in LJ guides:
 
 | Action | Use Case | `reftarget` Value | Additional Fields |
 |--------|----------|-------------------|-------------------|
@@ -75,20 +84,20 @@ This document defines the structure and field requirements for `content.json` fi
 | `formfill` | Enter text in field | CSS selector | `targetvalue` |
 | `hover` | Reveal hover-dependent UI | CSS selector | - |
 | `navigate` | Change pages | URL path | - |
-| `noop` | Non-interactive numbered step (no automation) | Not used | - |
+| `noop` | Non-interactive numbered step | Not used | - |
 
 ### The `noop` Action
 
-Use `noop` for steps that should be **numbered** within a `section` but don't trigger any UI automation. This is distinct from `markdown` blocks, which are unnumbered.
+Use `noop` for steps that should be **numbered** within a `section` but don't trigger UI automation.
 
 **When to use `noop`:**
 - The step is inside a `section` and should be numbered in sequence with interactive steps
-- The step is a directive telling the user to do something manually (e.g., "Enter the username and password", "Click **Save**")
+- The step is a directive telling the user to do something manually
 - The step is instructional but part of a numbered procedure
 
 **When NOT to use `noop`:**
-- The content is an observation or confirmation (e.g., "You should see a success message") → use `markdown`
-- The content is purely explanatory and should NOT be numbered → use `markdown`
+- The content is an observation or confirmation → use `markdown`
+- The content is purely explanatory → use `markdown`
 - The content is outside a `section` → use `markdown`
 
 ```json
@@ -101,12 +110,7 @@ Use `noop` for steps that should be **numbered** within a `section` but don't tr
 
 ### The `doIt` Property
 
-Add `"doIt": false` to any interactive block where the user should perform the action manually. This hides the "Do it" button while keeping the "Show me" highlight.
-
-**When to use `doIt: false`:**
-- The step involves user-specific input (e.g., selecting their own data source, entering a custom name)
-- The automated action could cause unintended side effects
-- The step highlights an element but the user should decide when/how to interact
+Add `"doIt": false` to any interactive block where the user should perform the action manually.
 
 ```json
 {
@@ -121,168 +125,23 @@ Add `"doIt": false` to any interactive block where the user should perform the a
 
 ---
 
-## Field Reference
+## Requirements in LJ Guides
 
-### IMPORTANT: Use Correct Field Names
+See [`docs/requirements-reference.md`](../../../../docs/requirements-reference.md) for the full reference. Common LJ requirements:
 
-**Common mistakes to avoid:**
-- ❌ `description` → ✅ `content`
-- ❌ `formvalue` → ✅ `targetvalue`
-- ❌ `title` on interactive blocks (not needed)
-
-### Optional Properties
-
-| Property | Type | Default | Description |
-|----------|------|---------|-------------|
-| `doIt` | boolean | `true` | Set to `false` to hide the "Do it" button while keeping "Show me" |
-
----
-
-## JSON Structure Examples
-
-### Highlight Action (Correct)
-
-```json
-{
-  "type": "interactive",
-  "action": "highlight",
-  "reftarget": "[data-testid=\"my-element\"]",
-  "content": "Click **Button** to do the thing.",
-  "requirements": ["exists-reftarget"]
-}
-```
-
-### Button Action (Correct)
-
-Uses button text, not CSS selector:
-
-```json
-{
-  "type": "interactive",
-  "action": "button",
-  "reftarget": "Install",
-  "content": "Click **Install** to add the dashboards.",
-  "requirements": ["exists-reftarget"]
-}
-```
-
-### Formfill Action (Correct)
-
-```json
-{
-  "type": "interactive",
-  "action": "formfill",
-  "reftarget": "[aria-label=\"Search connections by name\"]",
-  "targetvalue": "value to enter",
-  "content": "Enter the value.",
-  "requirements": ["exists-reftarget"]
-}
-```
-
-### Hover Action (Correct)
-
-For revealing hover-dependent UI:
-
-```json
-{
-  "type": "interactive",
-  "action": "hover",
-  "reftarget": "[data-testid=\"hover-target\"]",
-  "content": "Hover over this element to reveal options.",
-  "requirements": ["exists-reftarget"]
-}
-```
-
-### Section Block (Correct)
-
-Wraps interactive/noop steps so they render as a numbered sequence. All `interactive` and `noop` blocks inside a section are assigned step numbers (1, 2, 3...). `markdown` and `image` blocks inside a section are unnumbered.
-
-```json
-{
-  "type": "section",
-  "blocks": [
-    {
-      "type": "interactive",
-      "action": "noop",
-      "content": "Sign in to your Grafana environment."
-    },
-    {
-      "type": "multistep",
-      "content": "Navigate to **Connections > Add new connection**.",
-      "requirements": ["navmenu-open"],
-      "steps": [
-        { "action": "highlight", "reftarget": "a[data-testid='data-testid Nav menu item'][href='/connections']" },
-        { "action": "highlight", "reftarget": "a[data-testid='data-testid Nav menu item'][href='/connections/add-new-connection']" }
-      ]
-    },
-    {
-      "type": "markdown",
-      "content": "You should see the connections page."
-    }
-  ]
-}
-```
-
-> **Key rule:** A `section` with only one step should be a plain `interactive` block instead. Don't wrap a single step in a section.
-
-### Multistep Block (Correct)
-
-For navigation sequences:
-
-```json
-{
-  "type": "multistep",
-  "content": "Navigate to **X > Y > Z**.",
-  "requirements": ["navmenu-open"],
-  "steps": [
-    { "action": "highlight", "reftarget": "[aria-label=\"Expand section: Connections\"]" },
-    { "action": "highlight", "reftarget": "a[href=\"/connections/add-new-connection\"]" }
-  ]
-}
-```
-
-### Guided Block (Correct)
-
-User performs action manually, no "Do it" button:
-
-```json
-{
-  "type": "guided",
-  "content": "Copy the installation command and run it on your server.",
-  "requirements": []
-}
-```
-
-### Markdown Block (Correct)
-
-```json
-{
-  "type": "markdown",
-  "content": "This is explanatory text. Use markdown formatting:\n\n- Bullet points\n- **Bold text**\n- `Code snippets`"
-}
-```
-
----
-
-## Requirements Reference
-
-| Requirement | When to Use | Notes |
-|-------------|-------------|-------|
-| `exists-reftarget` | Any DOM interaction (highlight, formfill, button, hover) | Include for selector-targeting steps |
-| `navmenu-open` | Navigation menu elements (ensures menu is expanded) | — |
-| `on-page:/path` | Page-specific actions (checks current URL) | — |
-| `section-completed:id` | Sequential dependencies between sections | — |
-| `is-admin` | Admin-only features | — |
-| `has-datasource:type` | When a specific data source is needed | — |
-| `has-plugin:id` | When a specific plugin must be installed | — |
-
-> `exists-reftarget` is the standard convention for selector-targeting steps. Include it in the `requirements` array for any block or step with a `reftarget`.
+| Requirement | When to Use |
+|-------------|-------------|
+| `exists-reftarget` | Any DOM interaction (highlight, formfill, button, hover) |
+| `navmenu-open` | Navigation menu elements |
+| `on-page:/path` | Page-specific actions |
+| `section-completed:id` | Sequential dependencies between sections |
+| `is-admin` | Admin-only features |
+| `has-datasource:<identifier>` | When a specific data source is needed |
+| `has-plugin:id` | When a specific plugin must be installed |
 
 ---
 
 ## When to Use Markdown Instead of Interactive
-
-Some steps are better as plain `markdown` blocks rather than `interactive`:
 
 | Scenario | Why Markdown is Better |
 |----------|------------------------|
@@ -292,22 +151,9 @@ Some steps are better as plain `markdown` blocks rather than `interactive`:
 | Complex multi-option flows | Better to explain options than force one path |
 | Steps after external verification | User must complete real-world action first |
 
-### Example from Windows Integration
-
-The "Test Alloy connection" button only appears after the user has actually installed Alloy on their Windows machine. Since automation can't do that, the step is markdown:
-
-```json
-{
-  "type": "markdown",
-  "content": "After installing Alloy, click **Test Alloy connection** to verify the installation."
-}
-```
-
 ---
 
-## Scaffolding Rules
-
-### CRITICAL: Scaffold ALL Milestones
+## CRITICAL: Scaffold ALL Milestones
 
 **You MUST create content.json for EVERY milestone in the learning path.**
 
@@ -318,25 +164,12 @@ This includes:
 - ✅ Conclusion/outro pages (use `markdown` blocks)
 - ✅ External-only actions (use `markdown` or `guided` blocks)
 
-**Why scaffold everything?**
-- Pathfinder needs a content.json for every milestone to track progress through the learning path
-- Even non-interactive milestones need to be represented so users can mark them complete
-- Skipping milestones breaks the learning path flow
-- **The content.json is the source of truth** — all milestone content must live here
-
-### For Milestones WITH Interactive UI Steps:
-
-- Numbered steps that reference Grafana UI → `interactive` blocks with `action: "highlight"` and empty `reftarget`
-- Sequential navigation steps (e.g., "Navigate to X > Y > Z") → `multistep` blocks
-- Explanatory text between steps → `markdown` blocks
-
-### For Milestones WITHOUT Interactive UI Steps:
+### For Milestones WITHOUT Interactive UI Steps
 
 Convert ALL content to `markdown` blocks:
 
 ```json
 {
-  "schemaVersion": "1.0.0",
   "id": "learning-path-milestone-slug",
   "title": "Milestone Title",
   "blocks": [
@@ -352,9 +185,7 @@ Convert ALL content to `markdown` blocks:
 
 ## CRITICAL: Include ALL Supplementary Content from Frontmatter
 
-**The content.json files are the source of truth for learning paths.** You MUST extract and include
-ALL supplementary content from the website milestone's YAML frontmatter. These appear as markdown
-blocks at the END of the `blocks` array.
+The content.json files are the source of truth for learning paths. Extract and include ALL supplementary content from the website milestone's YAML frontmatter as markdown blocks at the END of the `blocks` array.
 
 ### Frontmatter Sections to Extract
 
@@ -366,7 +197,7 @@ blocks at the END of the `blocks` array.
 
 ### Formatting Rules
 
-Each supplementary block uses a **horizontal rule divider** (`---`) followed by an **H3 heading** (`###`). This visually separates supplementary content from the main body and renders the heading at a larger, more readable size than bold text.
+Each supplementary block uses a **horizontal rule divider** (`---`) followed by an **H3 heading** (`###`).
 
 ### Block Ordering
 
@@ -410,21 +241,20 @@ Supplementary blocks MUST appear at the end of the `blocks` array, in this order
 
 Before proceeding to selector discovery, verify EACH content.json file:
 
-### Root-Level Schema:
-- [ ] File includes `"schemaVersion": "1.0.0"` at root level
+### Root-Level Schema
 - [ ] File includes `"id"` field with format `[learning-path-slug]-[milestone-slug]`
 - [ ] File includes `"title"` field with human-readable milestone title
 - [ ] File includes `"blocks"` array at root level
 
-### Block-Level Requirements:
+### Block-Level Requirements
 - [ ] Every block has a `"type"` field
 - [ ] Instruction text uses `"content"` (NOT `"description"`)
 - [ ] Formfill actions use `"targetvalue"` (NOT `"formvalue"`)
 - [ ] Navigation steps use `"multistep"` blocks
-- [ ] Interactive blocks that target a CSS selector include `exists-reftarget` in their requirements array (repo convention)
+- [ ] Interactive blocks that target a CSS selector include `exists-reftarget` in their requirements array
 - [ ] Interactive blocks have empty `"reftarget": ""` (selectors added in Step 5)
 
-### Supplementary Content:
+### Supplementary Content
 - [ ] **`side_journeys` from frontmatter** → included as "More to explore" markdown block (if present)
 - [ ] **`related_journeys` from frontmatter** → included as "Related paths" markdown block (if present)
 - [ ] **`cta.troubleshooting` from frontmatter** → included as "Troubleshooting" markdown block (if present)

--- a/.cursor/common-workflows.mdc
+++ b/.cursor/common-workflows.mdc
@@ -13,7 +13,7 @@ description: Reusable workflow templates for common interactive guide patterns i
   "id": "setup-{datasource-type}",
   "title": "Set Up {DataSource} Data Source",
   "requirements": ["is-admin"],
-  "objectives": ["has-datasource:type:{datasource-type}"],
+  "objectives": ["has-datasource:{datasource-type}"],
   "blocks": [
     {
       "type": "interactive",
@@ -219,7 +219,7 @@ description: Reusable workflow templates for common interactive guide patterns i
   "type": "section",
   "id": "setup-prometheus",
   "title": "Setup Prometheus",
-  "objectives": ["has-datasource:type:prometheus"],
+  "objectives": ["has-datasource:prometheus"],
   "blocks": [
     {
       "type": "interactive",
@@ -270,7 +270,7 @@ description: Reusable workflow templates for common interactive guide patterns i
   "type": "section",
   "id": "setup-loki",
   "title": "Setup Loki",
-  "objectives": ["has-datasource:type:loki"],
+  "objectives": ["has-datasource:loki"],
   "blocks": [
     {
       "type": "interactive",
@@ -321,7 +321,7 @@ description: Reusable workflow templates for common interactive guide patterns i
   "type": "section",
   "id": "setup-influxdb",
   "title": "Setup InfluxDB",
-  "objectives": ["has-datasource:type:influxdb"],
+  "objectives": ["has-datasource:influxdb"],
   "blocks": [
     {
       "type": "interactive",

--- a/.cursor/complete-example-tutorial.mdc
+++ b/.cursor/complete-example-tutorial.mdc
@@ -59,7 +59,7 @@ This complete guide demonstrates all interactive features and best practices. Us
       "id": "setup-prometheus",
       "title": "Section 2: Configure Prometheus Data Source",
       "requirements": ["is-admin"],
-      "objectives": ["has-datasource:type:prometheus"],
+      "objectives": ["has-datasource:prometheus"],
       "tooltip": "Creates Prometheus data source - skipped if already configured",
       "blocks": [
         {

--- a/.cursor/edge-cases-and-troubleshooting.mdc
+++ b/.cursor/edge-cases-and-troubleshooting.mdc
@@ -94,7 +94,7 @@ description: Edge cases, troubleshooting patterns, and debugging techniques for 
   "type": "section",
   "id": "setup-prometheus",
   "title": "Setup Prometheus",
-  "objectives": ["has-datasource:type:prometheus"],
+  "objectives": ["has-datasource:prometheus"],
   "tooltip": "Skips if Prometheus already configured",
   "blocks": [
     // Setup steps only run if Prometheus not configured
@@ -781,7 +781,7 @@ See also: dashboard-specific lazy-render rule in `.cursor/skills/autogen-guide-d
   "type": "interactive",
   "action": "button",
   "reftarget": "prometheus",
-  "requirements": ["has-datasource:type:prometheus"],
+  "requirements": ["has-datasource:prometheus"],
   "tooltip": "Works with any Prometheus data source",
   "content": "Select any Prometheus data source"
 }

--- a/.cursor/review-guide-pr.mdc
+++ b/.cursor/review-guide-pr.mdc
@@ -141,7 +141,7 @@ Beyond the blocking issues above, look for these patterns:
 
 ### 4.1 Missing Objectives
 
-Expensive setup sections (data source creation, plugin installation) should have `objectives` so they auto-complete if the resource already exists. E.g., a "Setup Prometheus" section should have `"objectives": ["has-datasource:type:prometheus"]`.
+Expensive setup sections (data source creation, plugin installation) should have `objectives` so they auto-complete if the resource already exists. E.g., a "Setup Prometheus" section should have `"objectives": ["has-datasource:prometheus"]`.
 
 ### 4.2 Disconnected Requirements and Objectives
 

--- a/.cursor/review-guide-pr.mdc
+++ b/.cursor/review-guide-pr.mdc
@@ -94,7 +94,7 @@ Every block must have a valid `type`. Interactive blocks must have a valid `acti
 
 ### 2.5 Schema Version
 
-If `schemaVersion` is present, it MUST be `"1.1.0"`. Older `"1.0.0"` guides are grandfathered for read but new content should not use them. The field can be omitted — the schema default applies.
+If `schemaVersion` is present, any string value is accepted at runtime — both `"1.0.0"` (used by the majority of shipped guides) and `"1.1.0"` are valid. Prefer `"1.1.0"` for new guides but do not flag `"1.0.0"` as an error and do not request changes to existing guides solely to update this field. The field can be omitted entirely.
 
 ## 3. Content Quality
 

--- a/.cursor/tutorial-patterns.mdc
+++ b/.cursor/tutorial-patterns.mdc
@@ -246,7 +246,7 @@ The term "guide" is preferred over "tutorial" throughout this documentation.
       "type": "section",
       "id": "setup-monitoring-data",
       "title": "Setup Monitoring Data",
-      "objectives": ["has-datasource:type:prometheus"],
+      "objectives": ["has-datasource:prometheus"],
       "blocks": [
         // Data source setup
       ]
@@ -550,7 +550,7 @@ Content complexity analysis:
       "id": "setup-prometheus-datasource",
       "title": "Configure Prometheus Data Source",
       "requirements": ["is-admin"],
-      "objectives": ["has-datasource:type:prometheus"],
+      "objectives": ["has-datasource:prometheus"],
       "blocks": [
         // Data source setup steps
       ]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,7 @@ Full reference documentation lives in `docs/`. AI-oriented references live in `.
 15. **Bold only GUI names** -- "Click **Save & test**" not "Click the **Save & test** button"
 16. **`skippable: true` for conditional steps** -- use for permission-gated steps and optional/conditional fields
 17. **No focus-before-formfill** -- `highlight` on an input with `doIt: true` is a no-op; use `formfill` instead, or set `doIt: false`
-18. **`schemaVersion` is optional** -- if included, use `"schemaVersion": "1.1.0"`; the schema defaults to `"1.1.0"` when omitted
+18. **`schemaVersion` is optional and not enforced** -- the schema accepts any string value including `"1.0.0"` (used by the majority of shipped guides) and `"1.1.0"`. Prefer `"1.1.0"` for new guides but do not change existing guides solely to update this field
 19. **`popout` requires `targetvalue`** -- `popout` actions MUST set `targetvalue` to exactly `"sidebar"` or `"floating"`; the schema rejects any other value, and `popout` is not allowed inside `guided` blocks
 20. **Use `openGuide`, not `?doc=`** -- to chain a follow-up guide after a `navigate` step, set `openGuide: "bundled:<guide-id>"` on the interactive block; the legacy `?doc=` query param is back-compat only
 21. **`lazyRender` for virtualised targets** -- any step targeting a virtualised container (long tables, paginated lists, dashboard rows below the fold) MUST be inside a `guided` block with `lazyRender: true` on the step; plain `interactive` will fail because `exists-reftarget` cannot scroll

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ When a doc here disagrees with the upstream schema, the schema wins. Authoritati
 
 | Document | Purpose |
 |----------|---------|
-| [docs/json-guide-reference.md](docs/json-guide-reference.md) | All 16 block types and their properties |
+| [docs/json-guide-reference.md](docs/json-guide-reference.md) | All 17 registered block types and their properties (plus `challenge`, a runtime-only block type in the `JsonBlock` union — 18 total in the union) |
 | [docs/interactive-actions.md](docs/interactive-actions.md) | Action type behavior: `highlight`, `button`, `formfill`, `navigate`, `hover`, `noop`, `popout` |
 | [docs/requirements-reference.md](docs/requirements-reference.md) | All requirement types (fixed + parameterized) |
 | [docs/selectors-and-testids.md](docs/selectors-and-testids.md) | Stable selector patterns and pseudo-selectors |

--- a/docs/json-guide-reference.md
+++ b/docs/json-guide-reference.md
@@ -44,6 +44,7 @@ Every JSON guide has these fields:
 | `terminal-connect` | Interactive | Connect to Coda terminal | Establish terminal session |
 | `grot-guide` | Structural | Choose-your-own-adventure decision tree | Hand-authored branching guides (block editor only — CLI-excluded) |
 | `snippet-ref` | Structural | Reference to a pre-authored shared snippet | Editor-only; resolved at parse time via Snippet Picker (CLI-excluded) |
+| `challenge` | Interactive | CTF/Coda-VM challenge for hands-on learning | Hand-authored or editor only; not available via CLI `add-block` |
 
 ---
 
@@ -544,6 +545,43 @@ A reference to a pre-authored shared snippet resolved at parse time. This is the
 | `snippetId` | string | ✅ | Kebab-case identifier for the shared snippet to include |
 
 > **Authoring**: `snippet-ref` blocks are excluded from the Pathfinder CLI (`CLI_EXCLUDED_BLOCK_TYPES`). Use the editor's Snippet Picker to insert them, or hand-author the JSON if the snippet ID is known.
+
+---
+
+## Challenge Block
+
+A CTF/Coda-VM challenge block for challenge-based learning. The learner is given a brief, a terminal environment, and must satisfy a success criterion (typically a shell command that exits 0). `challenge` is part of the `JsonBlock` runtime union but is not currently available via the CLI `add-block` command — hand-author the JSON or use the editor. Check with the Pathfinder team for current editor support.
+
+```json
+{
+  "type": "challenge",
+  "mode": "coda",
+  "title": "Fix the broken configuration",
+  "brief": "The Alloy configuration file has an error. Find and fix it so the agent restarts successfully.",
+  "successCriteria": "coda-exit-zero:systemctl is-active alloy && echo ok",
+  "setupScript": "#!/bin/bash\necho 'broken' > /etc/alloy/config.alloy",
+  "hintLevels": [
+    "Check /etc/alloy/config.alloy for syntax errors.",
+    "Use `alloy fmt` to identify the specific line.",
+    "The closing brace on line 12 is missing."
+  ],
+  "failureMessage": "The Alloy service is not running. Review the configuration and try again."
+}
+```
+
+| Property | Type | Required | Default | Description |
+|----------|------|----------|---------|-------------|
+| `type` | string | ✅ | — | Must be `"challenge"` |
+| `successCriteria` | string | ✅ | — | Requirement token that determines pass/fail. Typically `coda-exit-zero:<command>` — see [Requirements Reference](requirements-reference.md#coda-exit-zero) |
+| `mode` | `"coda"` \| `"standard"` | ❌ | `"coda"` | `coda` uses a Coda VM environment; `standard` is a plain challenge without a VM |
+| `title` | string | ❌ | — | Challenge heading shown to the learner |
+| `brief` | string | ❌ | — | Challenge description and instructions (supports markdown) |
+| `setupScript` | string | ❌ | — | Shell script run to initialize the VM environment before the learner starts. Prefer over `setupCommands` |
+| `setupCommands` | string[] | ❌ | — | Array of setup commands (deprecated — prefer `setupScript`) |
+| `hintLevels` | string[] | ❌ | — | Progressive hints revealed one at a time as the learner requests them |
+| `failureMessage` | string | ❌ | — | Message shown when the learner's attempt fails |
+
+> **Authoring**: `challenge` blocks must be hand-authored or created via the editor — the Pathfinder CLI `add-block` command does not support them today.
 
 ---
 

--- a/docs/json-guide-reference.md
+++ b/docs/json-guide-reference.md
@@ -612,10 +612,11 @@ Knowledge assessment with single or multiple choice questions.
 | `multiSelect` | boolean | ❌ | `false` | Allow multiple answers (checkboxes) |
 | `completionMode` | string | ❌ | `"correct-only"` | `"correct-only"` or `"max-attempts"` |
 | `maxAttempts` | number | ❌ | `3` | Attempts before revealing (max-attempts mode) |
+| `shuffle` | boolean | ❌ | **`true`** | Randomize choice order for each learner. Set to `false` to preserve authored order. **Important:** if your question or hint references answer positions (e.g. "select the top option"), set `shuffle: false`. |
 | `requirements` | string[] | ❌ | — | Requirements for this quiz |
 | `skippable` | boolean | ❌ | `false` | Allow skipping |
 
-**Choice Properties:** `id` (string, required), `text` (string, required), `correct` (boolean), `hint` (string — shown when this wrong choice is selected).
+**Choice Properties:** `id` (string, required), `text` (string, required), `correct` (boolean), `hint` (string — shown when this wrong choice is selected), `pinned` (boolean — when `true`, this choice stays in its authored position even when `shuffle` is enabled; useful for "None of the above" style answers).
 
 **Multi-select example:**
 

--- a/docs/json-guide-reference.md
+++ b/docs/json-guide-reference.md
@@ -43,6 +43,7 @@ Every JSON guide has these fields:
 | `terminal` | Interactive | Shell command with Copy/Exec | Coda terminal commands |
 | `terminal-connect` | Interactive | Connect to Coda terminal | Establish terminal session |
 | `grot-guide` | Structural | Choose-your-own-adventure decision tree | Hand-authored branching guides (block editor only — CLI-excluded) |
+| `snippet-ref` | Structural | Reference to a pre-authored shared snippet | Editor-only; resolved at parse time via Snippet Picker (CLI-excluded) |
 
 ---
 
@@ -525,6 +526,24 @@ Self-contained choose-your-own-adventure decision tree. Users start on a welcome
 ### See Also
 
 - Pathfinder source: `src/types/json-guide.types.ts:533-625` (types), `src/types/json-guide.schema.ts:481-590` (schema), `src/cli/utils/block-registry.ts:80` (CLI exclusion).
+
+### Snippet Ref Block
+
+A reference to a pre-authored shared snippet resolved at parse time. This is the 17th registered block type, alongside `grot-guide`, it is excluded from the Pathfinder CLI — it must be authored through the Snippet Picker in the block editor or by hand-writing the JSON.
+
+```json
+{
+  "type": "snippet-ref",
+  "snippetId": "my-shared-snippet"
+}
+```
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `type` | string | ✅ | Must be `"snippet-ref"` |
+| `snippetId` | string | ✅ | Kebab-case identifier for the shared snippet to include |
+
+> **Authoring**: `snippet-ref` blocks are excluded from the Pathfinder CLI (`CLI_EXCLUDED_BLOCK_TYPES`). Use the editor's Snippet Picker to insert them, or hand-author the JSON if the snippet ID is known.
 
 ---
 

--- a/docs/json-guide-reference.md
+++ b/docs/json-guide-reference.md
@@ -802,6 +802,24 @@ If the variable is not set, `[not set]` is displayed as a fallback.
 
 ## Common Property Patterns
 
+### Editor-Only Annotation: `authorNote`
+
+Every block type supports an optional `authorNote` field. It is an editor-only annotation that is stripped before the guide is published — it never appears to learners. Use it to leave authoring notes, TODOs, or rationale directly inline with a block.
+
+```json
+{
+  "type": "interactive",
+  "action": "highlight",
+  "reftarget": "a[data-testid='data-testid Nav menu item'][href='/dashboards']",
+  "content": "Click **Dashboards**.",
+  "authorNote": "TODO: verify the nav testid still matches after the sidebar redesign"
+}
+```
+
+| Property | Type | Available on | Description |
+|----------|------|-------------|-------------|
+| `authorNote` | string | All block types | Editor-only inline note. Stripped on export; never shown to learners. |
+
 ### Requirements Array
 
 Requirements are specified as string arrays. All must pass for the element to be enabled:

--- a/docs/requirements-reference.md
+++ b/docs/requirements-reference.md
@@ -379,6 +379,25 @@ This requirement is evaluated differently by different rendering tools, allowing
 
 **Note**: Place a `terminal-connect` block before any `terminal` blocks to give users a way to establish the connection.
 
+### `coda-exit-zero:<command>`
+
+**Purpose**: Runs a shell command against the learner's active Coda challenge VM. The requirement passes if and only if the command exits with status 0. Used as the `successCriteria` value in [challenge blocks](./json-guide-reference.md#challenge-block).
+
+```json
+{
+  "type": "challenge",
+  "successCriteria": "coda-exit-zero:systemctl is-active alloy && echo ok",
+  "brief": "Fix the Alloy configuration so the service starts successfully."
+}
+```
+
+**Examples**:
+- `coda-exit-zero:cat /tmp/result | grep 'success'` — passes if the file contains "success"
+- `coda-exit-zero:systemctl is-active alloy` — passes if the alloy service is running
+- `coda-exit-zero:python3 /tmp/solution.py` — passes if the script exits cleanly
+
+**Note**: This requirement is only meaningful inside a `challenge` block's `successCriteria` field. It does not apply to `requirements` arrays on standard blocks.
+
 ---
 
 ## Variable Requirements
@@ -570,6 +589,7 @@ Objectives declare what a guide step will accomplish. They use the same syntax a
 | `section-completed:<sectionId>`      | Another section has been completed                     |
 | `var-<name>:<value>`                 | Guide variable has expected value (`*` = any non-empty) |
 | `renderer:<renderer>`                | Rendering context matches (`pathfinder` or `website`)  |
+| `coda-exit-zero:<command>`           | Shell command exits 0 against the learner's Coda challenge VM |
 
 ---
 


### PR DESCRIPTION
## Summary

This PR fixes 9 documented discrepancies between the interactive-tutorials authoring docs and the grafana-pathfinder-app implementation (the ground truth). The research was conducted in a prior scout pass; this PR applies the precise doc edits.

**Rule:** When a doc here disagrees with the schema, the schema wins. (`CLAUDE.md`)

---

## The 9 fixes

| # | Fix | Severity | Files |
|---|-----|----------|-------|
| D1 | **`has-datasource:type:X` syntax** — global-replace broken form across 5 `.cursor/*.mdc` files; `type:prometheus` was the literal search string passed to `hasDataSourceCheck`, which never matched any real datasource | **WRONG (bug)** | `common-workflows.mdc`, `tutorial-patterns.mdc`, `complete-example-tutorial.mdc`, `review-guide-pr.mdc`, `edge-cases-and-troubleshooting.mdc` |
| D2 | **`snippet-ref` block** — documented the 17th registered block type (editor-only, CLI-excluded, requires `snippetId`) | UNDOCUMENTED | `docs/json-guide-reference.md` |
| D3 | **`challenge` block** — documented the CTF/Coda-VM challenge block type with all fields: `mode`, `title`, `brief`, `successCriteria`, `setupScript`, `hintLevels`, `failureMessage` | UNDOCUMENTED | `docs/json-guide-reference.md` |
| D4 | **`coda-exit-zero:` requirement** — documented the 15th parameterized requirement; used as `challenge.successCriteria` | UNDOCUMENTED | `docs/requirements-reference.md` |
| D5 | **Quiz `shuffle` + choice `pinned`** — `shuffle` defaults to `true` (randomizes choice order); `pinned` keeps a choice in authored position despite shuffle | UNDOCUMENTED | `docs/json-guide-reference.md` |
| D6 | **"16 block types" count** — updated to 17 registered (18 in union including runtime-only `challenge`) | STALE | `CLAUDE.md` |
| D7 | **`build-interactive-lj/reference/json-schema.md`** — replaced 432-line drifted/incomplete partial copy of the schema with pointers to canonical docs, keeping only LJ-specific scaffolding rules | STALE/INCOMPLETE | `.cursor/commands/build-interactive-lj/reference/json-schema.md` |
| D8 | **`schemaVersion` "must be 1.1.0"** — corrected false "fails validation" claim; `schemaVersion` is `z.string().optional()` with no version gate; ~264 of 285 shipped guides use `"1.0.0"` | STALE/MISLEADING | `AGENTS.md`, `.cursor/review-guide-pr.mdc`, `.cursor/best-practices.mdc` |
| D9 | **`authorNote` field** — documented editor-only annotation available on every block type, stripped on export | UNDOCUMENTED | `docs/json-guide-reference.md` |

**D10 (challenge missing from VALID_BLOCK_TYPES) is a code bug in pathfinder-app — out of scope for this repo.**

## Ground truth

All fixes are verified against `grafana-pathfinder-app` source:
- `src/types/json-guide.schema.ts` — Zod schemas, `VALID_BLOCK_TYPES`, `JsonChallengeBlockSchema`, quiz `shuffle`/`pinned`
- `src/types/json-guide.types.ts` — `JsonBlock` union (18 members), `AuthorAnnotated`/`authorNote`
- `src/types/requirements.types.ts` — `ParameterizedRequirementPrefix.CODA_EXIT_ZERO`
- `src/requirements-manager/checks/grafana-api.ts:97-120` — `hasDataSourceCheck` (proves D1 bug)
- `src/cli/utils/block-registry.ts` — `CLI_EXCLUDED_BLOCK_TYPES`

🤖 Generated with [Claude Code](https://claude.com/claude-code)