### PR TITLE
Adds advice for tabbed dashboards.

### DIFF
--- a/docs/selectors-and-testids.md
+++ b/docs/selectors-and-testids.md
@@ -61,6 +61,31 @@ Follow this priority order when choosing selectors:
 | Related metrics tab   | `button[data-testid="data-testid Tab Related metrics"]`                                        | Tab toggle              |
 | Related logs tab      | `button[data-testid="data-testid Tab Related logs"]`                                           | Tab toggle              |
 
+### Tabs: `button` vs `a`
+
+The testid string `data-testid Tab <name>` is always correct, but the **element tag depends on the tab type**. grafana-ui's `Tab` component renders an `<a>` when it receives an `href` prop and a `<button>` otherwise:
+
+| Tab type                                   | Has `href`? | Selector tag | Examples                                        |
+|--------------------------------------------|-------------|--------------|-------------------------------------------------|
+| Panel-editor tabs                          | No          | `button`     | Queries, Transformations, Alert                 |
+| Viz picker tabs                            | No          | `button`     | All visualizations, Suggestions                 |
+| Drilldown / app tabs                       | No          | `button`     | Breakdown, Related metrics, Slow traces         |
+| **Dashboard scenes `TabsLayout` section tabs** | **Yes** | **`a`**      | Contest Overview tabs (Winner, Full Results, …) |
+
+Dashboard section tabs navigate by URL slug, so scenes passes an `href` and the tab renders as an anchor. Targeting them with `button[...]` silently matches nothing.
+
+```json
+{
+  "type": "interactive",
+  "action": "highlight",
+  "reftarget": "a[data-testid='data-testid Tab Winner']",
+  "requirements": ["exists-reftarget"],
+  "content": "We're starting on the Winner tab."
+}
+```
+
+When you can't tell which applies, a tag-agnostic `[data-testid='data-testid Tab <name>']` matches either element.
+
 ### Data Source Elements
 
 | Component        | Selector                                             |

--- a/shared/snippets/tab-button-pattern.json
+++ b/shared/snippets/tab-button-pattern.json
@@ -1,7 +1,7 @@
 {
   "id": "tab-button-pattern",
   "title": "Tab Button Pattern",
-  "description": "Generic pattern for clicking a named tab — replace `{TabName}` with the actual tab label (e.g. 'Slow traces', 'Breakdown').",
+  "description": "Generic pattern for clicking a named tab — replace `{TabName}` with the actual tab label (e.g. 'Slow traces', 'Breakdown'). NOTE: use `button[...]` for panel-editor, viz-picker, and drilldown/app tabs; use `a[...]` for dashboard scenes TabsLayout SECTION tabs, which render as anchors (see `_note`).",
   "blocks": [
     {
       "type": "interactive",
@@ -11,5 +11,5 @@
       "requirements": ["exists-reftarget"]
     }
   ],
-  "_note": "Pattern for clicking tabs. Replace {TabName} with the actual tab name (e.g., 'Slow traces', 'Breakdown', 'Related metrics')."
+  "_note": "Pattern for clicking tabs. Replace {TabName} with the actual tab name (e.g., 'Slow traces', 'Breakdown', 'Related metrics'). The testid string 'data-testid Tab <name>' is always correct, but the element TAG depends on the tab type: grafana-ui's Tab component renders an <a> when it receives an href and a <button> otherwise. Panel-editor tabs (Queries, Transformations, Alert), the viz picker (All visualizations), and drilldown/app tabs have NO href → use button[...]. Dashboard scenes TabsLayout SECTION tabs navigate by URL slug and DO get an href → use a[...] (e.g. a[data-testid='data-testid Tab Winner']). When unsure, a tag-agnostic [data-testid='data-testid Tab <name>'] matches either."
 }


### PR DESCRIPTION
This PR adds some advice on handling tabs in dashboards, which Claude was having issues with whilst I was working on #443 which will add a dashboard tour for something that uses tabbed layouts.