### PR TITLE
Fix CI by using the node version specified by the pathfinder-app repo

### DIFF
--- a/.github/workflows/validate-json.yml
+++ b/.github/workflows/validate-json.yml
@@ -11,14 +11,14 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    
+
     steps:
     - name: Checkout code
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       with:
         persist-credentials: false
         submodules: false
-      
+
     - name: Checkout validation scripts from main
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       with:
@@ -28,20 +28,20 @@ jobs:
         sparse-checkout-cone-mode: false
         path: .github-trusted
         persist-credentials: false
-      
+
     - name: Validate index.json
       run: |
         echo "Validating index.json for well-formed JSON..."
-        
+
         # Check if index.json exists
         if [ ! -f "index.json" ]; then
           echo "❌ Error: index.json file not found"
           exit 1
         fi
-        
+
         # Validate JSON using the validation script
         python3 .github-trusted/.github/scripts/validate_json.py index.json
-        
+
         if [ $? -eq 0 ]; then
           echo "🎉 All validations passed! index.json is well-formed and properly structured."
         else
@@ -54,7 +54,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    
+
     steps:
     - name: Checkout code
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -73,7 +73,8 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
-        node-version: '22'
+        # Track pathfinder-app's engines.node so `npm ci` runs on a compatible version.
+        node-version-file: pathfinder-app/package.json
         cache: 'npm'
         cache-dependency-path: pathfinder-app/package-lock.json
 
@@ -105,15 +106,15 @@ jobs:
       run: |
         echo "🔍 Finding and validating content.json files..."
         echo ""
-        
+
         PASSED=0
         FAILED=0
-        
+
         # Find and iterate through each content.json file
         while IFS= read -r file; do
           if [ -n "$file" ]; then
             echo "📄 Validating: $file"
-            
+
             if node pathfinder-app/dist/cli/cli/index.js validate --strict "$file"; then
               PASSED=$((PASSED + 1))
             else
@@ -125,12 +126,12 @@ jobs:
         done < <(find . -name "content.json" -type f \
                    -not -path "./pathfinder-app/*" \
                    -not -path "./shared/*")
-        
+
         echo ""
         echo "📊 Validation Summary:"
         echo "  ✅ Passed: $PASSED"
         echo "  ❌ Failed: $FAILED"
-        
+
         if [ $FAILED -gt 0 ]; then
           echo ""
           echo "❌ $FAILED guide(s) failed validation!"


### PR DESCRIPTION
Unblocks https://github.com/grafana/interactive-tutorials/pull/435

```
Run npm ci
npm warn EBADENGINE Unsupported engine {
npm warn EBADENGINE   package: 'grafana-pathfinder-app@2.14.0',
npm warn EBADENGINE   required: { node: '>=24' },
npm warn EBADENGINE   current: { node: 'v22.23.1', npm: '10.9.8' }
npm warn EBADENGINE }
npm error code EUSAGE
npm error
```

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>
