### PR TITLE
Adds a tour of the Eurovision dashboard on Play.

### DIFF
--- a/play-eurovision-tour/content.json
+++ b/play-eurovision-tour/content.json
@@ -1,0 +1,10 @@
+{
+  "id": "play-eurovision-tour",
+  "title": "Take a Tour of the Eurovision 2026 Dashboard",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "## Introduction\n\nThis dashboard provides an overview of Eurovision 2026.\n\n_TODO: Replace this introduction once the dashboard JSON is provided. Describe what the dashboard shows and the Grafana features it demonstrates._"
+    }
+  ]
+}

--- a/play-eurovision-tour/content.json
+++ b/play-eurovision-tour/content.json
@@ -4,7 +4,266 @@
   "blocks": [
     {
       "type": "markdown",
-      "content": "## Introduction\n\nThis dashboard provides an overview of Eurovision 2026.\n\n_TODO: Replace this introduction once the dashboard JSON is provided. Describe what the dashboard shows and the Grafana features it demonstrates._"
+      "content": "## Introduction\n\nThis dashboard shows a full breakdown of the results and voting for the 2026 Eurovision Song Contest Final, held in Vienna, Austria on 16th May 2026.  25 countries competed for the votes of professional juries and the viewing public.\n\nThe jury and public in each country each award points to 10 other countries: 12 points for their favourite down to 1 point for their tenth favourite (and 0 for everyone else).  The winner is the country with the highest combined points total.\n\nThe whole dashboard is built from simple CSV data using Grafana's Google Sheets data source, with SQL expressions used to transform and join the data.  As we tour it, we'll also point out two layout features that keep everything tidy: **tabbed layouts** and **repeating rows**.\n\nThis tour assumes you're viewing the dashboard on Grafana Play with the **Country** variable set to **All** — the first step takes care of that for you."
+    },
+    {
+      "type": "interactive",
+      "action": "navigate",
+      "reftarget": "/d/eurovision/eurovision-2026?var-country=$__all",
+      "content": "Let's begin by opening the Eurovision 2026 dashboard with every country selected.",
+      "verify": "on-page:/d/eurovision/eurovision-2026"
+    },
+    {
+      "type": "markdown",
+      "content": "## Contest Overview\n\nThe first section of the dashboard summarizes the outcome of the contest.  Rather than stacking every panel on top of each other, it uses a **tabbed layout** so that related views share a single row.  Let's explore it."
+    },
+    {
+      "type": "section",
+      "id": "guide-section-overview",
+      "title": "Contest Overview and Tabbed Layouts",
+      "requirements": [
+        "on-page:/d/eurovision/eurovision-2026"
+      ],
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "button[data-testid='data-testid Tab Winner']",
+          "content": "The Contest Overview row uses a tabbed layout.  The Winner, Full Results, Popular Vote and Jury Vote tabs each show a different view of the same results without cluttering the dashboard.  We're starting on the Winner tab.",
+          "requirements": [
+            "exists-reftarget",
+            "on-page:/d/eurovision/eurovision-2026"
+          ],
+          "doIt": false,
+          "lazyRender": true
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "section[data-testid='data-testid Panel header Podium Finishers']",
+          "content": "The Winner tab summarizes who won, their song and their winning video, along with these podium finishers: the top three countries ranked by combined points.",
+          "requirements": [
+            "exists-reftarget",
+            "on-page:/d/eurovision/eurovision-2026"
+          ],
+          "doIt": false,
+          "lazyRender": true
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "section[data-testid='data-testid Panel header Points Breakdown by Type']",
+          "content": "This pie chart splits the winning country's points into the share that came from the professional juries and the share that came from the public televote.",
+          "requirements": [
+            "exists-reftarget",
+            "on-page:/d/eurovision/eurovision-2026"
+          ],
+          "doIt": false,
+          "lazyRender": true
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "section[data-testid='data-testid Panel header Point Award Frequencies']",
+          "content": "And this bar chart shows how often the winning country was awarded each points value across all of the voting countries.",
+          "requirements": [
+            "exists-reftarget",
+            "on-page:/d/eurovision/eurovision-2026"
+          ],
+          "doIt": false,
+          "lazyRender": true
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "button[data-testid='data-testid Tab Full Results']",
+          "content": "Now click the **Full Results** tab to see every country's score in one chart.",
+          "requirements": [
+            "exists-reftarget",
+            "on-page:/d/eurovision/eurovision-2026"
+          ],
+          "lazyRender": true
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "section[data-testid='data-testid Panel header Full Results']",
+          "content": "This stacked bar chart ranks all 25 countries by total points, with jury and televote points stacked together.  Tip: click **jury** or **televote** in the legend to show just that vote type on the graph.",
+          "requirements": [
+            "exists-reftarget",
+            "on-page:/d/eurovision/eurovision-2026"
+          ],
+          "doIt": false,
+          "lazyRender": true
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "button[data-testid='data-testid Tab Popular Vote']",
+          "content": "The **Popular Vote** tab ranks the countries by public televote points only.",
+          "requirements": [
+            "exists-reftarget",
+            "on-page:/d/eurovision/eurovision-2026"
+          ],
+          "doIt": false,
+          "lazyRender": true
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "button[data-testid='data-testid Tab Jury Vote']",
+          "content": "And the **Jury Vote** tab ranks them by professional jury points only.  Notice how the two often disagree!",
+          "requirements": [
+            "exists-reftarget",
+            "on-page:/d/eurovision/eurovision-2026"
+          ],
+          "doIt": false,
+          "lazyRender": true
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "You've seen how a tabbed layout keeps four related views of the results in a single, tidy row.  Next, let's discover how each panel turns raw spreadsheet data into these visualizations."
+    },
+    {
+      "type": "markdown",
+      "content": "## SQL Expressions in Grafana\n\nEvery panel in this dashboard shares the same recipe.  The data always comes from a Google Sheet containing two simple tabs: one describing the finalists, their songs and running order, and one containing the raw voting data (which country awarded how many points to which country, from the jury or the televote).\n\nThe Google Sheets queries simply fetch that raw data.  All of the counting, summing, joining and sorting you see on screen is done inside Grafana using the **SQL expressions** transformation.  Let's look at one."
+    },
+    {
+      "type": "section",
+      "id": "guide-section-sql",
+      "title": "Explore a SQL Expression",
+      "requirements": [
+        "on-page:/d/eurovision/eurovision-2026"
+      ],
+      "blocks": [
+        {
+          "type": "guided",
+          "content": "Open the Full Results panel for editing and switch to table view.",
+          "requirements": [
+            "on-page:/d/eurovision/eurovision-2026"
+          ],
+          "steps": [
+            {
+              "action": "highlight",
+              "reftarget": "section[data-testid='data-testid Panel header Full Results'] svg[data-testid='icon-ellipsis-v']",
+              "description": "Click here to open the panel menu.",
+              "lazyRender": true
+            },
+            {
+              "action": "highlight",
+              "reftarget": "a[data-testid='data-testid Panel menu item Edit']",
+              "description": "Now click Edit.",
+              "lazyRender": true
+            },
+            {
+              "action": "highlight",
+              "reftarget": "label[aria-label='Table view']",
+              "description": "Click the toggle to view the data as a table."
+            }
+          ],
+          "completeEarly": true
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "div[data-testid='data-testid Query editor row']:nth-match(1)",
+          "content": "This first query reads the raw voting data straight from the Google Sheet.  There's no aggregation here — it just returns every vote that was cast.",
+          "requirements": [
+            "exists-reftarget"
+          ],
+          "doIt": false,
+          "lazyRender": true
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "div[data-testid='data-testid Query editor row']:nth-match(2)",
+          "content": "This SQL expression sums each country's jury and televote points from those raw rows and sorts them into the final ranking.  Grafana runs the SQL over the query results, so the data source itself stays very simple.",
+          "requirements": [
+            "exists-reftarget"
+          ],
+          "doIt": false,
+          "lazyRender": true
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "button[data-testid='data-testid Back to dashboard button']",
+          "content": "Click the **Back to dashboard** button to continue the tour.",
+          "requirements": [
+            "exists-reftarget"
+          ],
+          "lazyRender": true
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "That single SQL expression did all of the aggregation for the Full Results chart.  Finally, let's see how the dashboard uses a variable to build a repeating, per-country section."
+    },
+    {
+      "type": "markdown",
+      "content": "## Repeating Rows and Variables\n\nThe lower part of the dashboard has a **repeating row** titled \"_Country_: Details\".  Grafana renders one copy of this row for every country you select, each with its own set of tabs — an Overview, the points awarded **to** that country, and the points given **by** that country.\n\nThis is driven by a dashboard **variable** named `country`.  The variable's values are read from the Google Sheet, and its value is substituted into the SQL expressions behind each panel — for example `WHERE country = \"${country}\"`.  The same variable even builds each country's YouTube link, by fetching that country's `youtube_id` and dropping it into a URL like `https://www.youtube.com/watch?v={{youtube_id}}`."
+    },
+    {
+      "type": "section",
+      "id": "guide-section-variables",
+      "title": "Repeating Rows and Variables",
+      "requirements": [
+        "on-page:/d/eurovision/eurovision-2026"
+      ],
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "input[data-testid='data-testid Dashboard template variables Variable Value DropDown value link text country-input']",
+          "content": "This is the Country variable at the top of the dashboard.  It's a multi-value variable set to All, so the repeating row below shows every country — pick just the ones you're interested in to narrow it down.",
+          "requirements": [
+            "exists-reftarget",
+            "on-page:/d/eurovision/eurovision-2026"
+          ],
+          "doIt": false,
+          "lazyRender": true
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "section[data-testid='data-testid Panel header Points Awarded to ${country}'] svg[data-testid='icon-ellipsis-v']",
+          "content": "Each repeating row has a \"Points Awarded to _Country_\" panel.  Open its menu, then choose Edit, to see the variable used inside a SQL expression.",
+          "requirements": [
+            "exists-reftarget",
+            "on-page:/d/eurovision/eurovision-2026"
+          ],
+          "lazyRender": true
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "div[data-testid='data-testid Query editor row']:nth-match(2)",
+          "content": "Study the SQL expression.  Note the `${country}` reference — the value of the variable for this repeated row (for example \"Austria\") is substituted into the expression when it's evaluated, so one panel definition serves every country.",
+          "requirements": [
+            "exists-reftarget"
+          ],
+          "doIt": false,
+          "lazyRender": true
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "button[data-testid='data-testid Back to dashboard button']",
+          "content": "Click the **Back to dashboard** button to finish the tour.",
+          "requirements": [
+            "exists-reftarget"
+          ],
+          "lazyRender": true
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "## Next Steps and Additional Resources\n\nWe hope you enjoyed this tour of the Eurovision 2026 dashboard.  Check out these resources to learn more about the techniques it uses:\n\n- [The Google Sheet used for the contest](https://docs.google.com/spreadsheets/d/1q0rR7luGqQUcb5spvhLaNMTe756NHyIXf6GktMpzEx0/view) (one tab for the finalists and songs, one tab for the voting).\n- [SQL expressions documentation](https://grafana.com/docs/grafana/latest/visualizations/panels-visualizations/query-transform-data/sql-expressions/).\n- [Google Sheets data source documentation](https://grafana.com/grafana/plugins/grafana-googlesheets-datasource/).\n- [Tabbed layouts and repeating rows (dashboard groupings)](https://grafana.com/docs/grafana/latest/dashboards/build-dashboards/create-dashboard/dashboard-groupings/).\n- [Dynamic text panel](https://grafana.com/grafana/plugins/marcusolsson-dynamictext-panel/) (used for the YouTube video links).\n- [Dynamic image panel](https://grafana.com/grafana/plugins/dalvany-image-panel/).\n"
     }
   ]
 }

--- a/play-eurovision-tour/content.json
+++ b/play-eurovision-tour/content.json
@@ -28,13 +28,12 @@
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "button[data-testid='data-testid Tab Winner']",
-          "content": "The Contest Overview row uses a tabbed layout.  The Winner, Full Results, Popular Vote and Jury Vote tabs each show a different view of the same results without cluttering the dashboard.  We're starting on the Winner tab.",
+          "reftarget": "a[data-testid='data-testid Tab Winner']",
+          "content": "The Contest Overview row uses a tabbed layout.  The Winner, Full Results, Popular Vote and Jury Vote tabs each show a different view of the same results without cluttering the dashboard.  Let's start on the **Winner** tab — click it to open it.",
           "requirements": [
             "exists-reftarget",
             "on-page:/d/eurovision/eurovision-2026"
           ],
-          "doIt": false,
           "lazyRender": true
         },
         {
@@ -76,7 +75,7 @@
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "button[data-testid='data-testid Tab Full Results']",
+          "reftarget": "a[data-testid='data-testid Tab Full Results']",
           "content": "Now click the **Full Results** tab to see every country's score in one chart.",
           "requirements": [
             "exists-reftarget",
@@ -88,7 +87,7 @@
           "type": "interactive",
           "action": "highlight",
           "reftarget": "section[data-testid='data-testid Panel header Full Results']",
-          "content": "This stacked bar chart ranks all 25 countries by total points, with jury and televote points stacked together.  Tip: click **jury** or **televote** in the legend to show just that vote type on the graph.",
+          "content": "This stacked bar chart ranks all 25 countries by total points, with jury and televote points stacked together.  Tip: click **jury** or **televote** in the legend to show just that vote type on the graph, then click the same legend item again to bring both back into the stacked view.",
           "requirements": [
             "exists-reftarget",
             "on-page:/d/eurovision/eurovision-2026"
@@ -99,25 +98,23 @@
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "button[data-testid='data-testid Tab Popular Vote']",
-          "content": "The **Popular Vote** tab ranks the countries by public televote points only.",
+          "reftarget": "a[data-testid='data-testid Tab Popular Vote']",
+          "content": "Now click the **Popular Vote** tab, which ranks the countries by public televote points only.",
           "requirements": [
             "exists-reftarget",
             "on-page:/d/eurovision/eurovision-2026"
           ],
-          "doIt": false,
           "lazyRender": true
         },
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "button[data-testid='data-testid Tab Jury Vote']",
-          "content": "And the **Jury Vote** tab ranks them by professional jury points only.  Notice how the two often disagree!",
+          "reftarget": "a[data-testid='data-testid Tab Jury Vote']",
+          "content": "Finally, click the **Jury Vote** tab to rank them by professional jury points only.  Notice how the two often disagree!",
           "requirements": [
             "exists-reftarget",
             "on-page:/d/eurovision/eurovision-2026"
           ],
-          "doIt": false,
           "lazyRender": true
         }
       ]
