### PR TITLE
Auto-enable deploy previews for learning path PRs

### DIFF
--- a/.cursor/commands/create-learning-path/README.md
+++ b/.cursor/commands/create-learning-path/README.md
@@ -26,7 +26,7 @@ Follow these phases in order:
 6. **Generate manifests.** Create `manifest.json` for the path (`type: "path"`, milestones array, targeting) and each milestone (`type: "guide"`, depends/recommends chain). Refer to `docs/manifest-reference.md`. Where fields can't be derived, ask the user to provide values before generating.
 7. **Discover selectors.** Use Playwright at `learn.grafana.net` to find stable CSS selectors for each interactive element. The user must log in through the Playwright browser window (Okta SAML).
 8. **Test in Pathfinder.** Tell the user which `content.json` to import into the Block Editor at `learn.grafana.net/?pathfinder-dev=true`. Wait for their feedback on each "Show me" / "Do it" button. Fix broken selectors based on their reports.
-9. **Verify and wrap up.** Cross-check all factual claims against live docs. Update `.github/CODEOWNERS`. Provide a summary of all files created.
+9. **Verify and wrap up.** Cross-check all factual claims against live docs. Update `.github/CODEOWNERS`. Provide a summary of all files created. Remind the user that opening the PR in `interactive-tutorials` auto-enables a Learning Hub deploy preview (no `deploy-preview` label needed for `*-lj/` packages).
 
 For background on how this command relates to `/build-interactive-lj`, refer to `.cursor/learning-path-workflows/workflows.md`.
 

--- a/.cursor/learning-path-workflows/workflows.md
+++ b/.cursor/learning-path-workflows/workflows.md
@@ -20,7 +20,7 @@ Make sure you have:
 - `content.json`, `manifest.json`, and `website.yaml` at the path level
 - `[milestone]/content.json`, `[milestone]/manifest.json`, and `[milestone]/website.yaml` for each milestone
 
-The `website.yaml` files are used to create deploy previews so you can see the non-interactive path before it's published to the Learning Hub.
+The `website.yaml` files are used to create deploy previews so you can see the non-interactive path before it's published to the Learning Hub. PRs that touch a `*-lj/` package (or any `website.yaml`) get a Learning Hub deploy preview automatically — watch for the bot comment with the preview URL (`/docs/learning-paths/...`). You do not need to add the `deploy-preview` label yourself for learning path PRs; for other PRs, add that label and push a commit to opt in.
 
 ## Run the command
 
@@ -70,7 +70,7 @@ Use the Block Builder **PR review tool** (dev tools, pathfinder-app 1.4.5+) to l
 
 The AI verifies factual claims against the docs, updates `.github/CODEOWNERS`, and provides a summary of all files created.
 
-**Your role:** Review the generated files, then open a PR in the `interactive-tutorials` repo.
+**Your role:** Review the generated files, then open a PR in the `interactive-tutorials` repo. CI adds the `deploy-preview` label and builds a Learning Hub preview; share the bot's preview URL with reviewers.
 
 ## Tips
 

--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -11,13 +11,56 @@ on:
       - closed
 
 jobs:
+  # Learning path PRs should preview without authors knowing to add a label.
+  # The reusable workflow only builds on opened/synchronize (not labeled), so
+  # path detection here must succeed on open — label-only was a race.
+  preview-gate:
+    if: >-
+      github.event.action != 'closed' &&
+      !github.event.pull_request.head.repo.fork
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      deploy: ${{ steps.decide.outputs.deploy }}
+    steps:
+      - id: decide
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HAS_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'deploy-preview') }}
+        run: |
+          set -euo pipefail
+          if [[ "${HAS_LABEL}" == "true" ]]; then
+            echo "deploy=true" >> "${GITHUB_OUTPUT}"
+            echo "Deploy preview enabled: deploy-preview label present"
+            exit 0
+          fi
+
+          if gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/files" --paginate \
+            --jq '.[].filename' \
+            | grep -E '(^|/)[^/]+-lj/|(^|/)website\.yaml$' >/dev/null; then
+            echo "deploy=true" >> "${GITHUB_OUTPUT}"
+            echo "Deploy preview enabled: PR touches a *-lj package or website.yaml"
+            exit 0
+          fi
+
+          echo "deploy=false" >> "${GITHUB_OUTPUT}"
+          echo "Deploy preview skipped: add the deploy-preview label to opt in"
+
   deploy-pr-preview:
     # Do not pin by SHA the WIF binding for github-docs-deploy-previews matches job_workflow_ref by branch ref. Pinning by SHA breaks getAccessToken.
