### PR TITLE
Unpin deploy preview reusable workflow

### DIFF
--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -12,7 +12,9 @@ on:
 
 jobs:
   deploy-pr-preview:
-    uses: grafana/writers-toolkit/.github/workflows/deploy-preview.yml@76d98bf2a72fdbc47893ab8cd09e7a05ab91dd18 # main
+    # Do not pin by SHA: the WIF binding for github-docs-deploy-previews matches
+    # job_workflow_ref by branch ref. Pinning by SHA breaks getAccessToken.
+    uses: grafana/writers-toolkit/.github/workflows/deploy-preview.yml@main
     if: >-
       !github.event.pull_request.head.repo.fork &&
       (contains(github.event.pull_request.labels.*.name, 'deploy-preview') ||

--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -12,8 +12,7 @@ on:
 
 jobs:
   deploy-pr-preview:
-    # Do not pin by SHA: the WIF binding for github-docs-deploy-previews matches
-    # job_workflow_ref by branch ref. Pinning by SHA breaks getAccessToken.
+    # Do not pin by SHA the WIF binding for github-docs-deploy-previews matches job_workflow_ref by branch ref. Pinning by SHA breaks getAccessToken.
     uses: grafana/writers-toolkit/.github/workflows/deploy-preview.yml@main
     if: >-
       !github.event.pull_request.head.repo.fork &&


### PR DESCRIPTION
Revert 7fed4fb (Renovate SHA-pin).

The WIF binding for `github-docs-deploy-previews@grafanalabs-workload-identity.iam.gserviceaccount.com` matches OIDC `job_workflow_ref` by branch ref. Pinning `grafana/writers-toolkit/.github/workflows/deploy-preview.yml` by SHA changes that claim from `...@refs/heads/main` to `...@<sha>`, which is not allow-listed, so `iam.serviceAccounts.getAccessToken` is denied.

Failing run: https://github.com/grafana/interactive-tutorials/actions/runs/29745735469/job/88365156652

Follow-up: add a package rule in `grafana/grafana-renovate-config` to stop Renovate re-pinning this ref.