### PR TITLE
Saved Queries Pathfinder Guide: Basics in Explore

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -80,6 +80,7 @@
 /grafana-13-tour-play/                                    @Jayclifford345 @mdcruz
 /kiosk/                                                   @Jayclifford345
 /rca-demo/                                                @simonprickett
+/saved-queries-explore/                                   @CollinFingar
 /slo-quickstart/                                          @grafana/slo-squad
 /sm-setting-up-your-first-check/                          @TheComeUpCode
 /test-sm-overview-tutorial/                               @TheComeUpCode

--- a/saved-queries-explore/content.json
+++ b/saved-queries-explore/content.json
@@ -1,0 +1,112 @@
+{
+  "id": "saved-queries-explore",
+  "title": "Save & reuse queries",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "Saved queries lets you save a query for later and pull those queries back into the editor. This guide helps you both save and reintroduce saved queries. These can also be used in other features, like the Panel editor!"
+    },
+    {
+      "type": "markdown",
+      "content": "To save the query you're working on, complete these steps:"
+    },
+    {
+      "type": "section",
+      "title": "Save a query",
+      "requirements": [
+        "has-feature:queryLibrary"
+      ],
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "navigate",
+          "reftarget": "/explore",
+          "content": "Open **Explore**",
+          "objectives": [
+            "on-page:/explore"
+          ]
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "div[data-testid='data-testid Query editor row']",
+          "content": "Check that you have a query here",
+          "tooltip": "The save option only appears once a query has a data source, so make sure you have a query first.",
+          "requirements": [
+            "on-page:/explore",
+            "exists-reftarget"
+          ],
+          "doIt": false
+        },
+        {
+          "type": "guided",
+          "content": "Open the Saved queries menu and then select the \"Save query\" action. You can then name your query, and add a description and tags. Confirm the save once ready!",
+          "steps": [
+            {
+              "action": "highlight",
+              "reftarget": "div[data-testid='data-testid Query editor row'] button[data-testid='data-testid saved queries button']"
+            },
+            {
+              "action": "highlight",
+              "reftarget": "div[data-testid='data-testid portal-container'] button[data-testid='data-testid save to query library button']"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "Prefer to pull in a query you saved earlier? You can either open a query in a new Query editor row or replace an existing row:"
+    },
+    {
+      "type": "section",
+      "title": "Reuse a saved query in a new row",
+      "requirements": [
+        "has-feature:queryLibrary"
+      ],
+      "blocks": [
+        {
+          "type": "guided",
+          "content": "Open the Saved queries modal via the \"Add from saved queries\" button. Once open, you can filter and search for the query you'd like and then confirm selection.",
+          "steps": [
+            {
+              "action": "highlight",
+              "reftarget": "div[data-testid='data-testid explorer scroll view'] button[data-testid='data-testid explore add from query library button']"
+            }
+          ],
+          "stepTimeout": 30000,
+          "requirements": [
+            "on-page:/explore"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "section",
+      "title": "Reuse a saved query in an existing row",
+      "requirements": [
+        "has-feature:queryLibrary"
+      ],
+      "blocks": [
+        {
+          "type": "guided",
+          "content": "In the row you'd like replaced, open the Saved queries menu and then select \"Replace query.\" Inside the Saved queries modal, search and filter for your desired query and then confirm selection.",
+          "steps": [
+            {
+              "action": "highlight",
+              "reftarget": "div[data-testid='data-testid Query editor row'] button[data-testid='data-testid saved queries button']"
+            },
+            {
+              "action": "highlight",
+              "reftarget": "div[data-testid='data-testid portal-container'] button[data-testid='data-testid replace query from library button']"
+            }
+          ],
+          "stepTimeout": 30000,
+          "requirements": [
+            "on-page:/explore"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/saved-queries-explore/content.json
+++ b/saved-queries-explore/content.json
@@ -13,18 +13,14 @@
     {
       "type": "section",
       "title": "Save a query",
-      "requirements": [
-        "has-feature:queryLibrary"
-      ],
+      "requirements": ["has-feature:queryLibrary"],
       "blocks": [
         {
           "type": "interactive",
           "action": "navigate",
           "reftarget": "/explore",
           "content": "Open **Explore**",
-          "objectives": [
-            "on-page:/explore"
-          ]
+          "objectives": ["on-page:/explore"]
         },
         {
           "type": "interactive",
@@ -32,10 +28,7 @@
           "reftarget": "div[data-testid='data-testid Query editor row']",
           "content": "Check that you have a query here",
           "tooltip": "The save option only appears once a query has a data source, so make sure you have a query first.",
-          "requirements": [
-            "on-page:/explore",
-            "exists-reftarget"
-          ],
+          "requirements": ["on-page:/explore", "exists-reftarget"],
           "doIt": false
         },
         {
@@ -44,15 +37,21 @@
           "steps": [
             {
               "action": "highlight",
-              "reftarget": "div[data-testid='data-testid Query editor row'] button[data-testid='data-testid saved queries button']"
+              "reftarget": "div[data-testid='data-testid Query editor row'] button[data-testid='data-testid saved queries button']",
+              "requirements": ["exists-reftarget"]
             },
             {
               "action": "highlight",
-              "reftarget": "div[data-testid='data-testid portal-container'] button[data-testid='data-testid save to query library button']"
+              "reftarget": "div[data-testid='data-testid portal-container'] button[data-testid='data-testid save to query library button']",
+              "requirements": ["exists-reftarget"]
             }
           ]
         }
       ]
+    },
+    {
+      "type": "markdown",
+      "content": "That's it - your query is now saved to the library and ready to reuse."
     },
     {
       "type": "markdown",
@@ -61,9 +60,7 @@
     {
       "type": "section",
       "title": "Reuse a saved query in a new row",
-      "requirements": [
-        "has-feature:queryLibrary"
-      ],
+      "requirements": ["has-feature:queryLibrary"],
       "blocks": [
         {
           "type": "guided",
@@ -71,22 +68,27 @@
           "steps": [
             {
               "action": "highlight",
-              "reftarget": "div[data-testid='data-testid explorer scroll view'] button[data-testid='data-testid explore add from query library button']"
+              "reftarget": "div[data-testid='data-testid explorer scroll view'] button[data-testid='data-testid explore add from query library button']",
+              "requirements": ["exists-reftarget"]
             }
           ],
           "stepTimeout": 30000,
-          "requirements": [
-            "on-page:/explore"
-          ]
+          "requirements": ["on-page:/explore"]
         }
       ]
     },
     {
+      "type": "markdown",
+      "content": "The saved query now runs in its own new row, alongside your existing queries."
+    },
+    {
+      "type": "markdown",
+      "content": "To swap out the query in a row you're already using, replace it instead:"
+    },
+    {
       "type": "section",
       "title": "Reuse a saved query in an existing row",
-      "requirements": [
-        "has-feature:queryLibrary"
-      ],
+      "requirements": ["has-feature:queryLibrary"],
       "blocks": [
         {
           "type": "guided",
@@ -94,19 +96,23 @@
           "steps": [
             {
               "action": "highlight",
-              "reftarget": "div[data-testid='data-testid Query editor row'] button[data-testid='data-testid saved queries button']"
+              "reftarget": "div[data-testid='data-testid Query editor row'] button[data-testid='data-testid saved queries button']",
+              "requirements": ["exists-reftarget"]
             },
             {
               "action": "highlight",
-              "reftarget": "div[data-testid='data-testid portal-container'] button[data-testid='data-testid replace query from library button']"
+              "reftarget": "div[data-testid='data-testid portal-container'] button[data-testid='data-testid replace query from library button']",
+              "requirements": ["exists-reftarget"]
             }
           ],
           "stepTimeout": 30000,
-          "requirements": [
-            "on-page:/explore"
-          ]
+          "requirements": ["on-page:/explore"]
         }
       ]
+    },
+    {
+      "type": "markdown",
+      "content": "The row now runs your chosen saved query. You've saved and reused queries in Explore!"
     }
   ]
 }

--- a/saved-queries-explore/content.json
+++ b/saved-queries-explore/content.json
@@ -12,6 +12,7 @@
     },
     {
       "type": "section",
+      "id": "save-a-query",
       "title": "Save a query",
       "requirements": ["has-feature:queryLibrary"],
       "blocks": [
@@ -26,23 +27,26 @@
           "type": "interactive",
           "action": "highlight",
           "reftarget": "div[data-testid='data-testid Query editor row']",
-          "content": "Check that you have a query here",
+          "content": "Confirm a query exists in the editor",
           "tooltip": "The save option only appears once a query has a data source, so make sure you have a query first.",
           "requirements": ["on-page:/explore", "exists-reftarget"],
           "doIt": false
         },
         {
           "type": "guided",
-          "content": "Open the Saved queries menu and then select the \"Save query\" action. You can then name your query, and add a description and tags. Confirm the save once ready!",
+          "content": "Open the **Saved queries** menu, then choose **Save query**. In the dialog that opens, give your query a name (and an optional description and tags), then confirm to save it to the library.",
+          "requirements": ["on-page:/explore"],
           "steps": [
             {
               "action": "highlight",
               "reftarget": "div[data-testid='data-testid Query editor row'] button[data-testid='data-testid saved queries button']",
+              "description": "Click to open the **Saved queries** menu.",
               "requirements": ["exists-reftarget"]
             },
             {
               "action": "highlight",
               "reftarget": "div[data-testid='data-testid portal-container'] button[data-testid='data-testid save to query library button']",
+              "description": "Click **Save query**, then complete the dialog to finish saving.",
               "requirements": ["exists-reftarget"]
             }
           ]
@@ -59,21 +63,22 @@
     },
     {
       "type": "section",
+      "id": "reuse-in-new-row",
       "title": "Reuse a saved query in a new row",
       "requirements": ["has-feature:queryLibrary"],
       "blocks": [
         {
           "type": "guided",
-          "content": "Open the Saved queries modal via the \"Add from saved queries\" button. Once open, you can filter and search for the query you'd like and then confirm selection.",
+          "content": "Click **Add from saved queries** to open the Saved queries dialog. In the dialog, search or filter for the query you want, then select it to add it as a new row.",
+          "requirements": ["on-page:/explore"],
           "steps": [
             {
               "action": "highlight",
               "reftarget": "div[data-testid='data-testid explorer scroll view'] button[data-testid='data-testid explore add from query library button']",
+              "description": "Click **Add from saved queries**, then pick a query in the dialog.",
               "requirements": ["exists-reftarget"]
             }
-          ],
-          "stepTimeout": 30000,
-          "requirements": ["on-page:/explore"]
+          ]
         }
       ]
     },
@@ -87,26 +92,28 @@
     },
     {
       "type": "section",
+      "id": "reuse-in-existing-row",
       "title": "Reuse a saved query in an existing row",
       "requirements": ["has-feature:queryLibrary"],
       "blocks": [
         {
           "type": "guided",
-          "content": "In the row you'd like replaced, open the Saved queries menu and then select \"Replace query.\" Inside the Saved queries modal, search and filter for your desired query and then confirm selection.",
+          "content": "In the row you want to change, open the **Saved queries** menu and choose **Replace query**. In the dialog, search or filter for the query you want, then select it to replace the current query.",
+          "requirements": ["on-page:/explore"],
           "steps": [
             {
               "action": "highlight",
               "reftarget": "div[data-testid='data-testid Query editor row'] button[data-testid='data-testid saved queries button']",
+              "description": "Click to open the **Saved queries** menu.",
               "requirements": ["exists-reftarget"]
             },
             {
               "action": "highlight",
               "reftarget": "div[data-testid='data-testid portal-container'] button[data-testid='data-testid replace query from library button']",
+              "description": "Click **Replace query**, then pick a query in the dialog.",
               "requirements": ["exists-reftarget"]
             }
-          ],
-          "stepTimeout": 30000,
-          "requirements": ["on-page:/explore"]
+          ]
         }
       ]
     },

--- a/saved-queries-explore/manifest.json
+++ b/saved-queries-explore/manifest.json
@@ -1,0 +1,26 @@
+{
+  "id": "saved-queries-explore",
+  "type": "guide",
+  "description": "Hands-on guide: Save and reuse queries in Grafana Explore.",
+  "category": "general",
+  "author": {
+    "team": "interactive-learning"
+  },
+  "startingLocation": "/explore",
+  "targeting": {
+    "match": {
+      "and": [
+        {
+          "urlPrefix": "/explore"
+        }
+      ]
+    }
+  },
+  "testEnvironment": {
+    "tier": "local"
+  },
+  "depends": [],
+  "recommends": [],
+  "suggests": [],
+  "provides": []
+}

--- a/saved-queries-explore/manifest.json
+++ b/saved-queries-explore/manifest.json
@@ -12,13 +12,16 @@
     "match": {
       "and": [
         {
+          "targetPlatform": "cloud"
+        },
+        {
           "urlPrefix": "/explore"
         }
       ]
     }
   },
   "testEnvironment": {
-    "tier": "local"
+    "tier": "cloud"
   },
   "depends": [],
   "recommends": [],

--- a/saved-queries-explore/manifest.json
+++ b/saved-queries-explore/manifest.json
@@ -4,7 +4,8 @@
   "description": "Hands-on guide: Save and reuse queries in Grafana Explore.",
   "category": "general",
   "author": {
-    "team": "interactive-learning"
+    "team": "Grafana Sharing Squad",
+    "name": "collinfingar"
   },
   "startingLocation": "/explore",
   "targeting": {


### PR DESCRIPTION
### What this PR adds:
- A guide for using the Enterprise Grafana feature Saved queries in Explore.
- Separate sections for saving a query and reusing existing queries

Alongside [this Panel Edit](https://github.com/grafana/interactive-tutorials/pull/445) version

https://github.com/user-attachments/assets/ff1ba177-0f62-4201-b96e-f48afa519a7b

