### PR TITLE
Jeffgoll/monitor aws resources lj

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -61,6 +61,7 @@
 /linux-server-integration-lj/                             @chri2547
 /logql-101/                                               @nicolevanderhoeven
 /macos-integration-lj/                                    @chri2547
+/monitor-aws-resources-lj/                                @hcloward
 /monitor-azure-resources-lj/                              @hcloward
 /mysql-data-source-lj/                                    @chri2547
 /mysql-integration-lj/                                    @chri2547

--- a/monitor-aws-resources-lj/advantages/content.json
+++ b/monitor-aws-resources-lj/advantages/content.json
@@ -1,0 +1,30 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "monitor-aws-resources-advantages",
+  "title": "Advantages of Grafana Cloud Provider Observability",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "Grafana Cloud Provider Observability is a comprehensive monitoring solution that simplifies AWS observability without the operational overhead of managing monitoring infrastructure. The integration provides immediate visibility into your AWS environment through pre-configured dashboards and alerting rules.\n\nGrafana Cloud Provider Observability differs from traditional AWS monitoring approaches by providing a unified observability platform that offers centralized access and management. This approach gives you complete visibility into your AWS environment alongside other infrastructure components."
+    },
+    {
+      "type": "section",
+      "title": "Advantages of Cloud Provider Observability for AWS",
+      "autoCollapse": false,
+      "blocks": [
+        {
+          "type": "markdown",
+          "content": "With Grafana Cloud Provider Observability, you can:\n\n- **Deploy instantly**: Connect your AWS account in minutes without installing agents or configuring complex monitoring pipelines.\n- **Use pre-built dashboards**: Access ready-to-use dashboards covering popular AWS services like EC2, RDS, Lambda, and S3.\n- **Scale automatically**: Handle monitoring for thousands of AWS resources without managing monitoring infrastructure.\n- **Customize visualizations**: Modify existing dashboards or create new ones tailored to your specific use cases.\n- **Set intelligent alerts**: Use templated alert rules optimized for AWS services with smart thresholds and notification routing."
+        },
+        {
+          "type": "markdown",
+          "content": "Cloud Provider Observability gives you a single place to monitor AWS alongside your other infrastructure."
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "In your next milestone, you'll access the Cloud Provider Observability AWS configuration interface in Grafana Cloud to begin setting up the integration."
+    }
+  ]
+}

--- a/monitor-aws-resources-lj/advantages/manifest.json
+++ b/monitor-aws-resources-lj/advantages/manifest.json
@@ -1,0 +1,17 @@
+{
+  "id": "monitor-aws-resources-advantages",
+  "type": "guide",
+  "description": "Learn the specific benefits of using Grafana Cloud Provider Observability to monitor your AWS infrastructure and services.",
+  "category": "data-availability",
+  "author": {
+    "name": "Jack Baldry",
+    "team": "Grafana Documentation"
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": [],
+  "recommends": ["monitor-aws-resources-navigate-aws-config"],
+  "suggests": [],
+  "provides": []
+}

--- a/monitor-aws-resources-lj/advantages/website.yaml
+++ b/monitor-aws-resources-lj/advantages/website.yaml
@@ -1,0 +1,13 @@
+menuTitle: Advantages
+weight: 200
+step: 3
+layout: single-journey
+cta:
+  type: continue
+description: Learn the specific benefits of using Grafana Cloud to monitor your AWS infrastructure and services.
+keywords:
+- Grafana Cloud
+- AWS integration
+- monitoring advantages
+- unified observability
+- pre-built dashboards

--- a/monitor-aws-resources-lj/business-value/content.json
+++ b/monitor-aws-resources-lj/business-value/content.json
@@ -1,0 +1,40 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "monitor-aws-resources-business-value",
+  "title": "The case for observability",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "IT systems are complicated. There are nodes, pods, services, system resources - sometimes thousands of them - all connected in a complex web of relationships. And when things go wrong, it can be very difficult to determine the root cause and fix it quickly. Consider the following:\n\n- Slow performance in an application might be caused by heavy load, or it could be a memory leak or even a hardware error. Monitoring your infrastructure allows you to find the root cause quickly and accurately.\n- Running out of disk space can be a disaster for any environment. Understanding that there's a problem before it becomes a problem enables you to prevent it.\n- When applications or services are co-located, being able to identify hotspots and conflicts between them can help you redistribute the load properly.\n\nAnd time is of the essence. System downtime can be very expensive. If you run customer-facing applications such as e-commerce site or a financial institution, every minute of downtime costs you money. Some estimates put the average cost of downtime at $5,600 per minute. If you are a large retailer, this cost can be much more. Even if you're not running a commercial service, downtime can have impact. If you can't turn on your lights because your home automation is having problems, it's still a real issue."
+    },
+    {
+      "type": "section",
+      "title": "Enter observability",
+      "autoCollapse": false,
+      "blocks": [
+        {
+          "type": "video",
+          "src": "https://www.youtube.com/embed/TQur9GJHIIQ",
+          "provider": "youtube",
+          "title": "What is observability?"
+        },
+        {
+          "type": "markdown",
+          "content": "Observability is the process of making a system's internal state more transparent. Systems are made observable by the data they produce, which in turn helps you to determine if your infrastructure or application is healthy and functioning normally."
+        },
+        {
+          "type": "markdown",
+          "content": "Observability is a holistic approach to understanding and managing complex systems. It involves collecting data from all parts of the system to create a deep understanding of the system's internal workings and how these interact with each other. Observability focuses on understanding and interpreting data to make the system's behavior and performance as transparent as possible. It also requires a means of making the data easily available for humans to interpret.\n\nAn observability system enables system operators, DevOps practitioners, and site reliability engineers to ask questions across the information gathered. These are questions that are not anticipated in advance, but rather questions that arise due to unexpected or novel events within a system."
+        },
+        {
+          "type": "markdown",
+          "content": "Observability helps you answer unanticipated questions when complex systems behave unexpectedly."
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "In your next milestone, you'll learn the advantages of monitoring AWS resources with Cloud Provider Observability."
+    }
+  ]
+}

