### PR TITLE
Add interactive-dashboards-lj Pathfinder package

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -91,6 +91,7 @@
 /visualization-logs/                                      @jstickler
 /visualization-metrics-lj/                                @knylander-grafana
 /visualization-traces-lj/                                 @knylander-grafana
+/interactive-dashboards-lj/                               @bonnywelsford-source
 /welcome-to-play/                                         @Jayclifford345 @mdcruz
 /windows-integration/                                     @chri2547
 /haproxy-load-balancer-lj/                                @tacole02

--- a/interactive-dashboards-lj/assets/selector-notes.md
+++ b/interactive-dashboards-lj/assets/selector-notes.md
@@ -1,0 +1,88 @@
+# Selector discovery notes — interactive-dashboards-lj
+
+Selectors verified live at **learn.grafana.net** (Grafana 12.4+ sidebar dashboard options flow).
+
+## Verification status
+
+| Milestone | Status |
+|-----------|--------|
+| create-query-variable | Live tested — sidebar flow verified |
+| create-custom-variable | Live tested — sidebar + Custom Variable modal verified |
+| use-variables-queries | Live tested — panel menu noop, doIt on Run/Save/Exit; Back to dashboard skippable |
+| chain-variables | Live tested — Classic query note added; Regex placeholder is not a value |
+| configure-display-options | Live tested — Label/Display/Multi as noop (Pathfinder flaky); Sort copy fixed |
+| test-variable-interactions | Live tested — Share uses `new share button`; doIt on variable/Share; view mode required for Share |
+
+## Key selectors — sidebar dashboard options flow (Grafana 12.4+)
+
+| UI element | Selector |
+|------------|----------|
+| Edit / Exit edit | `[data-testid='data-testid Edit dashboard button']` |
+| Dashboard options (right sidebar gear) | `button[data-testid='data-testid Dashboard Sidebar options button']` |
+| Add variable (sidebar Variables section) | `button[data-testid='data-testid add variable button']` |
+| Variable type: Query | `[data-testid='data-testid variable type query'] button` |
+| Variable type: Custom | `[data-testid='data-testid variable type custom'] button` |
+| Variable name | `input[data-testid='data-testid variable name input']` |
+| Variable label (sidebar) | `input[data-testid='data-testid variable label input']` — correct testid (verified in Safari Inspect); Pathfinder `exists-reftarget` still flaky → guide uses `noop` |
+| Variable Display select | Testid exists (`Variable editor Display select`) but Pathfinder `exists-reftarget` fails on combobox — guide uses `noop` |
+| Multi-value / Include All | Same Pathfinder visibility failures on switches — guide uses `noop`; inspect later if restoring highlights |
+| Open query variable editor | `button[data-testid='data-testid Query Variable editor open button']` |
+| Data source picker | `[data-testid='data-testid Select a data source']` |
+| Query refresh | `[data-testid='data-testid Variable editor Form Query Refresh select']` |
+| Query preview | `button[data-testid='data-testid Query Variable editor preview button']` |
+| Close query editor | `button[data-testid='data-testid Query Variable editor close button']` |
+| Save dashboard | `[data-testid='data-testid Save dashboard button']` |
+| Panel menu (any title) | `button[data-testid*='Panel menu']` |
+| Panel menu → Edit | `a[data-testid='data-testid Panel menu item Edit']` |
+| Share (view mode, Grafana 11.1+) | `[data-testid='data-testid new share button']` — not legacy `share-button` |
+| Open custom variable editor | `button[data-testid='data-testid custom-variable-options-open-button']` |
+| Custom CSV options input (in modal) | `[data-testid='data-testid custom-variable-input']` |
+| Custom Apply (modal) | `button[data-testid='data-testid custom-variable-apply-button']` |
+
+## Deprecated — full settings page flow
+
+**Do not use** for variables on learn.grafana.net. The Variables tab shows:
+"Variable settings have moved to the dashboard's sidebar."
+
+| Deprecated element | Old selector |
+|--------------------|--------------|
+| View all settings → Variables tab | `a[data-testid='data-testid Tab Variables']` |
+| Add variable (empty list CTA) | `[data-testid='data-testid Call to action button Add variable']` |
+| Variable type dropdown | `[data-testid='data-testid Variable editor Form Type select']` |
+| Apply / Back to list | Full-page variable editor buttons |
+
+## Known risks
+
+1. **Variables section collapsed** — if **Add variable** isn't visible after **Dashboard options**, expand the **Variables** section in the pane.
+2. **Query editor** — PromQL query entry uses a Monaco editor without a stable single-field test id; left as markdown instruction.
+3. **Query Variable modal blocks docked sidebar** — `create-query-variable` pops out before the section and docks back after it (`renderer:pathfinder` conditional), matching `fleet-mgt-monitor-health-lj`. Pop out at start only; mid-flow popout resets step completion. Broader LJ popout norm is parked for a separate PR. **Open variable editor** has **Do it** enabled after popout.
+4. **Variable list row click** — editing an existing variable requires clicking a row in the variables table; no stable generic selector — uses `noop` step.
+5. **No Configure button (Grafana 12.4+)** — in dashboard edit mode, open the panel via **⋮ → Edit**, not a **Configure** button. Panel menu is often hover-only and title-specific, so `use-variables-queries` uses a `noop` for that step (guided highlight failed with Pathfinder's "hidden due to screen size" even on large viewports).
+6. **Demo metrics may lack `environment`** — filtering with `environment="$environment"` can correctly return **No data** if the label is absent; Custom variables still work for teaching `$variable` syntax.
+7. **Back to dashboard vs Exit edit** — **Back to dashboard** only exists in the panel editor. After **Save**, you may already be on the dashboard canvas; make that step `skippable` and follow with **Exit edit** (`Edit dashboard button` testid — same control, label toggles).
+
+## Block Editor testing (`?dev=true`)
+
+Pop out and Dock are **unnumbered** meta-steps outside the section (same as fleet LJs). Learners never see them on the website renderer.
+
+### Known Pathfinder bug — Preview resets on pop out / dock
+
+In Block Editor dev mode, **Pop out and Dock remount the BlockEditor** in the other surface (sidebar ↔ floating). Each new instance defaults `viewMode` to **`edit`** — only guide JSON is persisted to localStorage, not the active view mode. Result: switching from **Preview (eyeball)** to **Edit (pencil)** after pop out or dock.
+
+- **Affects:** authors testing guides in Block Editor (`?dev=true`)
+- **Does not affect:** learners (no Block Editor; pop out shows the guide renderer only)
+- **Workaround:** click **Preview** again after pop out or dock
+- **Fix (Pathfinder):** persist `viewMode` across panel-mode handoffs, or share editor state between sidebar/floating BlockEditor mounts — [grafana-pathfinder-app#1290](https://github.com/grafana/grafana-pathfinder-app/issues/1290)
+
+### Known Pathfinder bug — floating panel scroll jumps on large highlights
+
+On **Refresh** (and similar modal steps), clicking **Show me** draws a highlight on `[data-testid='data-testid Variable editor Form Query Refresh select']`, which wraps the whole **Refresh** row — the orange box is intentionally large. If the floating guide overlaps that highlight, Pathfinder's `useHighlightDodge` may **reposition** the panel or switch it to **compact** mode (`height: auto`). When the highlight clears or updates (e.g. after selecting **On dashboard load**), the panel restores to **full** and the guide **scroll resets to the top**. Step progress is not lost; scroll back to your step.
+
+- **Workaround:** skip **Show me** on Refresh/Preview; read the instruction and act manually, then mark the step complete.
+- **Authoring option:** convert optional modal config steps (Refresh, Preview) to markdown-only like the Query step — avoids dodge entirely.
+- **Fix (Pathfinder):** preserve floating-panel scroll position across compact ↔ full transitions; consider tighter highlight targets for radio/toggle groups — [grafana-pathfinder-app#1291](https://github.com/grafana/grafana-pathfinder-app/issues/1291)
+
+## Pathfinder test order
+
+1. Import `interactive-dashboards-lj/create-query-variable/content.json`
+2. Then `create-custom-variable`, `use-variables-queries`, `chain-variables`, `configure-display-options`, `test-variable-interactions`

--- a/interactive-dashboards-lj/chain-variables/content.json
+++ b/interactive-dashboards-lj/chain-variables/content.json
@@ -1,0 +1,130 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "interactive-dashboards-chain-variables",
+  "title": "Chain variables together",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "Chained variables create dependent relationships where the options available in one variable depend on the selections made in another. This pattern enables cascading filters that help users drill down through hierarchical data structures."
+    },
+    {
+      "type": "markdown",
+      "content": "Cascading filter patterns are common in multi-tier filtering scenarios such as region > cluster > namespace > pod. Each level narrows the available options based on the previous selection, creating an intuitive navigation experience through your infrastructure or data hierarchy.\n\nTo create chained variables, complete the following steps:"
+    },
+    {
+      "type": "conditional",
+      "conditions": ["renderer:pathfinder"],
+      "whenTrue": [
+        {
+          "type": "interactive",
+          "action": "popout",
+          "targetvalue": "floating",
+          "content": "Pop this guide out so you can keep it visible while you work through this milestone, including when the **Query Variable** editor opens."
+        }
+      ],
+      "whenFalse": []
+    },
+    {
+      "type": "section",
+      "autoCollapse": false,
+      "blocks": [
+        {
+          "type": "markdown",
+          "content": "You'll create a parent variable and a child variable whose query references the parent selection."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='data-testid Edit dashboard button']",
+          "content": "Open your dashboard and click **Edit**.",
+          "requirements": ["exists-reftarget"],
+          "skippable": true
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "button[data-testid='data-testid Dashboard Sidebar options button']",
+          "content": "In the right sidebar, click **Dashboard options** (gear icon).",
+          "requirements": ["exists-reftarget"]
+        },
+        {
+          "type": "markdown",
+          "content": "Create your first-level (parent) variable if you don't already have one.\n\nFor example, in the **Variables** section click **Add variable**, choose **Query**, name it `region`, and enter query `label_values(region)`. Click **Save** when finished."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "button[data-testid='data-testid add variable button']",
+          "content": "In the **Variables** section of the pane, click **Add variable** to create a dependent (child) variable.",
+          "requirements": ["exists-reftarget"]
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='data-testid variable type query'] button",
+          "content": "Click **Query** to choose the query variable type.",
+          "requirements": ["exists-reftarget"]
+        },
+        {
+          "type": "interactive",
+          "action": "formfill",
+          "reftarget": "input[data-testid='data-testid variable name input']",
+          "targetvalue": "cluster",
+          "content": "Name your dependent variable.\n\nFor example, enter `cluster`.",
+          "requirements": ["exists-reftarget"],
+          "doIt": false
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "button[data-testid='data-testid Query Variable editor open button']",
+          "content": "Under **Query options**, click **Open variable editor**.",
+          "requirements": ["exists-reftarget"]
+        },
+        {
+          "type": "markdown",
+          "content": "Under **Query type**, select **Classic query** so the **Query** field appears.\n\nIn the **Query** field, reference the parent variable to filter results.\n\nFor example, use `label_values(up{region=\"$region\"}, cluster)`."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "button[data-testid='data-testid Query Variable editor close button']",
+          "content": "Click **Close** to finish configuring the query.",
+          "requirements": ["exists-reftarget"]
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='data-testid Save dashboard button']",
+          "content": "Click **Save** to save the dashboard with your chained variables.",
+          "requirements": ["exists-reftarget"]
+        },
+        {
+          "type": "markdown",
+          "content": "Test the cascading behavior by changing the parent variable selection. The dependent variable options should update automatically.\n\nRepeat to add additional levels—for example, a `namespace` variable that depends on `cluster`."
+        }
+      ]
+    },
+    {
+      "type": "conditional",
+      "conditions": ["renderer:pathfinder"],
+      "whenTrue": [
+        {
+          "type": "interactive",
+          "action": "popout",
+          "targetvalue": "sidebar",
+          "content": "Dock this guide back to the sidebar to continue to the next milestone."
+        }
+      ],
+      "whenFalse": []
+    },
+    {
+      "type": "markdown",
+      "content": "Selecting a value in the parent variable updates the available options in dependent variables, creating a cascading filter experience.\n\nIn the next milestone, you learn how to configure variable display options to control how variables appear to your users."
+    },
+    {
+      "type": "markdown",
+      "content": "---\n\n### More to explore (optional)\n\nAt this point in your journey, you can explore the following paths:\n\n- [Chained variable examples](https://grafana.com/docs/grafana/latest/visualizations/dashboards/variables/add-template-variables/#grafana-play-dashboard-examples)"
+    }
+  ]
+}

