### PR TITLE
Catch bookends and light claims earlier in LP scaffolding

### DIFF
--- a/.cursor/commands/build-interactive-lj/README.md
+++ b/.cursor/commands/build-interactive-lj/README.md
@@ -21,9 +21,10 @@ Follow these phases in order:
 3. **Scaffold content files.** Create `content.json` for every milestone in the interactive-tutorials repo — interactive blocks for UI steps, markdown blocks for conceptual content. Because the website markdown is no longer used to render this learning path, capture all conceptual prose from each milestone's `index.md` body as markdown blocks so no content is lost. Extract `side_journeys`, `related_journeys`, and `cta.troubleshooting` from each existing `index.md` and include them as markdown blocks. **Exception: the `business-value` milestone gets markdown blocks only — no interactive blocks, sections, or guided blocks.**
 4. **Create website metadata files.** Create a `website.yaml` for the path and each milestone, derived from the front matter of the corresponding website markdown files. Map the path `_index.md` front matter into the path-level `website.yaml` and each milestone `index.md` front matter into that milestone's `website.yaml` (for example, `title` → `menuTitle`, plus `description`, `weight`, step ordering, `cta`, `related_journeys` at the path level, and `side_journeys` at the step level). These files take the place of the markdown front matter as the package's source of website metadata; the website markdown itself stays unchanged. Refer to `docs/website-yaml-reference.md`.
 5. **Generate manifests.** Create `manifest.json` for the path (`type: "path"`, milestones array, targeting) and each milestone (`type: "guide"`, depends/recommends chain). Refer to `docs/manifest-reference.md`. **Exception: exclude `business-value` from the path-level `milestones` array.** The `business-value` milestone still gets its own `manifest.json` with `depends: []` and `recommends: ["[slug]-[first-interactive-milestone]"]`, but it is not a registered stop on the path.
-6. **Discover selectors.** Use Playwright at `learn.grafana.net` to find stable CSS selectors for each interactive element. The user must log in through the Playwright browser window (Okta SAML).
-7. **Test in Pathfinder.** Tell the user which `content.json` to import into the Block Editor at `learn.grafana.net/?pathfinder-dev=true`. Wait for their feedback on each "Show me" / "Do it" button. Fix broken selectors based on their reports.
-8. **Verify and wrap up.** Cross-check all factual claims against live docs. Update `.github/CODEOWNERS`. Provide a summary of all files created.
+6. **Scaffold self-check (required).** Before Playwright, run [../create-learning-path/reference/scaffold-self-check.md](../create-learning-path/reference/scaffold-self-check.md): section bookends, `button` vs CSS `reftarget` misuse, secrets `doIt`, and a light claim pass against the docs you already read. Fix findings (or ask the author) before continuing.
+7. **Discover selectors.** Use Playwright at `learn.grafana.net` to find stable CSS selectors for each interactive element. The user must log in through the Playwright browser window (Okta SAML).
+8. **Test in Pathfinder.** Tell the user which `content.json` to import into the Block Editor at `learn.grafana.net/?pathfinder-dev=true`. Wait for their feedback on each "Show me" / "Do it" button. Fix broken selectors based on their reports.
+9. **Verify and wrap up.** Re-run the light claim pass if prose changed. Cross-check remaining factual claims against live docs. Update `.github/CODEOWNERS`. Provide a summary of all files created.
 
 For background on how this command relates to `/create-learning-path`, refer to `.cursor/learning-path-workflows/workflows.md`.
 
@@ -44,6 +45,7 @@ For background on how this command relates to `/create-learning-path`, refer to 
 11. **Ask before fixing.** When the user reports a broken selector, explain the problem and proposed fix, then wait for approval.
 12. **3-attempt limit per selector.** If a selector fails after 3 tries, mark it `TODO:manual-review` and move on.
 13. **Update CODEOWNERS.** Add the new `[slug]-lj/` directory to `.github/CODEOWNERS`.
+14. **Do not skip the scaffold self-check.** Section bookends, `button`/CSS misuse, and unsupported product claims must be caught before selector discovery. See [../create-learning-path/reference/scaffold-self-check.md](../create-learning-path/reference/scaffold-self-check.md).
 
 ---
 