--- a/monitor-aws-resources-lj/business-value/manifest.json
+++ b/monitor-aws-resources-lj/business-value/manifest.json
@@ -1,0 +1,17 @@
+{
+  "id": "monitor-aws-resources-business-value",
+  "type": "guide",
+  "description": "Learn about observability and how it can help you solve real-world problems.",
+  "category": "data-availability",
+  "author": {
+    "name": "Jack Baldry",
+    "team": "Grafana Documentation"
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": [],
+  "recommends": ["monitor-aws-resources-advantages"],
+  "suggests": [],
+  "provides": []
+}

--- a/monitor-aws-resources-lj/business-value/website.yaml
+++ b/monitor-aws-resources-lj/business-value/website.yaml
@@ -1,0 +1,16 @@
+menuTitle: The case for observability
+weight: 100
+step: 2
+layout: single-journey
+cta:
+  type: continue
+keywords:
+- Grafana Labs
+- observability
+- monitoring
+side_journeys:
+  title: More to explore (optional)
+  heading: 'At this point in your journey, you can explore the following paths:'
+  items:
+  - title: What is observability?
+    link: /docs/grafana-cloud/introduction/what-is-observability/

--- a/monitor-aws-resources-lj/business-value/website.yaml
+++ b/monitor-aws-resources-lj/business-value/website.yaml
@@ -1,4 +1,5 @@
 menuTitle: The case for observability
+description: Learn about observability and how it can help you solve real-world problems
 weight: 100
 step: 2
 layout: single-journey

--- a/monitor-aws-resources-lj/connect-aws-account/content.json
+++ b/monitor-aws-resources-lj/connect-aws-account/content.json
@@ -1,0 +1,61 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "monitor-aws-resources-connect-aws-account",
+  "title": "Connect to AWS account",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "In this milestone, you'll establish the connection between your AWS account and Grafana Cloud using the IAM role you created in the previous milestone. This connection enables Grafana Cloud to securely access your AWS metrics and begin monitoring your resources.\n\nNavigate to the **Create new account** page in Grafana Cloud if you're not already there."
+    },
+    {
+      "type": "section",
+      "title": "Configure the integration",
+      "autoCollapse": false,
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "formfill",
+          "reftarget": "#name",
+          "targetvalue": "aws-ec2-account",
+          "content": "In the **Account name** field, enter a unique name that contains only alphanumeric characters, dashes, and underscores, for example `aws-ec2-account`.",
+          "doIt": false,
+          "requirements": ["exists-reftarget", "on-page:/a/grafana-csp-app/aws/configuration"]
+        },
+        {
+          "type": "interactive",
+          "action": "formfill",
+          "reftarget": "#arn",
+          "targetvalue": "arn:aws:iam::123456789012:role/GrafanaCloudMonitoringRole",
+          "content": "In the **ARN** field, paste the role ARN you copied from the previous milestone, for example `arn:aws:iam::123456789012:role/GrafanaCloudMonitoringRole`.",
+          "doIt": false,
+          "requirements": ["exists-reftarget"]
+        },
+        {
+          "type": "interactive",
+          "action": "formfill",
+          "reftarget": "#regions-selector",
+          "targetvalue": "us-east-1",
+          "content": "In the AWS Regions field, select all regions where the AWS resources you want to monitor are located, for example `us-east-1`.",
+          "doIt": false,
+          "requirements": ["exists-reftarget"]        
+        },
+        {
+          "type": "interactive",
+          "action": "button",
+          "reftarget": "Add account",
+          "content": "Click **Add account** to verify the connection and complete the setup.",
+          "doIt": false,
+          "requirements": ["exists-reftarget"]
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "Your AWS account is connected to Grafana Cloud and ready to collect metrics.\n\nIn your next milestone, you'll create a scrape job to customize metric collection for specific AWS services."
+    },
+    {
+      "type": "markdown",
+      "content": "---\n\n### More to explore (optional)\n\n- [Manage AWS accounts](https://grafana.com/docs/grafana-cloud/monitor-infrastructure/monitor-cloud-provider/aws/cloudwatch-metrics/cw-accounts/)"
+    }
+  ]
+}

--- a/monitor-aws-resources-lj/connect-aws-account/manifest.json
+++ b/monitor-aws-resources-lj/connect-aws-account/manifest.json
@@ -1,0 +1,18 @@
+{
+  "id": "monitor-aws-resources-connect-aws-account",
+  "type": "guide",
+  "description": "Configure the connection between your AWS account and Grafana Cloud using the IAM role you created.",
+  "category": "data-availability",
+  "author": {
+    "name": "Jack Baldry",
+    "team": "Grafana Documentation"
+  },
+  "startingLocation": "/a/grafana-csp-app/aws/configuration",
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": ["monitor-aws-resources-create-iam-role"],
+  "recommends": ["monitor-aws-resources-create-scrape-job"],
+  "suggests": [],
+  "provides": []
+}

--- a/monitor-aws-resources-lj/connect-aws-account/website.yaml
+++ b/monitor-aws-resources-lj/connect-aws-account/website.yaml
@@ -1,0 +1,19 @@
+menuTitle: Connect AWS account
+weight: 500
+step: 6
+layout: single-journey
+cta:
+  type: continue
+description: Configure the connection between your AWS account and Grafana Cloud using the IAM role you created.
+keywords:
+- AWS connection
+- IAM role
+- authentication
+- account setup
+- integration
+side_journeys:
+  title: More to explore (optional)
+  heading: 'At this point in your journey, you can explore the following paths:'
+  items:
+  - title: Manage AWS accounts
+    link: /docs/grafana-cloud/monitor-infrastructure/monitor-cloud-provider/aws/cloudwatch-metrics/cw-accounts/

--- a/monitor-aws-resources-lj/content.json
+++ b/monitor-aws-resources-lj/content.json
@@ -16,7 +16,7 @@
     },
     {
       "type": "markdown",
-      "content": "### Troubleshooting\n\nIf you get stuck, we've got your back. Where appropriate, troubleshooting information is just a click away.\n\n### More to explore\n\nWe understand you might want to explore other capabilities not strictly on this path. We'll provide you opportunities where it makes sense."
+      "content": "## Troubleshooting\n\nIf you get stuck, we've got your back! Where appropriate, troubleshooting information is just a click away.\n\n## More to explore\n\nWe understand you might want to explore other capabilities not strictly on this path. We'll provide you opportunities where it makes sense."
     }
   ]
 }

