### PR TITLE
Fix elasticsearch-logs-lj milestones surfacing as standalone guides

### DIFF
--- a/elasticsearch-logs-lj/add-logs-to-dashboard/manifest.json
+++ b/elasticsearch-logs-lj/add-logs-to-dashboard/manifest.json
@@ -8,18 +8,6 @@
     "team": "Grafana Documentation"
   },
   "startingLocation": "/explore",
-  "targeting": {
-    "match": {
-      "and": [
-        {
-          "targetPlatform": "cloud"
-        },
-        {
-          "urlPrefix": "/explore"
-        }
-      ]
-    }
-  },
   "testEnvironment": {
     "tier": "cloud"
   },

--- a/elasticsearch-logs-lj/configure-log-display/manifest.json
+++ b/elasticsearch-logs-lj/configure-log-display/manifest.json
@@ -8,18 +8,6 @@
     "team": "Grafana Documentation"
   },
   "startingLocation": "/connections/datasources",
-  "targeting": {
-    "match": {
-      "and": [
-        {
-          "targetPlatform": "cloud"
-        },
-        {
-          "urlPrefix": "/connections/datasources"
-        }
-      ]
-    }
-  },
   "testEnvironment": {
     "tier": "cloud"
   },

--- a/elasticsearch-logs-lj/end-journey/manifest.json
+++ b/elasticsearch-logs-lj/end-journey/manifest.json
@@ -8,15 +8,6 @@
     "team": "Grafana Documentation"
   },
   "startingLocation": "/explore",
-  "targeting": {
-    "match": {
-      "and": [
-        {
-          "targetPlatform": "cloud"
-        }
-      ]
-    }
-  },
   "testEnvironment": {
     "tier": "cloud"
   },

--- a/elasticsearch-logs-lj/filter-by-time-range/manifest.json
+++ b/elasticsearch-logs-lj/filter-by-time-range/manifest.json
@@ -8,18 +8,6 @@
     "team": "Grafana Documentation"
   },
   "startingLocation": "/explore",
-  "targeting": {
-    "match": {
-      "and": [
-        {
-          "targetPlatform": "cloud"
-        },
-        {
-          "urlPrefix": "/explore"
-        }
-      ]
-    }
-  },
   "testEnvironment": {
     "tier": "cloud"
   },

--- a/elasticsearch-logs-lj/navigate-to-explore/manifest.json
+++ b/elasticsearch-logs-lj/navigate-to-explore/manifest.json
@@ -8,18 +8,6 @@
     "team": "Grafana Documentation"
   },
   "startingLocation": "/explore",
-  "targeting": {
-    "match": {
-      "and": [
-        {
-          "targetPlatform": "cloud"
-        },
-        {
-          "urlPrefix": "/explore"
-        }
-      ]
-    }
-  },
   "testEnvironment": {
     "tier": "cloud"
   },

--- a/elasticsearch-logs-lj/select-logs-query-type/manifest.json
+++ b/elasticsearch-logs-lj/select-logs-query-type/manifest.json
@@ -8,18 +8,6 @@
     "team": "Grafana Documentation"
   },
   "startingLocation": "/explore",
-  "targeting": {
-    "match": {
-      "and": [
-        {
-          "targetPlatform": "cloud"
-        },
-        {
-          "urlPrefix": "/explore"
-        }
-      ]
-    }
-  },
   "testEnvironment": {
     "tier": "cloud"
   },

--- a/elasticsearch-logs-lj/value-of-log-exploration/manifest.json
+++ b/elasticsearch-logs-lj/value-of-log-exploration/manifest.json
@@ -8,15 +8,6 @@
     "team": "Grafana Documentation"
   },
   "startingLocation": "/explore",
-  "targeting": {
-    "match": {
-      "and": [
-        {
-          "targetPlatform": "cloud"
-        }
-      ]
-    }
-  },
   "testEnvironment": {
     "tier": "cloud"
   },

--- a/elasticsearch-logs-lj/write-lucene-query/manifest.json
+++ b/elasticsearch-logs-lj/write-lucene-query/manifest.json
@@ -8,18 +8,6 @@
     "team": "Grafana Documentation"
   },
   "startingLocation": "/explore",
-  "targeting": {
-    "match": {
-      "and": [
-        {
-          "targetPlatform": "cloud"
-        },
-        {
-          "urlPrefix": "/explore"
-        }
-      ]
-    }
-  },
   "testEnvironment": {
     "tier": "cloud"
   },


### PR DESCRIPTION
## Summary

Each milestone in `elasticsearch-logs-lj` carried its own `targeting.match` block in `manifest.json`, so Pathfinder's recommender matched every milestone independently and surfaced them as standalone interactive guides outside the learning path — in some cases (`end-journey`, `value-of-log-exploration`) on nearly any Grafana Cloud page, since those had only `targetPlatform: cloud` with no URL constraint.

Learning path steps are reached by progressing through the path, not via independent contextual recommendation, so step-level manifests should omit `targeting` entirely (it lives at the path level only). This is documented in [`.cursor/review-guide-pr.mdc`](https://github.com/grafana/interactive-tutorials/blob/main/.cursor/review-guide-pr.mdc) and [`.cursor/skills/migrate-guide/SKILL.md`](https://github.com/grafana/interactive-tutorials/blob/main/.cursor/skills/migrate-guide/SKILL.md), and confirmed against every other `*-lj` path in the repo (e.g. `drilldown-logs-lj`, `prometheus-lj`), whose milestone manifests correctly omit `targeting`.

- Removed `targeting` from all 8 step manifests: `navigate-to-explore`, `select-logs-query-type`, `write-lucene-query`, `configure-log-display`, `filter-by-time-range`, `add-logs-to-dashboard`, `end-journey`, `value-of-log-exploration`
- Path-level `manifest.json` (`elasticsearch-logs-lj/manifest.json`) is unchanged — it retains `targeting` so the path itself is still recommended contextually

## Test plan

- [x] Ran `node dist/cli/cli/index.js validate --packages elasticsearch-logs-lj` from a `grafana-pathfinder-app` checkout — all 8 packages pass (only the expected benign `targeting not specified` INFO/WARN, matching the same output for known-good `drilldown-logs-lj` steps)
- [x] Ran `node dist/cli/cli/index.js validate --packages .` across the whole repo — 99/99 packages valid, no regressions introduced