--- a/interactive-dashboards-lj/chain-variables/content.json
+++ b/interactive-dashboards-lj/chain-variables/content.json
@@ -29,10 +29,6 @@
       "autoCollapse": false,
       "blocks": [
         {
-          "type": "markdown",
-          "content": "You'll create a parent variable and a child variable whose query references the parent selection."
-        },
-        {
           "type": "interactive",
           "action": "highlight",
           "reftarget": "[data-testid='data-testid Edit dashboard button']",

--- a/interactive-dashboards-lj/chain-variables/manifest.json
+++ b/interactive-dashboards-lj/chain-variables/manifest.json
@@ -1,0 +1,17 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "interactive-dashboards-chain-variables",
+  "type": "guide",
+  "description": "Learn how to create dependent variable relationships and cascading filters.",
+  "category": "query-and-visualize",
+  "author": {
+    "name": "bonnywelsford-source",
+    "team": "Grafana Documentation"
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": ["interactive-dashboards-use-variables-queries"],
+  "recommends": ["interactive-dashboards-configure-display-options"],
+  "suggests": []
+}

--- a/interactive-dashboards-lj/chain-variables/website.yaml
+++ b/interactive-dashboards-lj/chain-variables/website.yaml
@@ -1,0 +1,20 @@
+menuTitle: Chain variables
+title: Chain variables together
+description: Learn how to create dependent variable relationships and cascading filters.
+weight: 500
+step: 6
+layout: single-journey
+cta:
+  type: continue
+side_journeys:
+  title: More to explore (optional)
+  heading: 'At this point in your journey, you can explore the following paths:'
+  items:
+    - title: Chained variable examples
+      link: /docs/grafana/latest/visualizations/dashboards/variables/add-template-variables/#grafana-play-dashboard-examples
+keywords:
+  - chained variables
+  - dependent variables
+  - cascading filters
+  - multi-tier filtering
+  - variable relationships

--- a/interactive-dashboards-lj/configure-display-options/content.json
+++ b/interactive-dashboards-lj/configure-display-options/content.json
@@ -1,0 +1,88 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "interactive-dashboards-configure-display-options",
+  "title": "Configure variable display options",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "Variable display configuration controls how variables appear and behave in your dashboard. Proper configuration improves the user experience by making variables intuitive and accessible to dashboard viewers."
+    },
+    {
+      "type": "markdown",
+      "content": "Display options include the type of selection options, user-friendly labels, and visibility settings. These configuration choices determine how users interact with your dashboard's filtering capabilities and can significantly impact usability.\n\nTo configure variable display options, complete the following steps:"
+    },
+    {
+      "type": "section",
+      "autoCollapse": false,
+      "blocks": [
+        {
+          "type": "markdown",
+          "content": "You'll customize how a variable appears and behaves on the dashboard."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='data-testid Edit dashboard button']",
+          "content": "Open your dashboard and click **Edit**.",
+          "requirements": ["exists-reftarget"],
+          "skippable": true
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "button[data-testid='data-testid Dashboard Sidebar options button']",
+          "content": "In the right sidebar, click **Dashboard options** (gear icon).",
+          "requirements": ["exists-reftarget"]
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "In the **Variables** section, click a variable name in the list to edit its configuration."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "In the **Label** field, enter a user-friendly display name.\n\nFor example, for the variable named `environment`, enter the label `Environment`."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "In the **Display** list, select where the variable appears on the dashboard.\n\nFor example, leave **Above dashboard** selected."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "In **Selection options**, optionally enable **Multi-value** to allow multiple selections."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Optionally enable **Include All value** to add an **All** choice."
+        },
+        {
+          "type": "markdown",
+          "content": "If your variable type includes a **Sort** setting (often in the query variable editor), you can choose how option values are ordered.\n\nFor example, select **Alphabetical (asc)**.\n\nCustom variables in the sidebar may not show **Sort** — you can skip this if you don't see it."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='data-testid Save dashboard button']",
+          "content": "Click **Save** to save your display configuration.",
+          "requirements": ["exists-reftarget"]
+        },
+        {
+          "type": "markdown",
+          "content": "The variable appears in the dashboard with your configured display options."
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "In the next milestone, you learn how to test variable interactions across different scenarios and edge cases."
+    },
+    {
+      "type": "markdown",
+      "content": "---\n\n### More to explore (optional)\n\nAt this point in your journey, you can explore the following paths:\n\n- [Configure variable selection options](https://grafana.com/docs/grafana/latest/visualizations/dashboards/variables/add-template-variables/#configure-variable-selection-options)"
+    }
+  ]
+}