@@ -56,6 +58,8 @@ For background on how this command relates to `/create-learning-path`, refer to 
 - Never use non-standard CSS (`:contains()`, `:has-text()`)
 - Never use data-dependent selectors — use `^=` starts-with patterns
 - Never leave placeholder selectors (`"[selector]"`, `"TODO"`)
+- Never put section intro/summary markdown **inside** the `section` when it will number as a fake step (`You'll…`, `To … complete the following steps`)
+- Never use `action: "button"` with a CSS selector `reftarget` (use `highlight` or `navigate`)
 
 ---
 
@@ -68,6 +72,7 @@ Consult these during the workflow:
 | `reference/json-schema.md` | Writing content.json (block types, action types, field reference) |
 | `reference/selector-patterns.md` | Discovering selectors (priority, stability, anti-patterns) |
 | `../create-learning-path/reference/frontmatter-schema.md` | Reading website front matter fields and CTA types (source only) |
+| `../create-learning-path/reference/scaffold-self-check.md` | After scaffold, before Playwright (bookends, claims, action sanity) |
 | `docs/website-yaml-reference.md` | Creating website.yaml (field reference, CTA types, examples) |
 | `docs/manifest-reference.md` | Generating manifest.json files |
 | `.cursor/proven-patterns.mdc` | Reusable patterns for common Grafana UI elements (auto-loaded) |

--- a/.cursor/commands/build-interactive-lj/README.md
+++ b/.cursor/commands/build-interactive-lj/README.md
@@ -25,6 +25,12 @@ Follow these phases in order:
 7. **Discover selectors.** Use Playwright at `learn.grafana.net` to find stable CSS selectors for each interactive element. The user must log in through the Playwright browser window (Okta SAML).
 8. **Test in Pathfinder.** Tell the user which `content.json` to import into the Block Editor at `learn.grafana.net/?pathfinder-dev=true`. Wait for their feedback on each "Show me" / "Do it" button. Fix broken selectors based on their reports.
 9. **Verify and wrap up.** Re-run the light claim pass if prose changed. Cross-check remaining factual claims against live docs. Update `.github/CODEOWNERS`. Provide a summary of all files created.
+10. **Ask about a Learning Hub deploy preview (required before opening the PR).** Website previews are opt-in via the `deploy-preview` label. Ask the author:
+
+    > Want a Learning Hub website deploy preview on the PR? Recommended for new `*-lj` paths so you can read the non-interactive pages before Learning Hub publish. This is markdown/`website.yaml` only, not Pathfinder Show me / Do it.
+
+    - **Yes (default for new paths):** When creating the PR, add `--label deploy-preview`. If the PR already exists without the label, add it with `gh pr edit <n> --add-label deploy-preview`, then push any new commit (or an empty commit) so the workflow runs on `synchronize`. Label-only events do not build.
+    - **No:** Open the PR without the label. Tell the author they can add `deploy-preview` later and push again if they change their mind.
 
 For background on how this command relates to `/create-learning-path`, refer to `.cursor/learning-path-workflows/workflows.md`.
 

--- a/.cursor/commands/create-learning-path/README.md
+++ b/.cursor/commands/create-learning-path/README.md
@@ -24,7 +24,7 @@ Follow these phases in order:
 4. **Scaffold content files.** Create `content.json` for every milestone — interactive blocks for UI steps, markdown blocks for conceptual content. While writing sections, keep bookends **outside** the `section` (critical rule 14). Never put "You'll…" / "To … complete the following steps" as the first block inside a `section`.
 5. **Create website metadata files.** Create `website.yaml` for the path and each milestone. Refer to `docs/website-yaml-reference.md`.
 6. **Generate manifests.** Create `manifest.json` for the path (`type: "path"`, milestones array, targeting) and each milestone (`type: "guide"`, depends/recommends chain). Refer to `docs/manifest-reference.md`. Where fields can't be derived, ask the user to provide values before generating.