@@ -140,11 +137,17 @@
       "blocks": [
         {
           "type": "guided",
-          "content": "Open the Full Results panel for editing and switch to table view.",
+          "content": "Switch to the Full Results tab, open that panel for editing, and switch to table view.",
           "requirements": [
             "on-page:/d/eurovision/eurovision-2026"
           ],
           "steps": [
+            {
+              "action": "highlight",
+              "reftarget": "a[data-testid='data-testid Tab Full Results']",
+              "description": "First, click the Full Results tab to bring that panel back into view.",
+              "lazyRender": true
+            },
             {
               "action": "highlight",
               "reftarget": "section[data-testid='data-testid Panel header Full Results'] svg[data-testid='icon-ellipsis-v']",

--- a/play-eurovision-tour/content.json
+++ b/play-eurovision-tour/content.json
@@ -137,7 +137,7 @@
       "blocks": [
         {
           "type": "guided",
-          "content": "Switch to the Full Results tab, open that panel for editing, and switch to table view.",
+          "content": "Switch to the Full Results tab and open that panel for editing.",
           "requirements": [
             "on-page:/d/eurovision/eurovision-2026"
           ],
@@ -159,14 +159,18 @@
               "reftarget": "a[data-testid='data-testid Panel menu item Edit']",
               "description": "Now click Edit.",
               "lazyRender": true
-            },
-            {
-              "action": "highlight",
-              "reftarget": "input[data-testid='data-testid toggle-table-view']",
-              "description": "Click the Table view toggle to view the data as a table."
             }
+          ]
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "label[for='table-view']",
+          "content": "Click the **Table view** toggle to see the panel's data as a table rather than a chart.",
+          "requirements": [
+            "exists-reftarget"
           ],
-          "completeEarly": true
+          "lazyRender": true
         },
         {
           "type": "interactive",
@@ -274,8 +278,7 @@
               "description": "Now click Edit.",
               "lazyRender": true
             }
-          ],
-          "completeEarly": true
+          ]
         },
         {
           "type": "interactive",
@@ -355,7 +358,7 @@
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "input[data-testid='data-testid toggle-table-view']",
+          "reftarget": "label[for='table-view']",
           "content": "Toggle **Table view** to see what the expression actually returns: a single row with one `country_rank` column.  The stat panel just formats that number as an ordinal — \"15th\" for Croatia.",
           "requirements": [
             "exists-reftarget"

--- a/play-eurovision-tour/content.json
+++ b/play-eurovision-tour/content.json
@@ -4,7 +4,7 @@
   "blocks": [
     {
       "type": "markdown",
-      "content": "## Introduction\n\nThis dashboard shows a full breakdown of the results and voting for the 2026 Eurovision Song Contest Final, held in Vienna, Austria on 16th May 2026.  25 countries competed for the votes of professional juries and the viewing public.\n\nThe jury and public in each country each award points to 10 other countries: 12 points for their favourite down to 1 point for their tenth favourite (and 0 for everyone else).  The winner is the country with the highest combined points total.\n\nThe whole dashboard is built from simple CSV data using Grafana's Google Sheets data source, with SQL expressions used to transform and join the data.  As we tour it, we'll also point out two layout features that keep everything tidy: **tabbed layouts** and **repeating rows**.\n\nThis tour assumes you're viewing the dashboard on Grafana Play with the **Country** variable set to **All** — the first step takes care of that for you."
+      "content": "## Introduction\n\nThis dashboard shows a full breakdown of the results and voting for the 2026 Eurovision Song Contest Final, held in Vienna, Austria on 16th May 2026.  25 countries competed for the votes of professional juries and the viewing public.\n\nThe jury and public in each country each award points to 10 other countries: 12 points for their favourite down to 1 point for their tenth favourite (and 0 for everyone else).  The winner is the country with the highest combined points total.\n\nThe whole dashboard is built from simple CSV data using Grafana's Google Sheets data source, with SQL expressions used to transform and join the data.  As we tour it, we'll also point out two layout features that keep everything tidy: **tabbed layouts** and **repeating rows**.\n\nThis tour assumes you're viewing the dashboard on Grafana Play with the **Country** variable set to **All** — the first step takes care of that for you.\n\nIf you'd like a more in-depth introduction to SQL expressions, try the [The Traitors UK dashboard](https://play.grafana.org/d/siqtdwm/the-traitors-uk-series-4) on Grafana Play and its interactive learning tour."
     },
     {
       "type": "interactive",
@@ -172,7 +172,7 @@
           "type": "interactive",
           "action": "highlight",
           "reftarget": "div[data-testid='data-testid Query editor row']:nth-match(1)",
-          "content": "This first query reads the raw voting data straight from the Google Sheet.  There's no aggregation here — it just returns every vote that was cast.",
+          "content": "This first query reads the raw voting data straight from the Google Sheet.  There's no aggregation here — it just returns every vote that was cast.\n\nNotice the **Hidden** badge on the query row.  Query A exists only to feed the SQL expression below it, which refers to those rows as table `A`.  Hiding a query keeps its results out of the visualization while still making them available to expressions — without it, this panel would try to plot several hundred individual votes on top of the 25 aggregated bars you actually want to see.  You can toggle it yourself with the crossed-out eye button (**Show response**) on the query row.",
           "requirements": [
             "exists-reftarget"
           ],
@@ -222,7 +222,26 @@
           "type": "interactive",
           "action": "highlight",
           "reftarget": "label[data-testid='data-testid Dashboard template variables submenu Label Country']",
-          "content": "This is the Country variable at the top of the dashboard.  It's a multi-value variable set to All, so the repeating row below shows every country — use the dropdown next to this label to pick just the ones you're interested in and narrow it down.",
+          "content": "This is the Country variable at the top of the dashboard.  It's a multi-value variable, and right now it's set to **All** — which is why there are 25 copies of the details row below, one per country.  Use the dropdown next to this label to pick just the countries you're interested in.",
+          "requirements": [
+            "exists-reftarget",
+            "on-page:/d/eurovision/eurovision-2026"
+          ],
+          "doIt": false,
+          "lazyRender": true
+        },
+        {
+          "type": "interactive",
+          "action": "navigate",
+          "reftarget": "/d/eurovision/eurovision-2026?var-country=Croatia&var-country=United%20Kingdom",
+          "content": "Let's narrow it down to two countries so the rest of the tour is easier to follow: **Croatia**, who finished mid-table, and the **United Kingdom**, who propped up the scoreboard.",
+          "verify": "on-page:/d/eurovision/eurovision-2026"
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "span[data-testid='data-testid dashboard-row-title-Croatia: Details']",
+          "content": "Twenty-five repeated rows just became two — \"Croatia: Details\" and \"United Kingdom: Details\".  Nothing about the dashboard changed except the variable's value; the row definition is written once and Grafana repeats it over whatever you select.",
           "requirements": [
             "exists-reftarget",
             "on-page:/d/eurovision/eurovision-2026"
@@ -232,7 +251,7 @@
         },
         {
           "type": "guided",
-          "content": "Open the first country's \"Points Awarded to\" panel for editing to see the variable used inside a SQL expression.",
+          "content": "Open Croatia's \"Points Awarded to\" panel for editing to see the variable used inside a SQL expression.",
           "requirements": [
             "on-page:/d/eurovision/eurovision-2026"
           ],
@@ -240,7 +259,7 @@
             {
               "action": "highlight",
               "reftarget": "a[data-testid^='data-testid Tab Points Awarded to']:nth-match(1)",
-              "description": "Scroll down to the first country's \"_Country_: Details\" row.  Each repeated row has its own Overview, \"Points Awarded to\" and \"Points Given by\" tabs — click the \"Points Awarded to\" tab.",
+              "description": "Scroll down to the \"Croatia: Details\" row.  Each repeated row has its own Overview, \"Points Awarded to\" and \"Points Given by\" tabs — click the \"Points Awarded to Croatia\" tab.",
               "lazyRender": true
             },
             {
@@ -262,7 +281,82 @@
           "type": "interactive",
           "action": "highlight",
           "reftarget": "div[data-testid='data-testid Query editor row']:nth-match(2)",
-          "content": "Study the SQL expression.  Note the `WHERE recipient_country = \"${country}\"` clause — the value of the variable for this repeated row (for example \"Albania\") is substituted in when the expression is evaluated, so one panel definition serves every country.  The same substitution is why the panel and its tab are titled with the country's actual name.",
+          "content": "Study the SQL expression.  Note the `WHERE recipient_country = \"${country}\"` clause — the value of the variable for this repeated row (here, \"Croatia\") is substituted in when the expression is evaluated, so one panel definition serves every country.  The same substitution is why the panel and its tab are titled with the country's actual name rather than `${country}`.",
+          "requirements": [
+            "exists-reftarget"
+          ],
+          "doIt": false,
+          "lazyRender": true
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "button[data-testid='data-testid Back to dashboard button']",
+          "content": "Click the **Back to dashboard** button to continue the tour.",
+          "requirements": [
+            "exists-reftarget"
+          ],
+          "lazyRender": true
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "## Working Out Each Country's Rank\n\nLet's look at one more SQL expression, because it solves a problem you'll meet in plenty of dashboards: turning a total into a **position in a league table**.\n\nEach country's **Overview** tab shows where that country finished — 1st, 2nd, 3rd and so on.  Nothing in the spreadsheet stores a finishing position, so the dashboard has to work it out.  The trick it uses is to count how many countries scored *more* points than this one, and add one.  If three countries beat you, you came 4th.\n\nThis panel has no title (it's one of the small unlabelled stats on the Overview tab), so rather than hunting for it in a panel menu, the next step opens it for editing directly."
+    },
+    {
+      "type": "section",
+      "id": "guide-section-rank",
+      "title": "Ranking with a SQL Expression",
+      "requirements": [
+        "on-page:/d/eurovision/eurovision-2026"
+      ],
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "a[data-testid='data-testid Tab Overview']:nth-match(1)",
+          "content": "First, click the **Overview** tab on Croatia's row.  Alongside the artist, song and running order you'll see a small stat showing Croatia finished **15th** — that's the panel we're about to open.  Scroll down to the United Kingdom's row and you'll see the same panel reporting **25th**, the same expression giving a different answer.",
+          "requirements": [
+            "exists-reftarget",
+            "on-page:/d/eurovision/eurovision-2026"
+          ],
+          "lazyRender": true
+        },
+        {
+          "type": "interactive",
+          "action": "navigate",
+          "reftarget": "/d/eurovision/eurovision-2026?var-country=Croatia&var-country=United%20Kingdom&editPanel=16",
+          "content": "Now let's open that ranking panel for editing.",
+          "verify": "on-page:/d/eurovision/eurovision-2026"
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "div[data-testid='data-testid Query editor row']:nth-match(1)",
+          "content": "As before, the first query is the plain Google Sheets query that fetches the raw voting rows.  It's hidden, so it feeds the expression below without being drawn on the panel.",
+          "requirements": [
+            "exists-reftarget"
+          ],
+          "doIt": false,
+          "lazyRender": true
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "div[data-testid='data-testid Query editor row']:nth-match(2)",
+          "content": "Here's the ranking expression.  Read it from the inside out: the subquery in the `FROM` clause totals up the points for every country, and the subquery in the `WHERE` clause totals up the points for this country.  `COUNT(*) + 1` then counts the countries whose total beat it and adds one, giving the finishing position.\n\nThis is a neat way to rank rows without a window function — and because `${country}` is substituted per repeated row, the same expression produces the right answer for all 25 countries.",
+          "requirements": [
+            "exists-reftarget"
+          ],
+          "doIt": false,
+          "lazyRender": true
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "input[data-testid='data-testid toggle-table-view']",
+          "content": "Toggle **Table view** to see what the expression actually returns: a single row with one `country_rank` column.  The stat panel just formats that number as an ordinal — \"15th\" for Croatia.",
           "requirements": [
             "exists-reftarget"
           ],
@@ -278,6 +372,13 @@
             "exists-reftarget"
           ],
           "lazyRender": true
+        },
+        {
+          "type": "interactive",
+          "action": "navigate",
+          "reftarget": "/d/eurovision/eurovision-2026?var-country=$__all",
+          "content": "Finally, let's set the **Country** variable back to **All**, so you're looking at the dashboard the way you found it — with all 25 countries repeated below.",
+          "verify": "on-page:/d/eurovision/eurovision-2026"
         }
       ]
     },

--- a/play-eurovision-tour/content.json
+++ b/play-eurovision-tour/content.json
@@ -162,8 +162,8 @@
             },
             {
               "action": "highlight",
-              "reftarget": "label[aria-label='Table view']",
-              "description": "Click the toggle to view the data as a table."
+              "reftarget": "input[data-testid='data-testid toggle-table-view']",
+              "description": "Click the Table view toggle to view the data as a table."
             }
           ],
           "completeEarly": true