--- a/interactive-dashboards-lj/configure-display-options/content.json
+++ b/interactive-dashboards-lj/configure-display-options/content.json
@@ -16,10 +16,6 @@
       "autoCollapse": false,
       "blocks": [
         {
-          "type": "markdown",
-          "content": "You'll customize how a variable appears and behaves on the dashboard."
-        },
-        {
           "type": "interactive",
           "action": "highlight",
           "reftarget": "[data-testid='data-testid Edit dashboard button']",
@@ -35,28 +31,23 @@
           "requirements": ["exists-reftarget"]
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "In the **Variables** section, click a variable name in the list to edit its configuration."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "In the **Label** field, enter a user-friendly display name.\n\nFor example, for the variable named `environment`, enter the label `Environment`."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "In the **Display** list, select where the variable appears on the dashboard.\n\nFor example, leave **Above dashboard** selected."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "In **Selection options**, optionally enable **Multi-value** to allow multiple selections."
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Optionally enable **Include All value** to add an **All** choice."
         },
         {

--- a/interactive-dashboards-lj/configure-display-options/manifest.json
+++ b/interactive-dashboards-lj/configure-display-options/manifest.json
@@ -1,0 +1,17 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "interactive-dashboards-configure-display-options",
+  "type": "guide",
+  "description": "Learn how to customize variable appearance and interaction patterns.",
+  "category": "query-and-visualize",
+  "author": {
+    "name": "bonnywelsford-source",
+    "team": "Grafana Documentation"
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": ["interactive-dashboards-chain-variables"],
+  "recommends": ["interactive-dashboards-test-variable-interactions"],
+  "suggests": []
+}

--- a/interactive-dashboards-lj/configure-display-options/website.yaml
+++ b/interactive-dashboards-lj/configure-display-options/website.yaml
@@ -1,0 +1,18 @@
+menuTitle: Configure display options
+title: Configure variable display options
+description: Learn how to customize variable appearance and interaction patterns.
+weight: 600
+step: 7
+layout: single-journey
+cta:
+  type: continue
+keywords:
+  - variable display
+  - multi-select
+  - variable user interface
+side_journeys:
+  title: More to explore (optional)
+  heading: 'At this point in your journey, you can explore the following paths:'
+  items:
+    - title: Configure variable selection options
+      link: /docs/grafana/latest/visualizations/dashboards/variables/add-template-variables/#configure-variable-selection-options

--- a/interactive-dashboards-lj/content.json
+++ b/interactive-dashboards-lj/content.json
@@ -1,0 +1,23 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "interactive-dashboards-lj",
+  "title": "Create interactive dashboards with variables",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "Welcome to the **Create interactive dashboards with variables** learning path. This journey teaches you to build interactive dashboards using variables, which lets users filter and customize views without editing queries or needing special permissions.\n\nUsing variables in dashboards helps you:\n\n- **End dashboard sprawl**: Replace dozens of environment-specific dashboards with a single, dynamic version.\n- **Empower users**: Enable self-service analytics so users can find insights without relying on creators.\n- **Reduce maintenance**: Lower the overhead of managing static copies of dashboards while increasing dashboard utility."
+    },
+    {
+      "type": "markdown",
+      "content": "## Here's what to expect\n\nWhen you complete this journey, you'll be able to:\n\n- Understand the types, use cases, and benefits of dashboard variables\n- Create query-based and custom variables\n- Use variables in panel queries to enable dynamic filtering\n- Chain variables together to build dependent relationships and cascading filters for hierarchical data\n- Configure variable display options and test variable interactions"
+    },
+    {
+      "type": "markdown",
+      "content": "## Before you begin\n\nBefore you begin, ensure you have the following:\n\n- Access to Grafana Cloud or a Grafana instance\n- Permissions to create and edit dashboards\n- At least one Prometheus or metrics data source connected"
+    },
+    {
+      "type": "markdown",
+      "content": "## Troubleshooting\n\nIf you get stuck, we've got your back! Where appropriate, troubleshooting information is just a click away.\n\n## More to explore\n\nWe understand you might want to explore other capabilities not strictly on this path. We'll provide you opportunities where it makes sense."
+    }
+  ]
+}