-7. **Scaffold self-check (required).** Before Playwright, run [reference/scaffold-self-check.md](reference/scaffold-self-check.md): section bookends, `button` vs CSS `reftarget` misuse, secrets `doIt`, and a light claim pass against the docs you already read. Fix findings (or ask the author) before continuing.
+7. **Scaffold self-check (required).** Before Playwright, run [reference/scaffold-self-check.md](reference/scaffold-self-check.md): section bookends, `button` vs CSS `reftarget` misuse, secrets `doIt`, redundant “copy this command” cues next to fenced samples, and a light claim pass against the docs you already read. Fix findings (or ask the author) before continuing.
 8. **Discover selectors.** Use Playwright at `learn.grafana.net` to find stable CSS selectors for each interactive element. The user must log in through the Playwright browser window (Okta SAML).
 9. **Test in Pathfinder.** Tell the user which `content.json` to import into the Block Editor at `learn.grafana.net/?pathfinder-dev=true`. Wait for their feedback on each "Show me" / "Do it" button. Fix broken selectors based on their reports.
 10. **Verify and wrap up.** Re-run the light claim pass if prose changed. Cross-check remaining factual claims against live docs. Update `.github/CODEOWNERS`. Provide a summary of all files created.
@@ -50,7 +50,7 @@ For background on how this command relates to `/build-interactive-lj`, refer to 
 7. **3-attempt limit per selector.** If a selector fails after 3 tries, mark it `TODO:manual-review` and move on.
 8. **Update CODEOWNERS.** Add the new `[slug]-lj/` directory to `.github/CODEOWNERS`.
 9. **Verify docs accuracy.** After testing, cross-check all factual claims against live Grafana documentation.
-10. **Do not skip the scaffold self-check.** Section bookends, `button`/CSS misuse, and unsupported product claims must be caught before selector discovery. See [reference/scaffold-self-check.md](reference/scaffold-self-check.md).
+10. **Do not skip the scaffold self-check.** Section bookends, `button`/CSS misuse, redundant copy cues next to listed commands, and unsupported product claims must be caught before selector discovery. See [reference/scaffold-self-check.md](reference/scaffold-self-check.md).
 
 ---
 
@@ -78,7 +78,7 @@ Consult these during the workflow:
 | `docs/website-yaml-reference.md` | Creating website.yaml (field reference, CTA types, examples) |
 | `../build-interactive-lj/reference/json-schema.md` | Writing content.json (block types, action types, field reference) |
 | `../build-interactive-lj/reference/selector-patterns.md` | Discovering selectors (priority, stability, anti-patterns) |
-| `reference/scaffold-self-check.md` | After scaffold, before Playwright (bookends, claims, action sanity) |
+| `reference/scaffold-self-check.md` | After scaffold, before Playwright (bookends, claims, action sanity, copy cues) |
 | `docs/manifest-reference.md` | Generating manifest.json files |
 | `.cursor/proven-patterns.mdc` | Reusable patterns for common Grafana UI elements (auto-loaded) |
 

--- a/.cursor/commands/create-learning-path/README.md
+++ b/.cursor/commands/create-learning-path/README.md
@@ -28,6 +28,12 @@ Follow these phases in order:
 8. **Discover selectors.** Use Playwright at `learn.grafana.net` to find stable CSS selectors for each interactive element. The user must log in through the Playwright browser window (Okta SAML).
 9. **Test in Pathfinder.** Tell the user which `content.json` to import into the Block Editor at `learn.grafana.net/?pathfinder-dev=true`. Wait for their feedback on each "Show me" / "Do it" button. Fix broken selectors based on their reports.
 10. **Verify and wrap up.** Re-run the light claim pass if prose changed. Cross-check remaining factual claims against live docs. Update `.github/CODEOWNERS`. Provide a summary of all files created.