--- a/monitor-aws-resources-lj/content.json
+++ b/monitor-aws-resources-lj/content.json
@@ -1,0 +1,22 @@
+{
+  "id": "monitor-aws-resources-lj",
+  "title": "Monitor AWS resources with Grafana Cloud",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "Welcome to the Grafana learning path that shows you how to monitor AWS resources using Grafana Cloud Provider Observability.\n\nYou'll use this path to connect your AWS account to Grafana Cloud and monitor your AWS services through comprehensive dashboards and metrics.\n\nThe Cloud provider AWS solution collects metrics from Amazon CloudWatch and presents them through pre-built dashboards optimized for AWS services.\n\nThe Cloud Provider AWS solution differs from traditional monitoring solutions by providing a unified observability platform that offers centralized access and management. This approach gives you complete visibility into your AWS environment alongside other infrastructure components."
+    },
+    {
+      "type": "markdown",
+      "content": "## Here's what to expect\n\nWhen you complete this journey, you'll be able to:\n\n- Understand the value of observability and the advantages of Grafana Cloud Provider Observability\n- Navigate to the Cloud provider AWS configuration interface in Grafana Cloud\n- Create an AWS IAM role with appropriate permissions for monitoring\n- Connect your AWS account to Grafana Cloud\n- Create scrape jobs to collect metrics from AWS services\n- Verify data is collected and sent to Grafana Cloud\n- Explore AWS service data using pre-built dashboards"
+    },
+    {
+      "type": "markdown",
+      "content": "## Before you begin\n\nBefore you monitor AWS resources, ensure that you have:\n\n- A Grafana Cloud account. To create a free account, go to [Grafana Cloud](https://grafana.com/signup/cloud/connect-account) and enter an email address and password.\n- An AWS account with administrative access or appropriate IAM permissions to create roles and policies.\n- AWS resources running that you want to monitor, such as EC2 instances, RDS databases, or Lambda functions, and at least one [Amazon tag](https://docs.aws.amazon.com/tag-editor/latest/userguide/tagging.html) on the resources in AWS so AWS can ingest metrics from CloudWatch into Grafana Cloud.\n- Basic familiarity with AWS services and understanding of their operation."
+    },
+    {
+      "type": "markdown",
+      "content": "### Troubleshooting\n\nIf you get stuck, we've got your back. Where appropriate, troubleshooting information is just a click away.\n\n### More to explore\n\nWe understand you might want to explore other capabilities not strictly on this path. We'll provide you opportunities where it makes sense."
+    }
+  ]
+}

--- a/monitor-aws-resources-lj/create-iam-role/content.json
+++ b/monitor-aws-resources-lj/create-iam-role/content.json
@@ -1,0 +1,57 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "monitor-aws-resources-create-iam-role",
+  "title": "Create an AWS IAM role",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "In this milestone, you'll create an AWS IAM role that grants Grafana Cloud the necessary permissions to collect metrics from your AWS account. This role uses the principle of least privilege, providing only the read-only access required for monitoring.\n\nThe IAM role establishes a secure trust relationship between your AWS account and Grafana Cloud, allowing metric collection without sharing long-term credentials or compromising security.\n\nYou can configure the AWS role automatically with CloudFormation or Terraform, or manually in the AWS Management Console. This milestone uses CloudFormation, the recommended approach."
+    },
+    {
+      "type": "section",
+      "title": "Start the IAM role setup in Grafana Cloud",
+      "autoCollapse": false,
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='configuration-card-accounts']",
+          "content": "From the **Configuration** tab, click the **AWS accounts** tile.",
+          "requirements": ["exists-reftarget", "on-page:/a/grafana-csp-app/aws/configuration"]
+        },
+        {
+          "type": "interactive",
+          "action": "button",
+          "reftarget": "Add new account",
+          "content": "On the **AWS accounts** page, click **Add new account** to open the **Create new account** page.",
+          "requirements": ["exists-reftarget"]
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "For **Create a new AWS role**, leave the **Automatically** and **Use CloudFormation** tiles selected."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "a:contains('Launch stack')",
+          "content": "Click **Launch stack** to open a CloudFormation template in your AWS account in a new tab.\n\nThe AWS account you're logged into when you click this button is the account that opens. To use a different account, log out of the current account and log in to the account you want to use.",
+          "doIt": false,
+          "requirements": ["exists-reftarget"]
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "Complete the remaining steps in the AWS console tab, then return to Grafana Cloud:\n\n1. Select the **I acknowledge that AWS CloudFormation might create IAM resources with custom names** checkbox.\n1. Click **Create stack**.\n1. Copy the `RoleARN` in the **Outputs** tab of the stack to use in the next milestone.\n1. Return to the **Create new account** page in Grafana Cloud when you have finished in AWS."
+    },
+    {
+      "type": "markdown",
+      "content": "You created a read-only AWS IAM role and copied its role ARN for the next milestone.\n\nIn your next milestone, you'll use this IAM role to connect your AWS account to Grafana Cloud."
+    },
+    {
+      "type": "markdown",
+      "content": "---\n\n### More to explore (optional)\n\n- [Additional ways to create an AWS IAM role](https://grafana.com/docs/grafana-cloud/monitor-infrastructure/monitor-cloud-provider/aws/cloudwatch-metrics/config-cw-metric-scrape/#create-an-aws-iam-role)"
+    }
+  ]
+}

--- a/monitor-aws-resources-lj/create-iam-role/manifest.json
+++ b/monitor-aws-resources-lj/create-iam-role/manifest.json
@@ -1,0 +1,18 @@
+{
+  "id": "monitor-aws-resources-create-iam-role",
+  "type": "guide",
+  "description": "Learn how to create the required AWS IAM role and policies to allow Grafana Cloud to access your AWS metrics.",
+  "category": "data-availability",
+  "author": {
+    "name": "Jack Baldry",
+    "team": "Grafana Documentation"
+  },
+  "startingLocation": "/a/grafana-csp-app/aws/configuration",
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": ["monitor-aws-resources-navigate-aws-config"],
+  "recommends": ["monitor-aws-resources-connect-aws-account"],
+  "suggests": [],
+  "provides": []
+}

--- a/monitor-aws-resources-lj/create-iam-role/website.yaml
+++ b/monitor-aws-resources-lj/create-iam-role/website.yaml
@@ -1,0 +1,19 @@
+menuTitle: Create IAM role
+weight: 400
+step: 5
+layout: single-journey
+cta:
+  type: continue
+description: Learn how to create the required AWS IAM role and policies to allow Grafana Cloud to access your AWS metrics.
+keywords:
+- AWS IAM
+- IAM role
+- permissions
+- CloudWatch access
+- security
+side_journeys:
+  title: More to explore (optional)
+  heading: 'At this point in your journey, you can explore the following paths:'
+  items:
+  - title: Additional ways to create an AWS IAM role
+    link: /docs/grafana-cloud/monitor-infrastructure/monitor-cloud-provider/aws/cloudwatch-metrics/config-cw-metric-scrape/#create-an-aws-iam-role