+    needs: preview-gate
     uses: grafana/writers-toolkit/.github/workflows/deploy-preview.yml@main
     if: >-
+      always() &&
+      !cancelled() &&
       !github.event.pull_request.head.repo.fork &&
-      (contains(github.event.pull_request.labels.*.name, 'deploy-preview') ||
-      github.event.action == 'closed')
+      (
+        github.event.action == 'closed' ||
+        (needs.preview-gate.result == 'success' && needs.preview-gate.outputs.deploy == 'true')
+      )
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/label-deploy-preview.yml
+++ b/.github/workflows/label-deploy-preview.yml
@@ -1,0 +1,45 @@
+name: Label learning path PRs for deploy preview
+
+# Adds the deploy-preview label so authors and reviewers can see that a Learning
+# Hub preview is expected. Deploy itself is gated in deploy-pr-preview.yml by
+# path match or label — this workflow is visibility only.
+
+permissions: {}
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+
+jobs:
+  label-deploy-preview:
+    if: ${{ !github.event.pull_request.head.repo.fork }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Add deploy-preview label for learning path packages
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HAS_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'deploy-preview') }}
+        run: |
+          set -euo pipefail
+
+          if [[ "${HAS_LABEL}" == "true" ]]; then
+            echo "deploy-preview label already present"
+            exit 0
+          fi
+
+          if ! gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/files" --paginate \
+            --jq '.[].filename' \
+            | grep -E '(^|/)[^/]+-lj/|(^|/)website\.yaml$' >/dev/null; then
+            echo "PR does not touch a *-lj package or website.yaml; leaving unlabeled"
+            exit 0
+          fi
+
+          gh pr edit "${PR_NUMBER}" --repo "${GITHUB_REPOSITORY}" --add-label deploy-preview
+          echo "Added deploy-preview label"

--- a/docs/website-yaml-reference.md
+++ b/docs/website-yaml-reference.md
@@ -4,6 +4,8 @@ Each learning path directory (`<NAME>-lj/`) and each of its step subdirectories 
 This file carries metadata consumed by the `grafana/website` build.
 It's unrelated to `manifest.json`, which controls in-product recommendation targeting.
 
+PRs that change `*-lj/` packages or `website.yaml` get a Learning Hub deploy preview automatically (see `.github/workflows/deploy-pr-preview.yml`). The bot comments with a preview URL under `/docs/learning-paths/`.
+
 There are two kinds of `website.yaml`:
 
 - **Path-level**: `<NAME>-lj/website.yaml`. Describes the whole learning path.


### PR DESCRIPTION
## Summary
- Learning path PRs (`*-lj/` or `website.yaml`) get a Learning Hub deploy preview automatically on open/sync — authors no longer need to discover the `deploy-preview` label.
- Still adds the `deploy-preview` label for visibility; non-LP PRs can opt in with the label + a push.
- Documents the behavior in author workflows and `website.yaml` reference.

## Test plan
- [ ] Open a PR that touches a `*-lj/` package and confirm **Deploy PR preview** runs without manually adding a label
- [ ] Confirm the bot adds the `deploy-preview` label
- [ ] Confirm a non-LP PR without the label still skips preview
- [ ] Confirm a non-LP PR with the label still previews after a push


Made with [Cursor](https://cursor.com)