+11. **Ask about a Learning Hub deploy preview (required before opening the PR).** Website previews are opt-in via the `deploy-preview` label. Ask the author:
+
+    > Want a Learning Hub website deploy preview on the PR? Recommended for new `*-lj` paths so you can read the non-interactive pages before Learning Hub publish. This is markdown/`website.yaml` only, not Pathfinder Show me / Do it.
+
+    - **Yes (default for new paths):** When creating the PR, add `--label deploy-preview`. If the PR already exists without the label, add it with `gh pr edit <n> --add-label deploy-preview`, then push any new commit (or an empty commit) so the workflow runs on `synchronize`. Label-only events do not build.
+    - **No:** Open the PR without the label. Tell the author they can add `deploy-preview` later and push again if they change their mind.
 
 For background on how this command relates to `/build-interactive-lj`, refer to `.cursor/learning-path-workflows/workflows.md`.
 

--- a/.cursor/commands/create-learning-path/README.md
+++ b/.cursor/commands/create-learning-path/README.md
@@ -21,12 +21,13 @@ Follow these phases in order:
 1. **Validate environment.** Confirm the `interactive-tutorials` repo is writable and the `website` repo is readable in the workspace, and that Playwright MCP is available. The `website` repo is a read-only source — it's used only to read canonical docs and any existing source markdown. All generated files are written to interactive-tutorials.
 2. **Read feature docs.** Identify the canonical Grafana docs pages for the feature. Read every doc page in full from the local `website` repo first, then WebFetch.
 3. **Propose path options.** Review existing paths in `interactive-tutorials/[slug]-lj` for structural patterns. Propose 2-4 path options with milestones. Target 2-5 minutes per milestone, 6-8 milestones per path (max 10). Wait for user approval before proceeding.
-4. **Scaffold content files.** Create `content.json` for every milestone — interactive blocks for UI steps, markdown blocks for conceptual content.
+4. **Scaffold content files.** Create `content.json` for every milestone — interactive blocks for UI steps, markdown blocks for conceptual content. While writing sections, keep bookends **outside** the `section` (critical rule 14). Never put "You'll…" / "To … complete the following steps" as the first block inside a `section`.
 5. **Create website metadata files.** Create `website.yaml` for the path and each milestone. Refer to `docs/website-yaml-reference.md`.
 6. **Generate manifests.** Create `manifest.json` for the path (`type: "path"`, milestones array, targeting) and each milestone (`type: "guide"`, depends/recommends chain). Refer to `docs/manifest-reference.md`. Where fields can't be derived, ask the user to provide values before generating.
-7. **Discover selectors.** Use Playwright at `learn.grafana.net` to find stable CSS selectors for each interactive element. The user must log in through the Playwright browser window (Okta SAML).
-8. **Test in Pathfinder.** Tell the user which `content.json` to import into the Block Editor at `learn.grafana.net/?pathfinder-dev=true`. Wait for their feedback on each "Show me" / "Do it" button. Fix broken selectors based on their reports.
-9. **Verify and wrap up.** Cross-check all factual claims against live docs. Update `.github/CODEOWNERS`. Provide a summary of all files created.
+7. **Scaffold self-check (required).** Before Playwright, run [reference/scaffold-self-check.md](reference/scaffold-self-check.md): section bookends, `button` vs CSS `reftarget` misuse, secrets `doIt`, and a light claim pass against the docs you already read. Fix findings (or ask the author) before continuing.
+8. **Discover selectors.** Use Playwright at `learn.grafana.net` to find stable CSS selectors for each interactive element. The user must log in through the Playwright browser window (Okta SAML).
+9. **Test in Pathfinder.** Tell the user which `content.json` to import into the Block Editor at `learn.grafana.net/?pathfinder-dev=true`. Wait for their feedback on each "Show me" / "Do it" button. Fix broken selectors based on their reports.
+10. **Verify and wrap up.** Re-run the light claim pass if prose changed. Cross-check remaining factual claims against live docs. Update `.github/CODEOWNERS`. Provide a summary of all files created.
 
 For background on how this command relates to `/build-interactive-lj`, refer to `.cursor/learning-path-workflows/workflows.md`.
 
@@ -43,6 +44,7 @@ For background on how this command relates to `/build-interactive-lj`, refer to 
 7. **3-attempt limit per selector.** If a selector fails after 3 tries, mark it `TODO:manual-review` and move on.
 8. **Update CODEOWNERS.** Add the new `[slug]-lj/` directory to `.github/CODEOWNERS`.
 9. **Verify docs accuracy.** After testing, cross-check all factual claims against live Grafana documentation.