--- a/monitor-aws-resources-lj/create-scrape-job/content.json
+++ b/monitor-aws-resources-lj/create-scrape-job/content.json
@@ -41,7 +41,7 @@
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "[data-testid='add-cloudwatch-job-button']",
+          "reftarget": "[data-testid='add-resource-button']",
           "content": "Click **Add new scrape job**.",
           "requirements": ["exists-reftarget"]
         },

--- a/monitor-aws-resources-lj/create-scrape-job/content.json
+++ b/monitor-aws-resources-lj/create-scrape-job/content.json
@@ -91,7 +91,7 @@
           "action": "formfill",
           "reftarget": "[data-testid='scrape-job-services-table']",
           "targetvalue": "scrape-job-parameters",
-          "content": "For each service that you selected and namespace that you specified, choose **Edit metrics** to view and configure each metric and its corresponding statistics to collect.\n\nIf you specified custom namespaces, choose **Edit metrics** for each namespace, and then type the exact name of each metric and its corresponding statistics to collect.",
+          "content": "For each service that you selected, you can optionally choose **Edit metrics** to view and configure each metric and its corresponding statistics to collect.\n\nIf you specified custom namespaces, you must choose **Edit metrics** for each namespace, and then type the exact name of each metric and its corresponding statistics to collect.",
           "doIt": false,
           "requirements": ["exists-reftarget"]
         },

--- a/monitor-aws-resources-lj/create-scrape-job/content.json
+++ b/monitor-aws-resources-lj/create-scrape-job/content.json
@@ -100,7 +100,6 @@
           "action": "button",
           "reftarget": "Create scrape job",
           "content": "Click **Create scrape job** to begin collecting metrics.",
-          "doIt": false,
           "requirements": ["exists-reftarget"]
         }
       ]

--- a/monitor-aws-resources-lj/create-scrape-job/content.json
+++ b/monitor-aws-resources-lj/create-scrape-job/content.json
@@ -1,0 +1,121 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "monitor-aws-resources-create-scrape-job",
+  "title": "Create a scrape job",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "In this milestone, you'll create a scrape job to customize metric collection from your AWS services. Scrape jobs let you specify which metrics to collect, set collection intervals, and apply filters to optimize performance and costs.\n\nScrape jobs provide granular control over metric collection, enabling you to focus on the most important metrics for your monitoring needs while avoiding unnecessary data collection."
+    },
+    {
+      "type": "multistep",
+      "content": "In Grafana Cloud, open the navigation menu and select **Observability > Cloud provider > AWS**, then click the **Configuration** tab.",
+      "requirements": ["navmenu-open"],
+      "steps": [
+        {
+          "action": "highlight",
+          "reftarget": "a[data-testid='data-testid Nav menu item'][href='/a/grafana-csp-app/aws']"
+        },
+        {
+          "action": "highlight",
+          "reftarget": "a[data-testid='data-testid Tab Configuration']"
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "To create the scrape job, complete the following steps:"
+    },
+    {
+      "type": "section",
+      "title": "Create the scrape job",
+      "autoCollapse": false,
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='configuration-card-cloudwatch']",
+          "content": "Select the **CloudWatch metrics scrape** tile.",
+          "requirements": ["exists-reftarget", "on-page:/a/grafana-csp-app/aws/configuration"]
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='add-cloudwatch-job-button']",
+          "content": "Click **Add new scrape job**.",
+          "requirements": ["exists-reftarget"]
+        },
+        {
+          "type": "interactive",
+          "action": "formfill",
+          "reftarget": "#account-selector",
+          "targetvalue": "customer-aws-account",
+          "content": "Select the AWS account you created in the previous milestone.",
+          "doIt": false,
+          "requirements": ["exists-reftarget"]        
+        },
+        {
+          "type": "interactive",
+          "action": "formfill",
+          "reftarget": "#name",
+          "targetvalue": "EC2-Production-Monitoring",
+          "content": "Enter a descriptive name for the scrape job in the **Scrape job name** field, for example `EC2-Production-Monitoring`.",
+          "doIt": false,
+          "requirements": ["exists-reftarget"]
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Leave the **Include your AWS resource tags** checkbox selected. This option is selected by default because Cloud Provider Observability for AWS requires tag data on the scrape info metrics for the best possible dashboard experience."
+        },
+        {
+          "type": "interactive",
+          "action": "formfill",
+          "reftarget": "[data-testid='service-multi-select']",
+          "targetvalue": "scrape-job-parameters",
+          "content": "Select the AWS services that you want to scrape. Find services by using search or browsing the list of services. A default set of metrics is collected for each service, which you can configure in the next step.",
+          "doIt": false,
+          "requirements": ["exists-reftarget"]
+        },
+        {
+          "type": "interactive",
+          "action": "formfill",
+          "reftarget": "[data-testid='custom-namespace-set-name']",
+          "targetvalue": "scrape-job-parameters",
+          "content": "Optionally, enter the names of any custom Cloudwatch namespaces that you want to scrape. Separate namespace names with a comma. In the next step, you'll manually configure the metrics to collect for each namespace.",
+          "doIt": false,
+          "requirements": ["exists-reftarget"]
+        },
+        {
+          "type": "interactive",
+          "action": "formfill",
+          "reftarget": "[data-testid='scrape-job-services-table']",
+          "targetvalue": "scrape-job-parameters",
+          "content": "For each service that you selected and namespace that you specified, choose **Edit metrics** to view and configure each metric and its corresponding statistics to collect.\n\nIf you specified custom namespaces, choose **Edit metrics** for each namespace, and then type the exact name of each metric and its corresponding statistics to collect.",
+          "doIt": false,
+          "requirements": ["exists-reftarget"]
+        },
+        {
+          "type": "interactive",
+          "action": "button",
+          "reftarget": "Create scrape job",
+          "content": "Click **Create scrape job** to begin collecting metrics.",
+          "doIt": false,
+          "requirements": ["exists-reftarget"]
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "The scrape job begins collecting metrics according to your configuration.\n\nIn your next milestone, you'll monitor the job status to verify data is getting sent from your Amazon account to Grafana Cloud."
+    },
+    {
+      "type": "markdown",
+      "content": "---\n\n### More to explore (optional)\n\n- [Create a scrape job using Terraform](https://grafana.com/docs/grafana-cloud/monitor-infrastructure/monitor-cloud-provider/aws/cloudwatch-metrics/config-cw-metric-scrape/#create-a-scrape-job-using-terraform)"
+    },
+    {
+      "type": "markdown",
+      "content": "---\n\n### Troubleshooting\n\nExplore the following troubleshooting topics if you need help:\n\n- [Verify AWS IAM permissions](https://grafana.com/docs/grafana-cloud/monitor-infrastructure/monitor-cloud-provider/aws/cloudwatch-metrics/config-cw-metric-scrape/#verify-aws-iam-permissions)\n- [Check resource tagging](https://grafana.com/docs/grafana-cloud/monitor-infrastructure/monitor-cloud-provider/aws/cloudwatch-metrics/config-cw-metric-scrape/#check-resource-tagging)"
+    }
+  ]
+}