--- a/interactive-dashboards-lj/create-custom-variable/content.json
+++ b/interactive-dashboards-lj/create-custom-variable/content.json
@@ -1,0 +1,126 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "interactive-dashboards-create-custom-variable",
+  "title": "Create custom variables",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "Custom variables use manually defined option lists rather than querying data sources, making them ideal for static values that don't change frequently or don't exist in your data. They're perfect for cases where you want to present specific choices to users without depending on query results."
+    },
+    {
+      "type": "markdown",
+      "content": "They also offer predictability and control when the available options should remain consistent regardless of what data exists in your data sources.\n\nWhile query-based variables are excellent for discovering dynamic infrastructure, custom variables provide control over exact options and ordering for business logic that exists outside your monitoring data.\n\nTo create a custom variable, complete the following steps:"
+    },
+    {
+      "type": "conditional",
+      "conditions": ["renderer:pathfinder"],
+      "whenTrue": [
+        {
+          "type": "interactive",
+          "action": "popout",
+          "targetvalue": "floating",
+          "content": "Pop this guide out so you can keep it visible while you work through this milestone, including when the **Custom Variable** editor opens."
+        }
+      ],
+      "whenFalse": []
+    },
+    {
+      "type": "section",
+      "autoCollapse": false,
+      "blocks": [
+        {
+          "type": "markdown",
+          "content": "You'll add a custom variable with a manually defined list of options."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='data-testid Edit dashboard button']",
+          "content": "Open your dashboard and click **Edit**.",
+          "requirements": ["exists-reftarget"]
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "button[data-testid='data-testid Dashboard Sidebar options button']",
+          "content": "In the right sidebar, click **Dashboard options** (gear icon).",
+          "requirements": ["exists-reftarget"]
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "button[data-testid='data-testid add variable button']",
+          "content": "In the **Variables** section of the pane, click **Add variable**.",
+          "requirements": ["exists-reftarget"]
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='data-testid variable type custom'] button",
+          "content": "Click **Custom** to choose the custom variable type.",
+          "requirements": ["exists-reftarget"]
+        },
+        {
+          "type": "interactive",
+          "action": "formfill",
+          "reftarget": "input[data-testid='data-testid variable name input']",
+          "targetvalue": "severity",
+          "content": "In the **Name** field, enter the variable name you'll use in queries.\n\nFor example, enter `severity`.",
+          "requirements": ["exists-reftarget"],
+          "doIt": false
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "button[data-testid='data-testid custom-variable-options-open-button']",
+          "content": "Under **Custom options**, click **Open variable editor**.",
+          "requirements": ["exists-reftarget"]
+        },
+        {
+          "type": "interactive",
+          "action": "formfill",
+          "reftarget": "[data-testid='data-testid custom-variable-input']",
+          "targetvalue": "critical,warning,info,debug",
+          "content": "In the **CSV** tab, enter comma-separated values.\n\nFor example, enter `critical,warning,info,debug`.\n\nReview **Preview of values** to confirm the list matches what you expect.",
+          "requirements": ["exists-reftarget"],
+          "doIt": false
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "button[data-testid='data-testid custom-variable-apply-button']",
+          "content": "Click **Apply** to save the custom options.",
+          "requirements": ["exists-reftarget"]
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='data-testid Save dashboard button']",
+          "content": "Click **Save** to save the dashboard with your new variable.",
+          "requirements": ["exists-reftarget"]
+        },
+        {
+          "type": "markdown",
+          "content": "The dashboard displays the custom variable at the top as a drop-down list with your defined options."
+        }
+      ]
+    },
+    {
+      "type": "conditional",
+      "conditions": ["renderer:pathfinder"],
+      "whenTrue": [
+        {
+          "type": "interactive",
+          "action": "popout",
+          "targetvalue": "sidebar",
+          "content": "Dock this guide back to the sidebar to continue to the next milestone."
+        }
+      ],
+      "whenFalse": []
+    },
+    {
+      "type": "markdown",
+      "content": "In the next milestone, you learn how to reference variables in panel queries to filter data based on user selections."
+    }
+  ]
+}