+10. **Do not skip the scaffold self-check.** Section bookends, `button`/CSS misuse, and unsupported product claims must be caught before selector discovery. See [reference/scaffold-self-check.md](reference/scaffold-self-check.md).
 
 ---
 
@@ -56,6 +58,8 @@ For background on how this command relates to `/build-interactive-lj`, refer to 
 - Never use data-dependent selectors — use `^=` starts-with patterns
 - Never leave placeholder selectors (`"[selector]"`, `"TODO"`)
 - All links in content.json must be absolute URLs (`https://grafana.com/docs/...`), not relative
+- Never put section intro/summary markdown **inside** the `section` when it will number as a fake step (`You'll…`, `To … complete the following steps`)
+- Never use `action: "button"` with a CSS selector `reftarget` (use `highlight` or `navigate`)
 
 ---
 
@@ -68,6 +72,7 @@ Consult these during the workflow:
 | `docs/website-yaml-reference.md` | Creating website.yaml (field reference, CTA types, examples) |
 | `../build-interactive-lj/reference/json-schema.md` | Writing content.json (block types, action types, field reference) |
 | `../build-interactive-lj/reference/selector-patterns.md` | Discovering selectors (priority, stability, anti-patterns) |
+| `reference/scaffold-self-check.md` | After scaffold, before Playwright (bookends, claims, action sanity) |
 | `docs/manifest-reference.md` | Generating manifest.json files |
 | `.cursor/proven-patterns.mdc` | Reusable patterns for common Grafana UI elements (auto-loaded) |
 

--- a/.cursor/commands/create-learning-path/reference/scaffold-self-check.md
+++ b/.cursor/commands/create-learning-path/reference/scaffold-self-check.md
@@ -67,3 +67,11 @@ After the self-check, tell the author in plain language:
 - That Playwright is next
 
 Keep it short. No severity labels or rule-number dumps unless they ask.
+
+---
+
+## 5. Deploy preview is a wrap-up decision (not this self-check)
+
+Do **not** block Playwright on a website preview. When you open (or are about to open) the PR, ask the author if they want the Learning Hub deploy preview (`deploy-preview` label). Default recommendation for new `*-lj` paths: yes.
+
+Remember: the preview workflow builds only on `opened` / `synchronize` while the label is present. If you add the label after the PR exists, push a commit so CI actually runs.