--- a/monitor-aws-resources-lj/create-scrape-job/content.json
+++ b/monitor-aws-resources-lj/create-scrape-job/content.json
@@ -82,7 +82,7 @@
           "action": "formfill",
           "reftarget": "[data-testid='custom-namespace-set-name']",
           "targetvalue": "scrape-job-parameters",
-          "content": "Optionally, enter the names of any custom Cloudwatch namespaces that you want to scrape. Separate namespace names with a comma. In the next step, you'll manually configure the metrics to collect for each namespace.",
+          "content": "Optionally, enter the names of any custom CloudWatch namespaces that you want to scrape. Separate namespace names with a comma. In the next step, you'll manually configure the metrics to collect for each namespace.",
           "doIt": false,
           "requirements": ["exists-reftarget"]
         },

--- a/monitor-aws-resources-lj/create-scrape-job/manifest.json
+++ b/monitor-aws-resources-lj/create-scrape-job/manifest.json
@@ -1,0 +1,18 @@
+{
+  "id": "monitor-aws-resources-create-scrape-job",
+  "type": "guide",
+  "description": "Learn how to create and configure scrape jobs to collect specific metrics from your AWS services.",
+  "category": "data-availability",
+  "author": {
+    "name": "Jack Baldry",
+    "team": "Grafana Documentation"
+  },
+  "startingLocation": "/a/grafana-csp-app/aws/configuration",
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": ["monitor-aws-resources-connect-aws-account"],
+  "recommends": ["monitor-aws-resources-verify-data-collection"],
+  "suggests": [],
+  "provides": []
+}

--- a/monitor-aws-resources-lj/create-scrape-job/website.yaml
+++ b/monitor-aws-resources-lj/create-scrape-job/website.yaml
@@ -1,0 +1,26 @@
+menuTitle: Create scrape job
+weight: 600
+step: 7
+layout: single-journey
+cta:
+  type: success
+  troubleshooting:
+    title: 'Explore the following troubleshooting topics if you need help:'
+    items:
+    - title: Verify AWS IAM permissions
+      link: /docs/grafana-cloud/monitor-infrastructure/monitor-cloud-provider/aws/cloudwatch-metrics/config-cw-metric-scrape/#verify-aws-iam-permissions
+    - title: Check resource tagging
+      link: /docs/grafana-cloud/monitor-infrastructure/monitor-cloud-provider/aws/cloudwatch-metrics/config-cw-metric-scrape/#check-resource-tagging
+description: Learn how to create and configure scrape jobs to collect specific metrics from your AWS services.
+keywords:
+- scrape job
+- metric collection
+- AWS services
+- configuration
+- custom metrics
+side_journeys:
+  title: More to explore (optional)
+  heading: 'At this point in your journey, you can explore the following paths:'
+  items:
+  - title: Create a scrape job using Terraform
+    link: /docs/grafana-cloud/monitor-infrastructure/monitor-cloud-provider/aws/cloudwatch-metrics/config-cw-metric-scrape/#create-a-scrape-job-using-terraform

--- a/monitor-aws-resources-lj/end-journey/content.json
+++ b/monitor-aws-resources-lj/end-journey/content.json
@@ -1,0 +1,15 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "monitor-aws-resources-end-journey",
+  "title": "Destination reached!",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "Congratulations on completing this journey! Job well done!\n\nWe hope you've enjoyed traveling with us as you:\n\n- Learned about the business value of observability for AWS infrastructure monitoring\n- Learned the advantages of using Grafana Cloud provider AWS for unified monitoring\n- Navigated to the AWS configuration interface in Grafana Cloud provider\n- Created an AWS IAM role with appropriate permissions for secure metric collection\n- Connected your AWS account to Grafana Cloud using role-based authentication\n- Created a scrape job to customize metric collection for your specific AWS services\n- Verified data was collected and sent from Amazon to Grafana Cloud\n- Explored AWS service data using pre-built dashboards and analysis tools"
+    },
+    {
+      "type": "markdown",
+      "content": "---\n\n### Related paths\n\nConsider taking the following paths after you complete this journey:\n\n- [Explore data using Metrics Drilldown](https://grafana.com/docs/learning-paths/drilldown-metrics/)\n- [Explore logs using Logs Drilldown](https://grafana.com/docs/learning-paths/drilldown-logs/)"
+    }
+  ]
+}