--- a/interactive-dashboards-lj/create-custom-variable/content.json
+++ b/interactive-dashboards-lj/create-custom-variable/content.json
@@ -29,10 +29,6 @@
       "autoCollapse": false,
       "blocks": [
         {
-          "type": "markdown",
-          "content": "You'll add a custom variable with a manually defined list of options."
-        },
-        {
           "type": "interactive",
           "action": "highlight",
           "reftarget": "[data-testid='data-testid Edit dashboard button']",

--- a/interactive-dashboards-lj/create-custom-variable/manifest.json
+++ b/interactive-dashboards-lj/create-custom-variable/manifest.json
@@ -1,0 +1,17 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "interactive-dashboards-create-custom-variable",
+  "type": "guide",
+  "description": "Learn how to create variables with manually defined option lists.",
+  "category": "query-and-visualize",
+  "author": {
+    "name": "bonnywelsford-source",
+    "team": "Grafana Documentation"
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": ["interactive-dashboards-create-query-variable"],
+  "recommends": ["interactive-dashboards-use-variables-queries"],
+  "suggests": []
+}

--- a/interactive-dashboards-lj/create-custom-variable/website.yaml
+++ b/interactive-dashboards-lj/create-custom-variable/website.yaml
@@ -1,0 +1,12 @@
+menuTitle: Create custom variable
+title: Create custom variables
+description: Learn how to create variables with manually defined option lists.
+weight: 300
+step: 4
+layout: single-journey
+cta:
+  type: continue
+keywords:
+  - custom variables
+  - static variables
+  - manual options

--- a/interactive-dashboards-lj/create-query-variable/content.json
+++ b/interactive-dashboards-lj/create-query-variable/content.json
@@ -30,11 +30,6 @@
       "blocks": [
         {
           "type": "markdown",
-          "content": "You'll open an existing dashboard, enter edit mode, and add a query-based variable from dashboard options."
-        },
-        {
-          "type": "interactive",
-          "action": "noop",
           "content": "Open a dashboard that uses a Prometheus or metrics data source."
         },
         {

--- a/interactive-dashboards-lj/create-query-variable/content.json
+++ b/interactive-dashboards-lj/create-query-variable/content.json
@@ -1,0 +1,153 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "interactive-dashboards-create-query-variable",
+  "title": "Create query-based variables",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "Query-based variables dynamically populate filter options by querying your data sources, which ensures that variable options always reflect your current infrastructure and data. Unlike static variable lists that require manual updates, query-based variables leverage your data to generate filter options."
+    },
+    {
+      "type": "markdown",
+      "content": "This approach eliminates manual maintenance when entities change, because the variable automatically discovers new values through queries. With query-based variables, your dashboard filters stay synchronized with reality every time you add a new server, deploy to a new region, or introduce new services.\n\nTo create a query-based variable, complete the following steps:"
+    },
+    {
+      "type": "conditional",
+      "conditions": ["renderer:pathfinder"],
+      "whenTrue": [
+        {
+          "type": "interactive",
+          "action": "popout",
+          "targetvalue": "floating",
+          "content": "Pop this guide out so you can keep it visible while you work through this milestone, including when the **Query Variable** editor opens."
+        }
+      ],
+      "whenFalse": []
+    },
+    {
+      "type": "section",
+      "autoCollapse": false,
+      "blocks": [
+        {
+          "type": "markdown",
+          "content": "You'll open an existing dashboard, enter edit mode, and add a query-based variable from dashboard options."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Open a dashboard that uses a Prometheus or metrics data source."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='data-testid Edit dashboard button']",
+          "content": "Click **Edit** in the top-right corner.",
+          "requirements": ["exists-reftarget"]
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "button[data-testid='data-testid Dashboard Sidebar options button']",
+          "content": "In the right sidebar, click **Dashboard options** (gear icon).",
+          "requirements": ["exists-reftarget"]
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "button[data-testid='data-testid add variable button']",
+          "content": "In the **Variables** section of the pane, click **Add variable**.",
+          "requirements": ["exists-reftarget"]
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='data-testid variable type query'] button",
+          "content": "Click **Query** to choose the query variable type.",
+          "requirements": ["exists-reftarget"]
+        },
+        {
+          "type": "interactive",
+          "action": "formfill",
+          "reftarget": "input[data-testid='data-testid variable name input']",
+          "targetvalue": "environment",
+          "content": "In the **Name** field, enter the variable name you'll use in queries.\n\nFor example, enter `environment`.",
+          "requirements": ["exists-reftarget"],
+          "doIt": false
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "button[data-testid='data-testid Query Variable editor open button']",
+          "content": "Under **Query options**, click **Open variable editor**.",
+          "requirements": ["exists-reftarget"]
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='data-testid Select a data source']",
+          "content": "In the **Query Variable** editor, select your Grafana Cloud Prometheus data source.",
+          "requirements": ["exists-reftarget"],
+          "doIt": false,
+          "skippable": true
+        },
+        {
+          "type": "markdown",
+          "content": "In the **Query** field, enter a query that returns the list of values.\n\nFor example, select **Classic query** and enter `label_values(up, environment)` to retrieve unique environment labels."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='data-testid Variable editor Form Query Refresh select']",
+          "content": "Under **Refresh**, select when variable values should update.\n\nFor example, select **On dashboard load**.",
+          "requirements": ["exists-reftarget"],
+          "doIt": false,
+          "skippable": true
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "button[data-testid='data-testid Query Variable editor preview button']",
+          "content": "Click **Preview** to review the list of values.",
+          "requirements": ["exists-reftarget"],
+          "doIt": false,
+          "skippable": true
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "button[data-testid='data-testid Query Variable editor close button']",
+          "content": "Click **Close** to finish configuring the query.",
+          "requirements": ["exists-reftarget"]
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='data-testid Save dashboard button']",
+          "content": "Click **Save** to save the dashboard with your new variable.",
+          "requirements": ["exists-reftarget"]
+        },
+        {
+          "type": "markdown",
+          "content": "The dashboard displays the query variable at the top as an interactive drop-down list."
+        }
+      ]
+    },
+    {
+      "type": "conditional",
+      "conditions": ["renderer:pathfinder"],
+      "whenTrue": [
+        {
+          "type": "interactive",
+          "action": "popout",
+          "targetvalue": "sidebar",
+          "content": "Dock this guide back to the sidebar to continue to the next milestone."
+        }
+      ],
+      "whenFalse": []
+    },
+    {
+      "type": "markdown",
+      "content": "In the next milestone, you learn how to create custom variables with manually defined options."
+    }
+  ]
+}

--- a/interactive-dashboards-lj/create-query-variable/manifest.json
+++ b/interactive-dashboards-lj/create-query-variable/manifest.json
@@ -11,7 +11,7 @@
   "testEnvironment": {
     "tier": "cloud"
   },
-  "depends": ["interactive-dashboards-understanding-variables"],
+  "depends": [],
   "recommends": ["interactive-dashboards-create-custom-variable"],
   "suggests": []
 }

--- a/interactive-dashboards-lj/create-query-variable/manifest.json
+++ b/interactive-dashboards-lj/create-query-variable/manifest.json
@@ -1,0 +1,17 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "interactive-dashboards-create-query-variable",
+  "type": "guide",
+  "description": "Learn how to create variables populated dynamically from data source queries.",
+  "category": "query-and-visualize",
+  "author": {
+    "name": "bonnywelsford-source",
+    "team": "Grafana Documentation"
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": ["interactive-dashboards-understanding-variables"],
+  "recommends": ["interactive-dashboards-create-custom-variable"],
+  "suggests": []
+}

--- a/interactive-dashboards-lj/create-query-variable/website.yaml
+++ b/interactive-dashboards-lj/create-query-variable/website.yaml
@@ -1,0 +1,12 @@
+menuTitle: Create query variable
+title: Create query-based variables
+description: Learn how to create variables populated dynamically from data source queries.
+weight: 200
+step: 3
+layout: single-journey
+cta:
+  type: continue
+keywords:
+  - query variables
+  - dynamic variables
+  - Prometheus

--- a/interactive-dashboards-lj/end-journey/content.json
+++ b/interactive-dashboards-lj/end-journey/content.json
@@ -1,0 +1,23 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "interactive-dashboards-end-journey",
+  "title": "Destination reached!",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "Congratulations on completing this journey! Job well done!"
+    },
+    {
+      "type": "markdown",
+      "content": "We hope you've enjoyed traveling with us as you:\n\n- Understood the value of dashboard variables for creating flexible, user-controlled dashboards\n- Created query-based variables that populate filter options dynamically from data sources\n- Created custom variables with manually defined option lists\n- Referenced variables in panel queries to enable dynamic filtering\n- Chained variables together to create cascading filter relationships\n- Configured variable display options for optimal user experience\n- Tested variable interactions across multiple scenarios and edge cases"
+    },
+    {
+      "type": "markdown",
+      "content": "---\n\n### Related paths\n\nConsider taking the following paths after you complete this journey:\n\n- [Transform data in a Grafana Cloud dashboard](https://grafana.com/docs/learning-paths/data-transformation/)\n- [Visualize metrics](https://grafana.com/docs/learning-paths/visualization-metrics/)\n- [Visualize logs](https://grafana.com/docs/learning-paths/visualization-logs/)\n- [Visualize traces](https://grafana.com/docs/learning-paths/visualization-traces/)"
+    },
+    {
+      "type": "markdown",
+      "content": "---\n\n### More to explore (optional)\n\nAt this point in your journey, you can explore the following paths:\n\n- [Multi-property variables](https://grafana.com/docs/grafana/latest/visualizations/dashboards/variables/add-template-variables/#multi-property-query-variables)\n- [Multi-property custom variables](https://grafana.com/docs/grafana/latest/visualizations/dashboards/variables/add-template-variables/#multi-property-custom-variables)\n- [Multi-property query variables](https://grafana.com/docs/grafana/latest/visualizations/dashboards/variables/add-template-variables/#multi-property-query-variables)"
+    }
+  ]
+}