--- a/.cursor/commands/create-learning-path/reference/scaffold-self-check.md
+++ b/.cursor/commands/create-learning-path/reference/scaffold-self-check.md
@@ -1,0 +1,69 @@
+# Scaffold self-check (create / convert learning paths)
+
+Run this **after** all `content.json`, `manifest.json`, and `website.yaml` files exist, and **before** Playwright selector discovery. Goal: catch Pathfinder structure and unsupported product claims while scaffolding is still cheap to fix. Do not wait for preflight or PR review for these items.
+
+Use for `/create-learning-path` and `/build-interactive-lj`.
+
+---
+
+## When to run
+
+1. Scaffold + manifests + `website.yaml` are on disk.
+2. Before asking the author to log in for Playwright.
+3. Again during wrap-up if you edited prose after selectors.
+
+If the self-check finds issues, fix them (or ask the author) before moving on. Do not treat this as optional polish.
+
+---
+
+## 1. Section bookends (critical rule 14)
+
+For every `section` in every milestone `content.json`:
+
+| Check | Fail if |
+| --- | --- |
+| Intro bookend | There is no one-sentence markdown block **immediately before** the `section` that states what the learner will do. Exception: a pre-section line already covers the goal (for example "To …, complete the following steps:"). |
+| Summary bookend | There is no one-sentence markdown block **immediately after** the `section` that states what the learner learned or what comes next. |
+| Intro inside section | The **first child** of the `section` is markdown that starts with `You'll `, `You will `, `In this section`, or `To … complete the following` (Pathfinder often numbers that as a fake step). |
+
+**Fix:** Move goal/intro markdown **outside** (before) the `section`. Keep interactive/multistep/guided blocks inside. Prefer a short outside summary after the section. If a section would contain only markdown (no interactive UI steps), drop the `section` wrapper and keep top-level markdown.
+
+---
+
+## 2. Action / selector sanity (scaffold-time)
+
+Scan interactive blocks before live DOM work:
+
+| Check | Fail if |
+| --- | --- |
+| `button` vs CSS | `action` is `button` but `reftarget` looks like a CSS selector (`a[…]`, `[data-testid=…]`, contains `=` or starts with `/` for a path used as click text). Use `highlight` (or `navigate`) for CSS. Use `button` only for visible button **label** text. |
+| Secrets | Any `formfill` / Do-it path fills passwords, tokens, or API keys with `doIt` not `false`. |
+| `exists-reftarget` | A block or step has `reftarget` but `requirements` omits `exists-reftarget` (repo convention). |
+| Multistep singleton | A `multistep` has exactly one step. Convert to a plain `interactive` block. |
+
+---
+
+## 3. Light claim pass (scaffold-time)
+
+Do a **short** product-fact check now. Full adversarial claim-check can still run later (preflight / review). At scaffold time, flag and fix:
+
+| Pattern | Why |
+| --- | --- |
+| Absolutes without a source (`only`, `never`, `always`, `must`, `live only in…`) | Easy to overstate. Soften or cite docs. |
+| Exit codes, defaults, limits, token types, action names | Must match the docs you already read (local `website` + live grafana.com). |
+| Archived or renamed tooling | Example: do not teach `grafana/k6-action` if docs/blog point to `setup-k6-action` / `run-k6-action`. |
+| Invented UI labels or menu paths | Must match the product UI or docs. |
+
+**Procedure:** For each milestone, list falsifiable product sentences. For each, point to a docs quote or URL from the feature-docs pass. No source → rewrite or remove before selectors. Do not invent behavior from training data.
+
+---
+
+## 4. Report to the author
+
+After the self-check, tell the author in plain language:
+
+- What you fixed automatically
+- Anything that still needs their call
+- That Playwright is next
+
+Keep it short. No severity labels or rule-number dumps unless they ask.

--- a/.cursor/commands/create-learning-path/reference/scaffold-self-check.md
+++ b/.cursor/commands/create-learning-path/reference/scaffold-self-check.md
@@ -58,7 +58,21 @@ Do a **short** product-fact check now. Full adversarial claim-check can still ru
 
 ---
 
-## 4. Report to the author
+## 4. Code samples and “copy” instructions (scaffold-time)
+
+When a milestone already shows a command or config in a fenced code block (or a bullet list of commands), do **not** also tell the learner to copy it.
+
+| Check | Fail if |
+| --- | --- |
+| Redundant copy cue | Prose says `Copy the following`, `Copy this command`, or similar immediately before/after a fenced sample the UI can already copy. |
+| Copyable chip in the action line | An interactive step’s `content` embeds a backtick command or env var (`k6 …`, `` `K6_CLOUD_…` ``) that Pathfinder may render as a separate copy control, when that value is already listed in nearby sample config. |
+| Extra copy-only step | A dedicated interactive or noop whose only job is “copy this command” while the same command sits in markdown. |
+
+**Fix:** Keep the fenced sample. In the step, use plain action language (open, note, create, run). Put env var names in surrounding markdown if needed, not as copy chips inside the action line.
+
+---
+
+## 5. Report to the author
 
 After the self-check, tell the author in plain language:
 
@@ -70,7 +84,7 @@ Keep it short. No severity labels or rule-number dumps unless they ask.
 
 ---
 
-## 5. Deploy preview is a wrap-up decision (not this self-check)
+## 6. Deploy preview is a wrap-up decision (not this self-check)
 
 Do **not** block Playwright on a website preview. When you open (or are about to open) the PR, ask the author if they want the Learning Hub deploy preview (`deploy-preview` label). Default recommendation for new `*-lj` paths: yes.
 