@@ -221,8 +221,8 @@
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "input[data-testid='data-testid Dashboard template variables Variable Value DropDown value link text country-input']",
-          "content": "This is the Country variable at the top of the dashboard.  It's a multi-value variable set to All, so the repeating row below shows every country — pick just the ones you're interested in to narrow it down.",
+          "reftarget": "label[data-testid='data-testid Dashboard template variables submenu Label Country']",
+          "content": "This is the Country variable at the top of the dashboard.  It's a multi-value variable set to All, so the repeating row below shows every country — use the dropdown next to this label to pick just the ones you're interested in and narrow it down.",
           "requirements": [
             "exists-reftarget",
             "on-page:/d/eurovision/eurovision-2026"
@@ -231,21 +231,38 @@
           "lazyRender": true
         },
         {
-          "type": "interactive",
-          "action": "highlight",
-          "reftarget": "section[data-testid='data-testid Panel header Points Awarded to ${country}'] svg[data-testid='icon-ellipsis-v']",
-          "content": "Each repeating row has a \"Points Awarded to _Country_\" panel.  Open its menu, then choose Edit, to see the variable used inside a SQL expression.",
+          "type": "guided",
+          "content": "Open the first country's \"Points Awarded to\" panel for editing to see the variable used inside a SQL expression.",
           "requirements": [
-            "exists-reftarget",
             "on-page:/d/eurovision/eurovision-2026"
           ],
-          "lazyRender": true
+          "steps": [
+            {
+              "action": "highlight",
+              "reftarget": "a[data-testid^='data-testid Tab Points Awarded to']:nth-match(1)",
+              "description": "Scroll down to the first country's \"_Country_: Details\" row.  Each repeated row has its own Overview, \"Points Awarded to\" and \"Points Given by\" tabs — click the \"Points Awarded to\" tab.",
+              "lazyRender": true
+            },
+            {
+              "action": "highlight",
+              "reftarget": "section[data-testid^='data-testid Panel header Points Awarded to'] svg[data-testid='icon-ellipsis-v']",
+              "description": "Click here to open that panel's menu.",
+              "lazyRender": true
+            },
+            {
+              "action": "highlight",
+              "reftarget": "a[data-testid='data-testid Panel menu item Edit']",
+              "description": "Now click Edit.",
+              "lazyRender": true
+            }
+          ],
+          "completeEarly": true
         },
         {
           "type": "interactive",
           "action": "highlight",
           "reftarget": "div[data-testid='data-testid Query editor row']:nth-match(2)",
-          "content": "Study the SQL expression.  Note the `${country}` reference — the value of the variable for this repeated row (for example \"Austria\") is substituted into the expression when it's evaluated, so one panel definition serves every country.",
+          "content": "Study the SQL expression.  Note the `WHERE recipient_country = \"${country}\"` clause — the value of the variable for this repeated row (for example \"Albania\") is substituted in when the expression is evaluated, so one panel definition serves every country.  The same substitution is why the panel and its tab are titled with the country's actual name.",
           "requirements": [
             "exists-reftarget"
           ],

--- a/play-eurovision-tour/manifest.json
+++ b/play-eurovision-tour/manifest.json
@@ -1,0 +1,32 @@
+{
+  "id": "play-eurovision-tour",
+  "type": "guide",
+  "schemaVersion": "1.1.0",
+  "repository": "interactive-tutorials",
+  "language": "en",
+  "description": "A guided tour of the Eurovision 2026 dashboard on Grafana Play, exploring how the data is transformed and visualized.",
+  "category": "general",
+  "author": {
+    "name": "Simon Prickett",
+    "team": "interactive-learning"
+  },
+  "startingLocation": "/d/eurovision/eurovision-2026",
+  "targeting": {
+    "match": {
+      "and": [
+        { "urlPrefix": "/d/eurovision/eurovision-2026" },
+        { "source": "play.grafana.org" }
+      ]
+    }
+  },
+  "testEnvironment": {
+    "tier": "cloud",
+    "instance": "play.grafana.org"
+  },
+  "depends": [],
+  "recommends": [],
+  "suggests": [],
+  "provides": [],
+  "conflicts": [],
+  "replaces": []
+}


### PR DESCRIPTION
This PR adds a tour of the [Eurovision dashboard](https://play.grafana.org/d/eurovision/eurovision-2026) that's new to Play.