--- a/monitor-aws-resources-lj/end-journey/manifest.json
+++ b/monitor-aws-resources-lj/end-journey/manifest.json
@@ -1,0 +1,17 @@
+{
+  "id": "monitor-aws-resources-end-journey",
+  "type": "guide",
+  "description": "Congratulations on completing the AWS monitoring learning path. Explore next steps and additional resources.",
+  "category": "data-availability",
+  "author": {
+    "name": "Jack Baldry",
+    "team": "Grafana Documentation"
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": ["monitor-aws-resources-explore-data"],
+  "recommends": [],
+  "suggests": ["drilldown-metrics-lj", "drilldown-logs-lj"],
+  "provides": []
+}

--- a/monitor-aws-resources-lj/end-journey/website.yaml
+++ b/monitor-aws-resources-lj/end-journey/website.yaml
@@ -1,0 +1,12 @@
+menuTitle: Destination reached!
+weight: 800
+step: 10
+layout: single-journey
+cta:
+  type: conclusion
+keywords:
+- AWS monitoring
+- completion
+- next steps
+- additional resources
+- observability journey

--- a/monitor-aws-resources-lj/end-journey/website.yaml
+++ b/monitor-aws-resources-lj/end-journey/website.yaml
@@ -1,4 +1,5 @@
 menuTitle: Destination reached!
+description: Congratulations on completing the Monitor AWS resources learning path. Review what you've accomplished and explore related paths.
 weight: 800
 step: 10
 layout: single-journey

--- a/monitor-aws-resources-lj/explore-data/content.json
+++ b/monitor-aws-resources-lj/explore-data/content.json
@@ -1,0 +1,83 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "monitor-aws-resources-explore-data",
+  "title": "Explore your AWS service data",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "In this milestone, you'll navigate and analyze the AWS metrics collected by Cloud provider. Cloud provider offers pre-built dashboards optimized for AWS services, along with powerful exploration tools to investigate performance patterns and identify potential issues.\n\nCloud provider AWS can deploy dashboards for each service you're monitoring, providing immediate insights into resource utilization, performance trends, and operational health."
+    },
+    {
+      "type": "markdown",
+      "content": "To install the preconfigured dashboards and alerts, complete the following steps:"
+    },
+    {
+      "type": "section",
+      "title": "Install preconfigured dashboards and alerts",
+      "autoCollapse": false,
+      "blocks": [
+        {
+          "type": "multistep",
+          "content": "In Grafana Cloud, open the navigation menu and select **Observability > Cloud provider > AWS**, then click the **Configuration** tab.",
+          "requirements": ["navmenu-open"],
+          "steps": [
+            {
+              "action": "highlight",
+              "reftarget": "a[data-testid='data-testid Nav menu item'][href='/a/grafana-csp-app/aws']"
+            },
+            {
+              "action": "highlight",
+              "reftarget": "a[data-testid='data-testid Tab Configuration']"
+            }
+          ]
+        },
+        {
+          "type": "markdown",
+          "content": "Scroll down to the **Dashboards and Alerts Installation** section."
+        },
+        {
+          "type": "interactive",
+          "action": "button",
+          "reftarget": "Install",
+          "content": "Click **Install** to install the prebuilt dashboards and alerts for your AWS services.",
+          "requirements": ["exists-reftarget", "on-page:/a/grafana-csp-app/aws/configuration"]
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "You installed the preconfigured dashboards and alerts for your AWS services."
+    },
+    {
+      "type": "markdown",
+      "content": "Now open a service dashboard to explore your AWS metrics."
+    },
+    {
+      "type": "interactive",
+      "action": "highlight",
+      "reftarget": "a[data-testid='data-testid Tab Services']",
+      "content": "Click the **Services** tab.",
+      "requirements": ["exists-reftarget", "on-page:/a/grafana-csp-app/aws"]
+    },
+    {
+      "type": "markdown",
+      "content": "Locate and click the specific service or source in the list. Use the **Service** or **Source** filters to find the service or source you want to see.\n\nFor example, select **AWS EC2** to view EC2 instance metrics. If there are multiple instances, select the instance ID for the instance you want to see."
+    },
+    {
+      "type": "markdown",
+      "content": "Explore the dashboard panels to understand your AWS resource performance. For instance, if you select a specific EC2 instance, you can explore the following panels:\n\n- Review **CPU Utilization** panels to identify high-load instances.\n- Examine **Network** charts to understand data transfer patterns.\n- Check **Disk Ops** metrics to spot storage bottlenecks.\n- Monitor **Instance Status** to verify resource health."
+    },
+    {
+      "type": "markdown",
+      "content": "Use dashboard controls to customize your view:\n\n- Select a **time range** using the time picker in the upper right. For example, select **Last 24 hours** to view recent performance.\n- Apply **variable filters** to focus on specific instances or regions. For example, select **us-east-1** from the **Region** dropdown.\n\nTo investigate specific metrics using Explore, click **Explore** on any interesting panel. Explore opens the metric in Grafana's query interface for detailed analysis."
+    },
+    {
+      "type": "markdown",
+      "content": "### Insights from AWS data\n\nDashboards provide the following operational insights:\n\n- **Resource utilization patterns**: Identify peak usage times and plan capacity accordingly.\n- **Performance bottlenecks**: Spot consistently high CPU, memory, or I/O utilization that may require optimization.\n- **Cost optimization opportunities**: Find under-utilized resources that could be downsized or terminated.\n- **Availability monitoring**: Track instance health and service uptime across your AWS environment."
+    },
+    {
+      "type": "markdown",
+      "content": "In your final milestone, you'll celebrate completing this AWS monitoring journey and discover additional resources for expanding your observability capabilities."
+    }
+  ]
+}

--- a/monitor-aws-resources-lj/explore-data/content.json
+++ b/monitor-aws-resources-lj/explore-data/content.json
@@ -39,7 +39,8 @@
           "type": "interactive",
           "action": "button",
           "reftarget": "Install",
-          "content": "Click **Install** to install the prebuilt dashboards and alerts for your AWS services.",
+          "content": "Click **Install** to install the prebuilt dashboards and alerts for your AWS services. If the dashboards are already installed, the **Uninstall button appears.",
+          "skippable": true,
           "requirements": ["exists-reftarget", "on-page:/a/grafana-csp-app/aws/configuration"]
         }
       ]

--- a/monitor-aws-resources-lj/explore-data/content.json
+++ b/monitor-aws-resources-lj/explore-data/content.json
@@ -39,7 +39,7 @@
           "type": "interactive",
           "action": "button",
           "reftarget": "Install",
-          "content": "Click **Install** to install the prebuilt dashboards and alerts for your AWS services. If the dashboards are already installed, the **Uninstall button appears.",
+          "content": "Click **Install** to install the prebuilt dashboards and alerts for your AWS services. If the dashboards are already installed, the **Uninstall** button appears.",
           "skippable": true,
           "requirements": ["exists-reftarget", "on-page:/a/grafana-csp-app/aws/configuration"]
         }