--- a/.cursor/learning-path-workflows/workflows.md
+++ b/.cursor/learning-path-workflows/workflows.md
@@ -72,7 +72,9 @@ Use the Block Builder **PR review tool** (dev tools, pathfinder-app 1.4.5+) to l
 
 The AI re-checks factual claims if prose changed, updates `.github/CODEOWNERS`, and provides a summary of all files created.
 
-**Your role:** Review the generated files, then open a PR in the `interactive-tutorials` repo.
+Before opening the PR, the AI asks whether you want a **Learning Hub website deploy preview**. That preview is the rendered non-interactive path from `website.yaml` (not Pathfinder). CI only builds it when the PR has the `deploy-preview` label **and** a commit push (`opened` / `synchronize`). Adding the label alone does not deploy.
+
+**Your role:** Review the generated files, decide yes/no on the deploy preview (yes is recommended for new paths), then open a PR in the `interactive-tutorials` repo.
 
 ## Tips
 

--- a/.cursor/learning-path-workflows/workflows.md
+++ b/.cursor/learning-path-workflows/workflows.md
@@ -45,11 +45,13 @@ The AI validates that both repos are accessible (the website repo is a read-only
 
 **Your role:** Review and approve the proposed milestones before the AI writes anything.
 
-### Phase 2: Content, manifest, and website metadata generation
+### Phase 2: Content, manifest, website metadata, and scaffold self-check
 
 The AI creates `content.json` files for every milestone (interactive blocks for UI steps, markdown blocks for conceptual content), generates `manifest.json` files with the correct dependency chains, and creates `website.yaml` files with metadata required to publish to the website.
 
-**Your role:** This phase is mostly automated. The agent might ask you to supply some of the `website.yaml` values if it can't derive them on its own.
+Before selector work, the AI runs a **scaffold self-check** (section bookends, `button` vs CSS selector misuse, secrets `doIt`, and a light claim pass against the docs already read). See [create-learning-path/reference/scaffold-self-check.md](../commands/create-learning-path/reference/scaffold-self-check.md). Issues found here should be fixed before Playwright.
+
+**Your role:** This phase is mostly automated. The agent might ask you to supply some of the `website.yaml` values if it can't derive them on its own. Confirm any product-claim questions if the agent cannot find a docs source.
 
 ### Phase 3: Selector discovery
 
@@ -68,13 +70,13 @@ Use the Block Builder **PR review tool** (dev tools, pathfinder-app 1.4.5+) to l
 
 ### Phase 5: Wrap-up
 
-The AI verifies factual claims against the docs, updates `.github/CODEOWNERS`, and provides a summary of all files created.
+The AI re-checks factual claims if prose changed, updates `.github/CODEOWNERS`, and provides a summary of all files created.
 
 **Your role:** Review the generated files, then open a PR in the `interactive-tutorials` repo.
 
 ## Tips
 
-- **Plan for session length.** Paths with 7+ milestones often take two sessions. A natural break point is after Phase 2 (all content and manifests on disk). Resume at Phase 3 (selector discovery) in a new session.
+- **Plan for session length.** Paths with 7+ milestones often take two sessions. A natural break point is after Phase 2 (all content, manifests, and scaffold self-check on disk). Resume at Phase 3 (selector discovery) in a new session.
 - **Selector fixes have a 3-attempt limit.** If a selector can't be resolved after 3 tries, the AI marks it `TODO:manual-review` and moves on. You can fix these by hand later.
 
 ---


### PR DESCRIPTION
## Summary
- Adds a required scaffold self-check (shared by `/create-learning-path` and `/build-interactive-lj`) that runs after content/manifests are written and before Playwright.
- Covers section bookends / fake in-section steps, `button` vs CSS `reftarget` misuse, secrets `doIt`, and a light claim pass against docs already read.
- Updates the learning path workflow doc so Phase 2 includes this gate.

Motivated by dogfooding automate-k6-cicd-lj, where bookend and claim issues only showed up in preflight.

## Test plan
- [ ] Skim `scaffold-self-check.md` for clarity
- [ ] Confirm create + convert command READMEs both point at the self-check before selector discovery
- [ ] Optional: run `/create-learning-path` on a tiny path and confirm the agent pauses for self-check before asking for Okta


Made with [Cursor](https://cursor.com)