--- a/interactive-dashboards-lj/end-journey/manifest.json
+++ b/interactive-dashboards-lj/end-journey/manifest.json
@@ -1,0 +1,22 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "interactive-dashboards-end-journey",
+  "type": "guide",
+  "description": "Congratulations on completing the interactive dashboards with variables learning path!",
+  "category": "query-and-visualize",
+  "author": {
+    "name": "bonnywelsford-source",
+    "team": "Grafana Documentation"
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": ["interactive-dashboards-test-variable-interactions"],
+  "recommends": [],
+  "suggests": [
+    "data-transformation-lj",
+    "visualization-metrics-lj",
+    "visualization-logs",
+    "visualization-traces-lj"
+  ]
+}

--- a/interactive-dashboards-lj/end-journey/website.yaml
+++ b/interactive-dashboards-lj/end-journey/website.yaml
@@ -1,0 +1,34 @@
+menuTitle: Destination reached!
+title: Destination reached!
+description: Congratulations on completing the interactive dashboards with variables learning path!
+weight: 800
+step: 9
+layout: single-journey
+cta:
+  type: conclusion
+  image:
+    src: /media/docs/learning-journey/journey-conclusion-header-1.svg
+    width: 735
+    height: 175
+side_journeys:
+  title: More to explore (optional)
+  heading: 'At this point in your journey, you can explore the following paths:'
+  items:
+    - title: Multi-property variables
+      link: /docs/grafana/latest/visualizations/dashboards/variables/add-template-variables/#multi-property-query-variables
+    - title: Multi-property custom variables
+      link: /docs/grafana/latest/visualizations/dashboards/variables/add-template-variables/#multi-property-custom-variables
+    - title: Multi-property query variables
+      link: /docs/grafana/latest/visualizations/dashboards/variables/add-template-variables/#multi-property-query-variables
+related_journeys:
+  title: Related paths
+  heading: Consider taking the following paths after you complete this journey.
+  items:
+    - title: Transform data in a Grafana Cloud dashboard
+      link: /docs/learning-paths/data-transformation/
+    - title: Visualize metrics
+      link: /docs/learning-paths/visualization-metrics/
+    - title: Visualize logs
+      link: /docs/learning-paths/visualization-logs/
+    - title: Visualize traces
+      link: /docs/learning-paths/visualization-traces/

--- a/interactive-dashboards-lj/manifest.json
+++ b/interactive-dashboards-lj/manifest.json
@@ -31,7 +31,6 @@
     "tier": "cloud"
   },
   "milestones": [
-    "interactive-dashboards-understanding-variables",
     "interactive-dashboards-create-query-variable",
     "interactive-dashboards-create-custom-variable",
     "interactive-dashboards-use-variables-queries",

--- a/interactive-dashboards-lj/manifest.json
+++ b/interactive-dashboards-lj/manifest.json
@@ -1,0 +1,49 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "interactive-dashboards-lj",
+  "type": "path",
+  "description": "Step-by-step guide: Create interactive dashboards with variables in Grafana Cloud.",
+  "category": "query-and-visualize",
+  "author": {
+    "name": "bonnywelsford-source",
+    "team": "Grafana Documentation"
+  },
+  "startingLocation": "/dashboards",
+  "targeting": {
+    "match": {
+      "or": [
+        {
+          "and": [
+            { "urlPrefix": "/dashboards" },
+            { "targetPlatform": "cloud" }
+          ]
+        },
+        {
+          "and": [
+            { "urlPrefix": "/d/" },
+            { "targetPlatform": "cloud" }
+          ]
+        }
+      ]
+    }
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "milestones": [
+    "interactive-dashboards-understanding-variables",
+    "interactive-dashboards-create-query-variable",
+    "interactive-dashboards-create-custom-variable",
+    "interactive-dashboards-use-variables-queries",
+    "interactive-dashboards-chain-variables",
+    "interactive-dashboards-configure-display-options",
+    "interactive-dashboards-test-variable-interactions",
+    "interactive-dashboards-end-journey"
+  ],
+  "depends": [],
+  "recommends": [
+    "data-transformation-lj",
+    "visualization-metrics-lj"
+  ],
+  "suggests": ["visualization-logs", "visualization-traces-lj"]
+}

--- a/interactive-dashboards-lj/test-variable-interactions/content.json
+++ b/interactive-dashboards-lj/test-variable-interactions/content.json
@@ -1,0 +1,93 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "interactive-dashboards-test-variable-interactions",
+  "title": "Test variable interactions",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "Testing variables across different scenarios ensures they work reliably for all users. Strategies include verifying single and multi-value selections, testing cascading behavior in chained variables, validating empty result handling, and monitoring query performance, especially on large datasets. Systematic testing prevents common issues and provides confidence that your interactive dashboard delivers a smooth user experience."
+    },
+    {
+      "type": "markdown",
+      "content": "To test variable interactions, complete the following steps:"
+    },
+    {
+      "type": "section",
+      "autoCollapse": false,
+      "blocks": [
+        {
+          "type": "markdown",
+          "content": "You'll exit edit mode and verify variable behavior from the dashboard viewer's perspective."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='data-testid Edit dashboard button']",
+          "content": "Return to dashboard view mode by clicking **Exit edit**.",
+          "requirements": ["exists-reftarget"],
+          "skippable": true
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "div[data-testid='data-testid template variable']",
+          "content": "Test single-value selection by choosing different variable options from the drop-down lists at the top of the dashboard.",
+          "requirements": ["exists-reftarget"],
+          "skippable": true
+        },
+        {
+          "type": "markdown",
+          "content": "Verify panels update with filtered data corresponding to each selection."
+        },
+        {
+          "type": "markdown",
+          "content": "If you're using multi-select variables, test selecting multiple values. Verify queries handle multiple selections correctly using regular expressions or IN clauses."
+        },
+        {
+          "type": "markdown",
+          "content": "Test the **All** option if it's enabled. Verify panels display data for all available values without errors."
+        },
+        {
+          "type": "markdown",
+          "content": "For chained variables, test cascading behavior. Change parent variable selections and verify that dependent variables update their options appropriately."
+        },
+        {
+          "type": "markdown",
+          "content": "Test empty states by selecting combinations that return no data. Verify panels display appropriate **No data** messages rather than errors."
+        },
+        {
+          "type": "markdown",
+          "content": "Test with different time ranges to verify time-dependent variables refresh correctly."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='data-testid new share button']",
+          "content": "Click **Share** in the top toolbar, then copy the dashboard URL from the share options.\n\nThe URL should include your variable selections in the query string.",
+          "requirements": ["exists-reftarget"],
+          "skippable": true
+        },
+        {
+          "type": "markdown",
+          "content": "Verify the URL includes variable selections in the query string for shareable filtered views."
+        },
+        {
+          "type": "markdown",
+          "content": "Monitor dashboard performance by checking query response times. If performance degrades, consider optimizing variable queries or adding query caching."
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "## Testing checklist\n\n| Test Scenario | Expected Behavior |\n| --- | --- |\n| Single value selection | Panels filter to selected value |\n| Multi-value selection | Panels show data for all selected values |\n| All option selected | Panels show data for all available values |\n| Cascading variable dependency | Dependent variables update when parent changes |\n| Empty result set | Panels show **No data** message |\n| URL parameters | Variable selections preserved in shareable URLs |\n| Query performance | Queries complete within acceptable time (< 5s) |"
+    },
+    {
+      "type": "markdown",
+      "content": "Congratulations! You've mastered creating interactive dashboards with variables."
+    },
+    {
+      "type": "markdown",
+      "content": "---\n\n### More to explore (optional)\n\nAt this point in your journey, you can explore the following paths:\n\n- [Inspect variables for dependencies](https://grafana.com/docs/grafana/latest/visualizations/dashboards/variables/inspect-variable/)"
+    }
+  ]
+}

