### PR TITLE
Hide Grafana Play on find-k6-limits path

### DIFF
--- a/find-k6-limits-lj/website.yaml
+++ b/find-k6-limits-lj/website.yaml
@@ -43,3 +43,4 @@ related_journeys:
     link: /docs/learning-paths/run-first-k6-test/
   - title: Establish a performance baseline with k6
     link: /docs/learning-paths/establish-k6-baseline/
+show_play: false


### PR DESCRIPTION
## Summary
- Set `show_play: false` on `find-k6-limits-lj/website.yaml` so sync hides **Try in Grafana Play** for this k6 path (k6 is not available in Play).
- Matches existing k6 paths such as `run-first-k6-test` and `k6-soak-testing`.

## Test plan
- [ ] Confirm `show_play: false` is present in `find-k6-limits-lj/website.yaml`
- [ ] After website sync, verify `/docs/learning-paths/find-k6-limits/` CTA has no Play button


Made with [Cursor](https://cursor.com)