@@ -70,7 +70,7 @@
     },
     {
       "type": "markdown",
-      "content": "Use dashboard controls to customize your view:\n\n- Select a **time range** using the time picker in the upper right. For example, select **Last 24 hours** to view recent performance.\n- Apply **variable filters** to focus on specific instances or regions. For example, select **us-east-1** from the **Region** dropdown.\n\nTo investigate specific metrics using Explore, click **Explore** on any interesting panel. Explore opens the metric in Grafana's query interface for detailed analysis."
+      "content": "Use dashboard controls to customize your view:\n\n- Select a **tßime range** using the time picker in the upper right. For example, select **Last 24 hours** to view recent performance.\n- Apply **variable filters** to focus on specific instances or regions. For example, select **us-east-1** from the **Region** dropdown.\n\nTo investigate specific metrics using Explore, click **Explore** on any interesting panel. Explore opens the metric in Grafana's query interface for detailed analysis."
     },
     {
       "type": "markdown",

--- a/monitor-aws-resources-lj/explore-data/content.json
+++ b/monitor-aws-resources-lj/explore-data/content.json
@@ -37,9 +37,10 @@
         },
         {
           "type": "interactive",
-          "action": "highlight",
-          "reftarget": "button:text('Install')",
-          "content": "Click **Install** to install the prebuilt dashboards and alerts for your AWS services. If the dashboards are already installed, the **Uninstall** button appears.",
+          "action": "button",
+          "reftarget": "Install",
+          "content": "Click **Install** to install the prebuilt dashboards and alerts for your AWS services. If the dashboards are already installed, the **Uninstall** button appears instead, and you can skip this step.",
+          "doIt": false,
           "skippable": true,
           "requirements": ["exists-reftarget", "on-page:/a/grafana-csp-app/aws/configuration"]
         }

--- a/monitor-aws-resources-lj/explore-data/content.json
+++ b/monitor-aws-resources-lj/explore-data/content.json
@@ -37,8 +37,8 @@
         },
         {
           "type": "interactive",
-          "action": "button",
-          "reftarget": "Install",
+          "action": "highlight",
+          "reftarget": "button:text('Install')",
           "content": "Click **Install** to install the prebuilt dashboards and alerts for your AWS services. If the dashboards are already installed, the **Uninstall** button appears.",
           "skippable": true,
           "requirements": ["exists-reftarget", "on-page:/a/grafana-csp-app/aws/configuration"]

--- a/monitor-aws-resources-lj/explore-data/manifest.json
+++ b/monitor-aws-resources-lj/explore-data/manifest.json
@@ -1,0 +1,18 @@
+{
+  "id": "monitor-aws-resources-explore-data",
+  "type": "guide",
+  "description": "Learn how to navigate and analyze your AWS metrics using Grafana dashboards and exploration tools.",
+  "category": "data-availability",
+  "author": {
+    "name": "Jack Baldry",
+    "team": "Grafana Documentation"
+  },
+  "startingLocation": "/a/grafana-csp-app/aws",
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": ["monitor-aws-resources-verify-data-collection"],
+  "recommends": ["monitor-aws-resources-end-journey"],
+  "suggests": [],
+  "provides": []
+}

--- a/monitor-aws-resources-lj/explore-data/website.yaml
+++ b/monitor-aws-resources-lj/explore-data/website.yaml
@@ -1,0 +1,13 @@
+menuTitle: Explore AWS data
+weight: 700
+step: 9
+layout: single-journey
+cta:
+  type: continue
+description: Learn how to navigate and analyze your AWS metrics using Grafana dashboards and exploration tools.
+keywords:
+- AWS metrics
+- dashboard exploration
+- data analysis
+- monitoring insights
+- performance metrics

--- a/monitor-aws-resources-lj/manifest.json
+++ b/monitor-aws-resources-lj/manifest.json
@@ -1,0 +1,43 @@
+{
+  "id": "monitor-aws-resources-lj",
+  "type": "path",
+  "description": "Step-by-step guide: Monitor AWS resources with Grafana Cloud Provider Observability.",
+  "category": "data-availability",
+  "author": {
+    "name": "Jack Baldry",
+    "team": "Grafana Documentation"
+  },
+  "startingLocation": "/a/grafana-csp-app/aws",
+  "targeting": {
+    "match": {
+      "and": [
+        {
+          "urlPrefixIn": [
+            "/a/grafana-csp-app/aws",
+            "/a/grafana-csp-app/aws/overview",
+            "/a/grafana-csp-app/aws/configuration"
+          ]
+        },
+        {
+          "targetPlatform": "cloud"
+        }
+      ]
+    }
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "milestones": [
+    "monitor-aws-resources-navigate-aws-config",
+    "monitor-aws-resources-create-iam-role",
+    "monitor-aws-resources-connect-aws-account",
+    "monitor-aws-resources-create-scrape-job",
+    "monitor-aws-resources-verify-data-collection",
+    "monitor-aws-resources-explore-data",
+    "monitor-aws-resources-end-journey"
+  ],
+  "depends": [],
+  "recommends": ["drilldown-metrics-lj", "drilldown-logs-lj"],
+  "suggests": [],
+  "provides": []
+}

--- a/monitor-aws-resources-lj/navigate-aws-config/content.json
+++ b/monitor-aws-resources-lj/navigate-aws-config/content.json
@@ -1,0 +1,40 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "monitor-aws-resources-navigate-aws-config",
+  "title": "Navigate to Cloud Provider Observability for AWS",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "In this milestone, you'll access the Cloud provider AWS configuration interface in Grafana Cloud. This interface provides the central location for managing your AWS monitoring setup, including authentication, service selection, and dashboard deployment.\n\nThe Cloud provider AWS configuration interface streamlines the integration process by providing guided setup steps to ensure your connection works correctly.\n\nMake sure you're signed in to your Grafana Cloud environment, for example `mystack.grafana.net`."
+    },
+    {
+      "type": "section",
+      "title": "Open AWS configuration",
+      "autoCollapse": false,
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "a[data-testid='data-testid Nav menu item'][href='/a/grafana-csp-app/aws']",
+          "content": "Open the navigation menu and click **Observability > Cloud provider > AWS**.",
+          "requirements": ["navmenu-open", "exists-reftarget"]
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "a[data-testid='data-testid Tab Configuration']",
+          "content": "On the **AWS** page, click the **Configuration** tab.",
+          "requirements": ["exists-reftarget", "on-page:/a/grafana-csp-app/aws"]
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "The Cloud provider AWS configuration page includes multiple options including authentication and setup instructions. This page guides you through the process of connecting your AWS account and selecting which services to monitor.\n\nIn your next milestone, you'll create the required AWS IAM role that allows Grafana Cloud to access your AWS metrics."
+    },
+    {
+      "type": "markdown",
+      "content": "---\n\n### More to explore (optional)\n\n- [Cloud Provider Observability overview](https://grafana.com/docs/grafana-cloud/monitor-infrastructure/monitor-cloud-provider/)"
+    }
+  ]
+}