--- a/interactive-dashboards-lj/test-variable-interactions/content.json
+++ b/interactive-dashboards-lj/test-variable-interactions/content.json
@@ -16,10 +16,6 @@
       "autoCollapse": false,
       "blocks": [
         {
-          "type": "markdown",
-          "content": "You'll exit edit mode and verify variable behavior from the dashboard viewer's perspective."
-        },
-        {
           "type": "interactive",
           "action": "highlight",
           "reftarget": "[data-testid='data-testid Edit dashboard button']",

--- a/interactive-dashboards-lj/test-variable-interactions/manifest.json
+++ b/interactive-dashboards-lj/test-variable-interactions/manifest.json
@@ -1,0 +1,17 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "interactive-dashboards-test-variable-interactions",
+  "type": "guide",
+  "description": "Learn how to verify variable behavior across different scenarios and edge cases.",
+  "category": "query-and-visualize",
+  "author": {
+    "name": "bonnywelsford-source",
+    "team": "Grafana Documentation"
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": ["interactive-dashboards-configure-display-options"],
+  "recommends": ["interactive-dashboards-end-journey"],
+  "suggests": []
+}

--- a/interactive-dashboards-lj/test-variable-interactions/website.yaml
+++ b/interactive-dashboards-lj/test-variable-interactions/website.yaml
@@ -1,0 +1,19 @@
+menuTitle: Test variables
+title: Test variable interactions
+description: Learn how to verify variable behavior across different scenarios and edge cases.
+weight: 700
+step: 8
+layout: single-journey
+cta:
+  type: success
+side_journeys:
+  title: More to explore (optional)
+  heading: 'At this point in your journey, you can explore the following paths:'
+  items:
+    - title: Inspect variables for dependencies
+      link: /docs/grafana/latest/visualizations/dashboards/variables/inspect-variable/
+keywords:
+  - testing
+  - validation
+  - troubleshooting
+  - edge cases

--- a/interactive-dashboards-lj/understanding-variables/content.json
+++ b/interactive-dashboards-lj/understanding-variables/content.json
@@ -1,0 +1,31 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "interactive-dashboards-understanding-variables",
+  "title": "Understanding dashboard variables",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "Static dashboards require creating separate copies for different environments, regions, or teams, leading to dashboard proliferation and maintenance challenges. Dashboard variables solve this problem by enabling a single dashboard to adapt dynamically based on user selections, transforming rigid monitoring views into flexible analytical tools."
+    },
+    {
+      "type": "markdown",
+      "content": "Variables allow users to control what data they see through familiar drop-down filters and selections. Instead of maintaining dozens of nearly identical dashboards that differ only by environment or region, you create one parameterized dashboard that adapts to any context."
+    },
+    {
+      "type": "markdown",
+      "content": "With variables, your users can filter and customize their dashboard experience without requiring query editing skills or special permissions, making observability accessible to broader audiences across your organization."
+    },
+    {
+      "type": "markdown",
+      "content": "In addition to eliminating dashboard sprawl and empowering users, dashboard variables provide the following advantages:\n\n- Reduce maintenance overhead through centralized dashboard logic that adapts to different contexts.\n- Improve user experience by providing familiar filtering interfaces.\n- Increase dashboard reuse across teams, regions, and use cases."
+    },
+    {
+      "type": "markdown",
+      "content": "In the next milestone, you learn how to create basic query-based variables that populate filter options from your data sources."
+    },
+    {
+      "type": "markdown",
+      "content": "---\n\n### More to explore (optional)\n\nAt this point in your journey, you can explore the following paths:\n\n- [Variables overview](https://grafana.com/docs/grafana/latest/visualizations/dashboards/variables/)\n- [Variable types](https://grafana.com/docs/grafana/latest/visualizations/dashboards/variables/add-template-variables/)"
+    }
+  ]
+}

--- a/interactive-dashboards-lj/understanding-variables/manifest.json
+++ b/interactive-dashboards-lj/understanding-variables/manifest.json
@@ -1,0 +1,17 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "interactive-dashboards-understanding-variables",
+  "type": "guide",
+  "description": "Learn about variable types, use cases, and the benefits of interactive dashboards.",
+  "category": "query-and-visualize",
+  "author": {
+    "name": "bonnywelsford-source",
+    "team": "Grafana Documentation"
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": [],
+  "recommends": ["interactive-dashboards-create-query-variable"],
+  "suggests": []
+}

--- a/interactive-dashboards-lj/understanding-variables/website.yaml
+++ b/interactive-dashboards-lj/understanding-variables/website.yaml
@@ -1,0 +1,20 @@
+menuTitle: Understanding variables
+title: Understanding dashboard variables
+description: Learn about variable types, use cases, and the benefits of interactive dashboards.
+weight: 100
+step: 2
+layout: single-journey
+cta:
+  type: continue
+side_journeys:
+  title: More to explore (optional)
+  heading: 'At this point in your journey, you can explore the following paths:'
+  items:
+    - title: Variables overview
+      link: /docs/grafana/latest/visualizations/dashboards/variables/
+    - title: Variables types
+      link: /docs/grafana/latest/visualizations/dashboards/variables/add-template-variables/
+keywords:
+  - variables
+  - interactive dashboards
+  - benefits

