### PR TITLE
Remove targeting for learning path milestones

### DIFF
--- a/elasticsearch-logs-lj/end-journey/manifest.json
+++ b/elasticsearch-logs-lj/end-journey/manifest.json
@@ -8,15 +8,6 @@
     "team": "Grafana Documentation"
   },
   "startingLocation": "/explore",
-  "targeting": {
-    "match": {
-      "and": [
-        {
-          "targetPlatform": "cloud"
-        }
-      ]
-    }
-  },
   "testEnvironment": {
     "tier": "cloud"
   },

--- a/elasticsearch-logs-lj/value-of-log-exploration/manifest.json
+++ b/elasticsearch-logs-lj/value-of-log-exploration/manifest.json
@@ -8,15 +8,6 @@
     "team": "Grafana Documentation"
   },
   "startingLocation": "/explore",
-  "targeting": {
-    "match": {
-      "and": [
-        {
-          "targetPlatform": "cloud"
-        }
-      ]
-    }
-  },
   "testEnvironment": {
     "tier": "cloud"
   },


### PR DESCRIPTION
They don't need targeting because it causes those milestones to get recommended in Pathfinder separately to the learning path.

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>