--- a/monitor-aws-resources-lj/navigate-aws-config/manifest.json
+++ b/monitor-aws-resources-lj/navigate-aws-config/manifest.json
@@ -1,0 +1,18 @@
+{
+  "id": "monitor-aws-resources-navigate-aws-config",
+  "type": "guide",
+  "description": "Learn how to access the AWS integration configuration interface in Grafana Cloud.",
+  "category": "data-availability",
+  "author": {
+    "name": "Jack Baldry",
+    "team": "Grafana Documentation"
+  },
+  "startingLocation": "/a/grafana-csp-app/aws",
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": [],
+  "recommends": ["monitor-aws-resources-create-iam-role"],
+  "suggests": [],
+  "provides": []
+}

--- a/monitor-aws-resources-lj/navigate-aws-config/website.yaml
+++ b/monitor-aws-resources-lj/navigate-aws-config/website.yaml
@@ -1,0 +1,19 @@
+menuTitle: Navigate to Cloud Provider Observability
+weight: 300
+step: 4
+layout: single-journey
+cta:
+  type: continue
+description: Learn how to access the AWS integration configuration interface in Grafana Cloud.
+keywords:
+- Grafana Cloud
+- AWS configuration
+- cloud provider
+- integration setup
+- navigation
+side_journeys:
+  title: More to explore (optional)
+  heading: 'At this point in your journey, you can explore the following paths:'
+  items:
+  - title: Cloud Provider Observability overview
+    link: /docs/grafana-cloud/monitor-infrastructure/monitor-cloud-provider/

--- a/monitor-aws-resources-lj/verify-data-collection/content.json
+++ b/monitor-aws-resources-lj/verify-data-collection/content.json
@@ -1,0 +1,48 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "monitor-aws-resources-verify-data-collection",
+  "title": "Verify data collection",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "In this milestone, you'll verify that data is collected and sent to Grafana Cloud. After you create your CloudWatch metrics scrape job, you can check that data is successfully getting sent from your Amazon account to Grafana Cloud."
+    },
+    {
+      "type": "section",
+      "title": "Check scrape job status",
+      "autoCollapse": false,
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "a[data-testid='data-testid Nav menu item'][href='/a/grafana-csp-app/aws']",
+          "content": "In Grafana Cloud, click **Observability > Cloud provider > AWS** in the main menu.",
+          "requirements": ["navmenu-open", "exists-reftarget"]
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "a[data-testid='data-testid Tab Services']",
+          "content": "Click the **Services** tab.",
+          "requirements": ["exists-reftarget", "on-page:/a/grafana-csp-app/aws"]
+        },
+        {
+          "type": "markdown",
+          "content": "Find your scrape job listed in the **Job name** column.\n\nIf data is getting sent to Grafana Cloud, the service's status is **Sending data**."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='service-overview-sending-datata-ok']",
+          "content": "Hover your mouse over the status to see the date data was last sent from your specific scrape job.\n\n",
+          "doIt": false,
+          "requirements": ["exists-reftarget"]
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "Data is successfully flowing from your Amazon account to Grafana Cloud.\n\nIn your next milestone, you'll explore the AWS service data collected through your scrape jobs using Grafana built-in dashboards and query tools."
+    }
+  ]
+}

--- a/monitor-aws-resources-lj/verify-data-collection/manifest.json
+++ b/monitor-aws-resources-lj/verify-data-collection/manifest.json
@@ -1,0 +1,18 @@
+{
+  "id": "monitor-aws-resources-verify-data-collection",
+  "type": "guide",
+  "description": "Learn how to verify data is collected and being sent to Grafana Cloud.",
+  "category": "data-availability",
+  "author": {
+    "name": "Jack Baldry",
+    "team": "Grafana Documentation"
+  },
+  "startingLocation": "/a/grafana-csp-app/aws",
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": ["monitor-aws-resources-create-scrape-job"],
+  "recommends": ["monitor-aws-resources-explore-data"],
+  "suggests": [],
+  "provides": []
+}

--- a/monitor-aws-resources-lj/verify-data-collection/website.yaml
+++ b/monitor-aws-resources-lj/verify-data-collection/website.yaml
@@ -1,0 +1,13 @@
+menuTitle: Verify data collection
+weight: 650
+step: 8
+layout: single-journey
+cta:
+  type: continue
+description: Learn how to verify data is collected and being sent to Grafana Cloud.
+keywords:
+- Grafana Cloud
+- AWS configuration
+- cloud provider
+- data verification
+- status check

--- a/monitor-aws-resources-lj/website.yaml
+++ b/monitor-aws-resources-lj/website.yaml
@@ -1,0 +1,34 @@
+menuTitle: Monitor AWS resources
+weight: 1000
+journey:
+  group: data-availability
+  skill: Beginner
+  source: Docs & blog posts
+  logo:
+    src: /media/docs/grafana-cloud/cloud-provider/CP_logo.svg
+    background: '#FFFFFF'
+    width: 46
+    height: 55
+step: 1
+layout: single-journey
+cascade:
+  layout: single-journey
+cta:
+  type: start
+  title: Are you ready?
+  cta_text: Let's go!
+description: Monitor AWS resources with Grafana Cloud Provider Observability by collecting Amazon CloudWatch metrics through pre-built dashboards.
+keywords:
+- AWS
+- monitoring
+- cloud integration
+- observability
+- Grafana Cloud
+related_journeys:
+  title: Related paths
+  heading: Consider taking the following paths after you complete this journey.
+  items:
+  - title: Explore data using Metrics Drilldown
+    link: /docs/learning-paths/drilldown-metrics/
+  - title: Explore logs using Logs Drilldown
+    link: /docs/learning-paths/drilldown-logs/


### PR DESCRIPTION
Adds interactivity to learning path, "Monitor AWS resources with Grafana Cloud."

Walks users through connecting an AWS account to Grafana Cloud Provider Observability and monitoring AWS services via Amazon CloudWatch metrics and pre-built dashboards.

The path (`monitor-aws-resources-lj`) covers the full onboarding flow across these milestones:
- Navigate to the Cloud provider AWS configuration in Grafana Cloud
- Create an AWS IAM role with the required monitoring permissions
- Connect the AWS account to Grafana Cloud
- Create a scrape job to collect metrics from AWS services
- Verify data collection
- Explore AWS service data using pre-built dashboards

It also includes a framing milestone and an end-of-journey wrap-up, plus the accompanying `manifest.json` and `website.yaml` for each module. 

Targeting is scoped to `/a/grafana-csp-app/aws` on the `cloud` platform, and the path recommends the Metrics Drilldown and Logs Drilldown journeys as follow-ups.

All controls were tested for show me/do it, using a private AWS account and Amazon Route 53 metrics.