--- a/interactive-dashboards-lj/use-variables-queries/content.json
+++ b/interactive-dashboards-lj/use-variables-queries/content.json
@@ -1,0 +1,96 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "interactive-dashboards-use-variables-queries",
+  "title": "Use variables in queries",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "Now that you've created variables, you can use them in panel queries to create dynamic filtering. When users change a variable selection, the panel automatically updates to show filtered results based on that selection."
+    },
+    {
+      "type": "markdown",
+      "content": "Variables use a basic syntax that works across different data sources. Understanding how to reference variables correctly for your data source ensures your panels respond dynamically to user interactions.\n\nTo use variables in panel queries, complete the following steps:"
+    },
+    {
+      "type": "section",
+      "autoCollapse": false,
+      "blocks": [
+        {
+          "type": "markdown",
+          "content": "You'll update a panel query to reference a dashboard variable and verify the filtered results."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Open a dashboard that already has a variable (for example, `environment`) and a panel that queries your metrics data source."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='data-testid Edit dashboard button']",
+          "content": "If you are not already editing, click **Edit** in the top-right corner.",
+          "requirements": ["exists-reftarget"],
+          "skippable": true
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Hover over the panel that you want to update, click the panel menu (⋮), then click **Edit**.\n\nThe panel editor opens."
+        },
+        {
+          "type": "markdown",
+          "content": "In the **Queries** tab, update your query to reference the variable with `$variableName` or `${variableName}`.\n\nFor example, change `up{environment=\"production\"}` to `up{environment=\"$environment\"}`.\n\nFor multi-value variables, use regular expression syntax: `up{environment=~\"$environment\"}`.\n\nIf the label does not exist on your series, the panel shows **No data** — that confirms the filter is applied. Use a label that exists on your metrics for live filtered results."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='data-testid RefreshPicker run button']",
+          "content": "Click **Run queries** (or **Refresh**) to test the query with the current variable value.",
+          "requirements": ["exists-reftarget"]
+        },
+        {
+          "type": "markdown",
+          "content": "Verify the query returns filtered results based on the variable selection."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='data-testid Save dashboard button']",
+          "content": "Click **Save**.",
+          "requirements": ["exists-reftarget"]
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='data-testid Back to dashboard button']",
+          "content": "Click **Back to dashboard** to leave the panel editor.",
+          "requirements": ["exists-reftarget"],
+          "skippable": true
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='data-testid Edit dashboard button']",
+          "content": "Click **Exit edit** to leave dashboard edit mode.",
+          "requirements": ["exists-reftarget"]
+        },
+        {
+          "type": "markdown",
+          "content": "When users change the variable selection in the dashboard, Grafana updates the panel data to show filtered results."
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "## Variable syntax examples\n\nDifferent data sources use different syntax for referencing variables in queries.\n\n**Prometheus queries**\n\n- Single value: `metric_name{label=\"$variable\"}`\n- Multi-value: `metric_name{label=~\"$variable\"}`\n\n**Loki queries**\n\n- Single value: `{environment=\"$environment\"}`\n- Multi-value: `{environment=~\"$environment\"}`\n\n**SQL queries**\n\n- Single value: `SELECT * FROM table WHERE column = '$variable'`\n- Multi-value: `SELECT * FROM table WHERE column IN ($variable:csv)`"
+    },
+    {
+      "type": "markdown",
+      "content": "In the next milestone, you learn how to create dependent variables that cascade based on other variable selections."
+    },
+    {
+      "type": "markdown",
+      "content": "---\n\n### Troubleshooting options\n\nExplore the following troubleshooting topic if you need help:\n\n- [Review variable syntax](https://grafana.com/docs/grafana/latest/visualizations/dashboards/variables/variable-syntax/)"
+    }
+  ]
+}

--- a/interactive-dashboards-lj/use-variables-queries/content.json
+++ b/interactive-dashboards-lj/use-variables-queries/content.json
@@ -17,11 +17,6 @@
       "blocks": [
         {
           "type": "markdown",
-          "content": "You'll update a panel query to reference a dashboard variable and verify the filtered results."
-        },
-        {
-          "type": "interactive",
-          "action": "noop",
           "content": "Open a dashboard that already has a variable (for example, `environment`) and a panel that queries your metrics data source."
         },
         {
@@ -33,8 +28,7 @@
           "skippable": true
         },
         {
-          "type": "interactive",
-          "action": "noop",
+          "type": "markdown",
           "content": "Hover over the panel that you want to update, click the panel menu (⋮), then click **Edit**.\n\nThe panel editor opens."
         },
         {

--- a/interactive-dashboards-lj/use-variables-queries/manifest.json
+++ b/interactive-dashboards-lj/use-variables-queries/manifest.json
@@ -1,0 +1,17 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "interactive-dashboards-use-variables-queries",
+  "type": "guide",
+  "description": "Learn how to reference variables in panel queries to create dynamic filtering.",
+  "category": "query-and-visualize",
+  "author": {
+    "name": "bonnywelsford-source",
+    "team": "Grafana Documentation"
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": ["interactive-dashboards-create-custom-variable"],
+  "recommends": ["interactive-dashboards-chain-variables"],
+  "suggests": []
+}

--- a/interactive-dashboards-lj/use-variables-queries/website.yaml
+++ b/interactive-dashboards-lj/use-variables-queries/website.yaml
@@ -1,0 +1,19 @@
+menuTitle: Use variables in queries
+title: Use variables in queries
+description: Learn how to reference variables in panel queries to create dynamic filtering.
+weight: 400
+step: 5
+layout: single-journey
+cta:
+  type: success
+troubleshooting:
+  heading: Troubleshooting options
+  title: 'Explore the following troubleshooting topic if you need help:'
+  items:
+    - title: Review variable syntax
+      link: /docs/grafana/latest/visualizations/dashboards/variables/variable-syntax/
+keywords:
+  - variable syntax
+  - dynamic queries
+  - PromQL
+  - LogQL

--- a/interactive-dashboards-lj/website.yaml
+++ b/interactive-dashboards-lj/website.yaml
@@ -1,0 +1,27 @@
+menuTitle: Create interactive dashboards with variables
+title: Create interactive dashboards with variables
+description: Learn how to create dynamic, user-controlled dashboards using variables for filtering and customization.
+weight: 1000
+journey:
+  group: query-and-visualize
+  skill: Beginner
+  source: Docs & blog posts
+  logo:
+    src: /static/img/menu/grafana2.svg
+    background: '#0068FF'
+    width: 80
+    height: 80
+step: 1
+layout: single-journey
+cascade:
+  layout: single-journey
+cta:
+  type: start
+  title: Are you ready?
+  cta_text: Let's go!
+keywords:
+  - variables
+  - interactive dashboards
+  - filters
+  - dynamic queries
+  - Grafana Cloud


### PR DESCRIPTION
## Summary
- Adds the `interactive-dashboards-lj` Pathfinder learning path package (query/custom variables, use in queries, chaining, display options, interaction testing).
- Guides live-tested against Grafana 12.4+ sidebar variable UI on learn.grafana.net.
- Registers CODEOWNERS for the package.

## Test plan
- [x] Pathfinder CLI `validate --package interactive-dashboards-lj` passes
- [x] Strict validate on all milestone `content.json` files
- [x] Live-tested milestones in Block Editor (`?dev=true`)
- [ ] CI validate-json workflow on this PR

Companion website PR: https://github.com/grafana/website/pull/31913

Merge this package PR before the website PR so Pathfinder embeds can resolve the guides.