### PR TITLE
Add 'Connect to an Elasticsearch data source' learning path

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -37,6 +37,7 @@
 /drilldown-logs-lj/                                       @jstickler
 /drilldown-metrics-lj/                                    @knylander-grafana
 /drilldown-traces-lj/                                     @knylander-grafana
+/elasticsearch-data-source-lj/                            @chri2547
 /elasticsearch-logs-lj/                                   @bonnywelsford-source
 /enable-block-editor/                                     @Jayclifford345
 /enable-coda/                                             @Jayclifford345

--- a/elasticsearch-data-source-lj/add-data-source/content.json
+++ b/elasticsearch-data-source-lj/add-data-source/content.json
@@ -1,0 +1,57 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "elasticsearch-data-source-add",
+  "title": "Add Elasticsearch as a data source",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "Grafana includes built-in support for Elasticsearch. In this milestone, you add the Elasticsearch data source to your Grafana Cloud instance.\n\nLet's walk through the steps together."
+    },
+    {
+      "type": "section",
+      "blocks": [
+        {
+          "type": "multistep",
+          "content": "In the navigation menu, navigate to **Connections > Data sources**.",
+          "steps": [
+            {
+              "action": "highlight",
+              "reftarget": "a[data-testid='data-testid Nav menu item'][href='/connections']",
+              "requirements": ["navmenu-open", "exists-reftarget"]
+            },
+            {
+              "action": "highlight",
+              "reftarget": "a[href='/connections/datasources']",
+              "requirements": ["navmenu-open", "exists-reftarget"]
+            }
+          ]
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='data-testid data-source-add-button']",
+          "requirements": ["exists-reftarget"],
+          "content": "Click **Add new data source**."
+        },
+        {
+          "type": "interactive",
+          "action": "formfill",
+          "reftarget": "input[placeholder='Filter by name or type']",
+          "targetvalue": "Elasticsearch",
+          "requirements": ["exists-reftarget"],
+          "content": "In the **Search** field, enter `Elasticsearch`."
+        },
+        {
+          "type": "interactive",
+          "action": "button",
+          "reftarget": "Elasticsearch",
+          "content": "From the search results, click **Elasticsearch**."
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "In the next milestone, you'll configure the connection details including the URL, authentication, index name, and time field."
+    }
+  ]
+}

--- a/elasticsearch-data-source-lj/add-data-source/manifest.json
+++ b/elasticsearch-data-source-lj/add-data-source/manifest.json
@@ -1,0 +1,21 @@
+{
+  "id": "elasticsearch-data-source-add",
+  "type": "guide",
+  "description": "Add the Elasticsearch data source in Grafana Cloud.",
+  "category": "data-availability",
+  "author": {
+    "name": "Chris Moyer",
+    "team": "Grafana Documentation"
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": [
+    "elasticsearch-data-source-verify-elasticsearch"
+  ],
+  "recommends": [
+    "elasticsearch-data-source-configure-connection"
+  ],
+  "suggests": [],
+  "provides": []
+}

--- a/elasticsearch-data-source-lj/add-data-source/website.yaml
+++ b/elasticsearch-data-source-lj/add-data-source/website.yaml
@@ -1,0 +1,20 @@
+menuTitle: Add data source
+weight: 300
+step: 4
+layout: single-journey
+cta:
+  type: continue
+keywords:
+- Elasticsearch
+- data source
+- add
+- connections
+side_journeys:
+  title: More to explore (optional)
+  heading: 'At this point in your journey, you can explore the following paths:'
+  items:
+  - title: Data source management in Grafana
+    link: /docs/grafana/latest/administration/data-source-management/
+  - title: Data source plugins for Grafana
+    link: https://grafana.com/grafana/plugins/data-source-plugins/
+description: Learn how to navigate Grafana Cloud and add the Elasticsearch data source.

--- a/elasticsearch-data-source-lj/business-value/content.json
+++ b/elasticsearch-data-source-lj/business-value/content.json
@@ -9,7 +9,7 @@
     },
     {
       "type": "markdown",
-      "content": "### Key capabilities\n\nThe Grafana Elasticsearch data source supports:\n\n- **Log queries** — Search, filter, and explore log data with Lucene query syntax.\n- **Metrics queries** — Aggregate and visualize numeric data using bucket and metric aggregations.\n- **Annotations** — Overlay Elasticsearch events on your dashboard graphs.\n- **Alerting** — Create alerts based on Elasticsearch query results.\n- **ES|QL queries (experimental)** — Query data using Elasticsearch's pipe-based query language.\n\nRefer to the [Elasticsearch data source documentation](https://grafana.com/docs/grafana/latest/datasources/elasticsearch/) for the full list of capabilities."
+      "content": "### Key capabilities\n\nThe Grafana Elasticsearch data source supports:\n\n- **Log queries** — Search, filter, and explore log data with Lucene query syntax.\n- **Metrics queries** — Aggregate and visualize numeric data using bucket and metric aggregations.\n- **Annotations** — Overlay Elasticsearch events on your dashboard graphs.\n- **Alerting** — Create alerts based on Elasticsearch query results.\n- **ES|QL queries** — Query data using Elasticsearch's pipe-based query language.\n\nRefer to the [Elasticsearch data source documentation](https://grafana.com/docs/grafana/latest/datasources/elasticsearch/) for the full list of capabilities."
     },
     {
       "type": "markdown",

--- a/elasticsearch-data-source-lj/business-value/content.json
+++ b/elasticsearch-data-source-lj/business-value/content.json
@@ -1,0 +1,23 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "elasticsearch-data-source-business-value",
+  "title": "When to query Elasticsearch directly",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "Elasticsearch is a search and analytics engine used for log aggregation, application search, and infrastructure monitoring. Many teams already run Elasticsearch to store logs, metrics, and events.\n\nThe Elasticsearch data source in Grafana lets you query your existing Elasticsearch instance directly — your data stays where it is while Grafana provides the visualization, exploration, and alerting layer on top."
+    },
+    {
+      "type": "markdown",
+      "content": "### Key capabilities\n\nThe Grafana Elasticsearch data source supports:\n\n- **Log queries** — Search, filter, and explore log data with Lucene query syntax.\n- **Metrics queries** — Aggregate and visualize numeric data using bucket and metric aggregations.\n- **Annotations** — Overlay Elasticsearch events on your dashboard graphs.\n- **Alerting** — Create alerts based on Elasticsearch query results.\n- **ES|QL queries (experimental)** — Query data using Elasticsearch's pipe-based query language.\n\nRefer to the [Elasticsearch data source documentation](https://grafana.com/docs/grafana/latest/datasources/elasticsearch/) for the full list of capabilities."
+    },
+    {
+      "type": "markdown",
+      "content": "### When to query Elasticsearch directly\n\nQuerying Elasticsearch directly is the right choice when:\n\n- **You already have data in Elasticsearch** and don't want to duplicate it into another store\n- **You need Elasticsearch's native search capabilities** like full-text Lucene search across log fields\n- **Your Elasticsearch instance is accessible** from Grafana Cloud (directly or via Private data source connect)\n- **You want a unified view** that combines Elasticsearch data with other data sources in a single dashboard\n\n### When to consider alternatives\n\nIf you use Amazon OpenSearch Service (the successor to Amazon Elasticsearch Service), use the [OpenSearch data source](https://grafana.com/docs/plugins/grafana-opensearch-datasource/latest/) instead. If you're starting fresh and want log aggregation native to Grafana Cloud, consider sending logs to [Grafana Loki](https://grafana.com/docs/grafana/latest/datasources/loki/)."
+    },
+    {
+      "type": "markdown",
+      "content": "In the next milestone, you'll verify that your Elasticsearch instance is running and gather the details needed to connect."
+    }
+  ]
+}

--- a/elasticsearch-data-source-lj/business-value/manifest.json
+++ b/elasticsearch-data-source-lj/business-value/manifest.json
@@ -1,0 +1,19 @@
+{
+  "id": "elasticsearch-data-source-business-value",
+  "type": "guide",
+  "description": "Learn when querying Elasticsearch directly from Grafana is the right choice for your logs and metrics.",
+  "category": "data-availability",
+  "author": {
+    "name": "Chris Moyer",
+    "team": "Grafana Documentation"
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": [],
+  "recommends": [
+    "elasticsearch-data-source-verify-elasticsearch"
+  ],
+  "suggests": [],
+  "provides": []
+}

--- a/elasticsearch-data-source-lj/business-value/website.yaml
+++ b/elasticsearch-data-source-lj/business-value/website.yaml
@@ -1,0 +1,21 @@
+menuTitle: Value of Elasticsearch
+weight: 100
+step: 2
+layout: single-journey
+cta:
+  type: continue
+keywords:
+- Elasticsearch
+- data source
+- Grafana Cloud
+- logs
+- metrics
+side_journeys:
+  title: More to explore (optional)
+  heading: 'At this point in your journey, you can explore the following paths:'
+  items:
+  - title: Elasticsearch data source documentation
+    link: /docs/grafana/latest/datasources/elasticsearch/
+  - title: Data source management in Grafana
+    link: /docs/grafana/latest/administration/data-source-management/
+description: Learn when querying Elasticsearch directly from Grafana is the right choice for your logs and metrics.

--- a/elasticsearch-data-source-lj/configure-connection/content.json
+++ b/elasticsearch-data-source-lj/configure-connection/content.json
@@ -1,0 +1,50 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "elasticsearch-data-source-configure-connection",
+  "title": "Configure the Elasticsearch connection",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "In this milestone, you configure the connection details so that Grafana Cloud can query your Elasticsearch instance. This includes the server URL, the authentication method, the index name, and the time field.\n\nRefer to [Configure the Elasticsearch data source](https://grafana.com/docs/grafana/latest/datasources/elasticsearch/configure/) for the full list of settings."
+    },
+    {
+      "type": "section",
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "input[data-testid='Datasource HTTP settings url']",
+          "doIt": false,
+          "requirements": ["exists-reftarget"],
+          "content": "Under **Connection > URL**, enter the URL of your Elasticsearch server, including the port.\n\nFor example: `http://elasticsearch.example.com:9200`"
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "input[data-testid='es-config-index-name']",
+          "doIt": false,
+          "skippable": true,
+          "requirements": ["exists-reftarget"],
+          "content": "Under **Elasticsearch details > Index name**, enter the name of the index you want to query.\n\nYou can use a wildcard pattern such as `logs-*`, a time pattern such as `[filebeat-]YYYY.MM.DD`, or a specific index name such as `application-logs`."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "input[data-testid='es-config-time-field']",
+          "doIt": false,
+          "skippable": true,
+          "requirements": ["exists-reftarget"],
+          "content": "Under **Elasticsearch details > Time field name**, enter the name of your time field.\n\nThe default is `@timestamp`. Enter a different name only if your index uses a custom time field."
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "### Configure authentication\n\nUnder **Authentication**, select the method that matches your Elasticsearch security configuration:\n\n- **Basic authentication** — Enter the username and password for your Elasticsearch user.\n- **No authentication** — Use only if your Elasticsearch instance doesn't require credentials. To authenticate with an API key, select **No authentication**, then add an HTTP header named `Authorization` with the value `ApiKey <your-api-key>`.\n- **Serverless API key** — Enter your API key to connect to an Elastic Cloud Serverless instance.\n\nEnter credentials directly in the Grafana UI — for your security, this path doesn't automate filling passwords or API keys."
+    },
+    {
+      "type": "markdown",
+      "content": "In the next milestone, you'll save and test the connection to verify everything is configured correctly."
+    }
+  ]
+}

--- a/elasticsearch-data-source-lj/configure-connection/content.json
+++ b/elasticsearch-data-source-lj/configure-connection/content.json
@@ -12,16 +12,18 @@
       "blocks": [
         {
           "type": "interactive",
-          "action": "highlight",
-          "reftarget": "input[data-testid='Datasource HTTP settings url']",
+          "action": "formfill",
+          "reftarget": "input#connection-url",
+          "targetvalue": "http://elasticsearch.example.com:9200",
           "doIt": false,
           "requirements": ["exists-reftarget"],
           "content": "Under **Connection > URL**, enter the URL of your Elasticsearch server, including the port.\n\nFor example: `http://elasticsearch.example.com:9200`"
         },
         {
           "type": "interactive",
-          "action": "highlight",
-          "reftarget": "input[data-testid='es-config-index-name']",
+          "action": "formfill",
+          "reftarget": "input#es_config_indexName",
+          "targetvalue": "logs-*",
           "doIt": false,
           "skippable": true,
           "requirements": ["exists-reftarget"],
@@ -29,8 +31,9 @@
         },
         {
           "type": "interactive",
-          "action": "highlight",
-          "reftarget": "input[data-testid='es-config-time-field']",
+          "action": "formfill",
+          "reftarget": "input#es_config_timeField",
+          "targetvalue": "@timestamp",
           "doIt": false,
           "skippable": true,
           "requirements": ["exists-reftarget"],

--- a/elasticsearch-data-source-lj/configure-connection/content.json
+++ b/elasticsearch-data-source-lj/configure-connection/content.json
@@ -43,7 +43,7 @@
     },
     {
       "type": "markdown",
-      "content": "### Configure authentication\n\nUnder **Authentication**, select the method that matches your Elasticsearch security configuration:\n\n- **Basic authentication** — Enter the username and password for your Elasticsearch user.\n- **No authentication** — Use only if your Elasticsearch instance doesn't require credentials. To authenticate with an API key, select **No authentication**, then add an HTTP header named `Authorization` with the value `ApiKey <your-api-key>`.\n- **Serverless API key** — Enter your API key to connect to an Elastic Cloud Serverless instance.\n\nEnter credentials directly in the Grafana UI — for your security, this path doesn't automate filling passwords or API keys."
+      "content": "### Configure authentication\n\nUnder **Authentication**, select the method that matches your Elasticsearch security configuration:\n\n- **Basic authentication** — Enter the username and password for your Elasticsearch user.\n- **Forward OAuth identity** — Forward the OAuth access token (and the OIDC ID token if available) of the user querying the data source.\n- **No authentication** — Use only if your Elasticsearch instance doesn't require credentials. To authenticate with an API key, select **No authentication**, then add an HTTP header named `Authorization` with the value `ApiKey <your-api-key>`.\n- **Serverless API key** — Enter your API key to connect to an Elastic Cloud Serverless instance.\n\nEnter credentials directly in the Grafana UI — for your security, this path doesn't automate filling passwords or API keys."
     },
     {
       "type": "markdown",

--- a/elasticsearch-data-source-lj/configure-connection/manifest.json
+++ b/elasticsearch-data-source-lj/configure-connection/manifest.json
@@ -1,0 +1,21 @@
+{
+  "id": "elasticsearch-data-source-configure-connection",
+  "type": "guide",
+  "description": "Configure the Elasticsearch connection details including URL, authentication, index name, and time field.",
+  "category": "data-availability",
+  "author": {
+    "name": "Chris Moyer",
+    "team": "Grafana Documentation"
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": [
+    "elasticsearch-data-source-add"
+  ],
+  "recommends": [
+    "elasticsearch-data-source-test-connection"
+  ],
+  "suggests": [],
+  "provides": []
+}

--- a/elasticsearch-data-source-lj/configure-connection/website.yaml
+++ b/elasticsearch-data-source-lj/configure-connection/website.yaml
@@ -1,0 +1,21 @@
+menuTitle: Configure connection
+weight: 400
+step: 5
+layout: single-journey
+cta:
+  type: continue
+keywords:
+- Elasticsearch
+- URL
+- authentication
+- index
+- time field
+side_journeys:
+  title: More to explore (optional)
+  heading: 'At this point in your journey, you can explore the following paths:'
+  items:
+  - title: Configure the Elasticsearch data source
+    link: /docs/grafana/latest/datasources/elasticsearch/configure/
+  - title: Private data source connect
+    link: /docs/grafana-cloud/connect-externally-hosted/private-data-source-connect/
+description: Configure the URL, authentication, index name, and time field for your Elasticsearch data source.

--- a/elasticsearch-data-source-lj/content.json
+++ b/elasticsearch-data-source-lj/content.json
@@ -1,0 +1,27 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "elasticsearch-data-source-lj",
+  "title": "Connect to an Elasticsearch data source in Grafana Cloud",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "Welcome to the Grafana learning path that shows you how to connect Grafana Cloud to an existing Elasticsearch instance and query your logs and metrics.\n\nElasticsearch is a search and analytics engine widely used for log aggregation, application search, and infrastructure monitoring. The built-in Elasticsearch data source lets you query and visualize logs or metrics stored in Elasticsearch, and annotate graphs with log events — no data migration required.\n\nThis path walks through adding and configuring the Elasticsearch data source, authenticating with your Elasticsearch instance, testing the connection, and verifying that data flows correctly into Grafana Explore."
+    },
+    {
+      "type": "markdown",
+      "content": "### Here's what to expect\n\nWhen you complete this path, you'll be able to:\n\n- Understand when querying Elasticsearch directly is the right choice\n- Verify that your Elasticsearch instance is running and gather the connection details Grafana needs\n- Add the Elasticsearch data source in Grafana Cloud\n- Configure the URL, authentication, index name, and time field\n- Test the connection to verify Grafana can reach your Elasticsearch instance\n- Query and explore Elasticsearch data in Grafana Explore"
+    },
+    {
+      "type": "markdown",
+      "content": "### Before you begin\n\nBefore you connect to an Elasticsearch data source, ensure you have:\n\n- A Grafana Cloud account. To create an account, refer to [Grafana Cloud](https://grafana.com/signup/cloud/connect-account).\n- Grafana organization administrator permissions. Only users with the `administrator` role can add data sources.\n- An Elasticsearch instance that is running and accessible (v7.17 or later, v8.x, v9.x, or Elastic Cloud Serverless).\n- Your Elasticsearch server URL, including the port (default: `9200`).\n- Authentication credentials with read access — a username and password, an API key, or none if Elasticsearch security is disabled.\n- Network access from Grafana Cloud to your Elasticsearch instance (directly or via [Private data source connect](https://grafana.com/docs/grafana-cloud/connect-externally-hosted/private-data-source-connect/))."
+    },
+    {
+      "type": "markdown",
+      "content": "### Troubleshooting\n\nIf you get stuck, we've got your back! Where appropriate, troubleshooting information is just a click away."
+    },
+    {
+      "type": "markdown",
+      "content": "### More to explore\n\nWe understand you might want to explore other capabilities not strictly on this path. We'll provide you opportunities where it makes sense."
+    }
+  ]
+}

--- a/elasticsearch-data-source-lj/end-journey/content.json
+++ b/elasticsearch-data-source-lj/end-journey/content.json
@@ -1,0 +1,11 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "elasticsearch-data-source-end-journey",
+  "title": "Destination reached!",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "Congratulations on completing this journey! Job well done!\n\nWe hope you've enjoyed traveling with us as you:\n\n- Learned when querying Elasticsearch directly is the right choice\n- Verified your Elasticsearch instance is running and gathered connection details\n- Added the Elasticsearch data source in Grafana Cloud\n- Configured the URL, authentication, index name, and time field\n- Successfully tested the connection to your Elasticsearch instance\n- Queried and explored Elasticsearch data in Grafana Explore"
+    }
+  ]
+}

--- a/elasticsearch-data-source-lj/end-journey/manifest.json
+++ b/elasticsearch-data-source-lj/end-journey/manifest.json
@@ -1,0 +1,19 @@
+{
+  "id": "elasticsearch-data-source-end-journey",
+  "type": "guide",
+  "description": "Summary of what you accomplished connecting Grafana to Elasticsearch and suggested next steps.",
+  "category": "data-availability",
+  "author": {
+    "name": "Chris Moyer",
+    "team": "Grafana Documentation"
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": [
+    "elasticsearch-data-source-explore-data"
+  ],
+  "recommends": [],
+  "suggests": [],
+  "provides": []
+}

--- a/elasticsearch-data-source-lj/end-journey/website.yaml
+++ b/elasticsearch-data-source-lj/end-journey/website.yaml
@@ -1,0 +1,22 @@
+menuTitle: Destination reached!
+weight: 700
+step: 8
+layout: single-journey
+cta:
+  type: conclusion
+keywords:
+- Elasticsearch
+- data source
+- completion
+- next steps
+side_journeys:
+  title: More to explore (optional)
+  heading: 'The world is your oyster! Read more about how you can:'
+  items:
+  - title: Explore Elasticsearch logs using Grafana
+    link: /docs/learning-paths/elasticsearch-logs/
+  - title: Elasticsearch query editor
+    link: /docs/grafana/latest/datasources/elasticsearch/query-editor/
+  - title: Elasticsearch data source documentation
+    link: /docs/grafana/latest/datasources/elasticsearch/
+description: Congratulations on completing the Elasticsearch data source learning path!

--- a/elasticsearch-data-source-lj/explore-data/content.json
+++ b/elasticsearch-data-source-lj/explore-data/content.json
@@ -1,0 +1,56 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "elasticsearch-data-source-explore-data",
+  "title": "Explore Elasticsearch data in Grafana",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "In this milestone, you verify that your Elasticsearch data source is working by running a query in Grafana's Explore."
+    },
+    {
+      "type": "section",
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "a[data-testid='data-testid Nav menu item'][href='/explore']",
+          "requirements": ["navmenu-open", "exists-reftarget"],
+          "content": "In the navigation menu, click **Explore**."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='data-testid Select a data source']",
+          "doIt": false,
+          "requirements": ["on-page:/explore", "exists-reftarget"],
+          "content": "From the data source dropdown at the top-left, select your Elasticsearch data source."
+        },
+        {
+          "type": "interactive",
+          "action": "formfill",
+          "reftarget": "[data-testid='query-editor-rows'] textarea",
+          "targetvalue": "*",
+          "doIt": false,
+          "skippable": true,
+          "requirements": ["on-page:/explore", "exists-reftarget"],
+          "content": "In the **Lucene Query** field, enter a query. Use `*` to match all documents, or a term such as `error` to search log content.\n\nElasticsearch uses Lucene query syntax. Boolean operators must be uppercase: `AND`, `OR`, `NOT`."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "button[data-testid='data-testid RefreshPicker run button']",
+          "requirements": ["on-page:/explore", "exists-reftarget"],
+          "content": "Click **Run query** (or press `Shift + Enter`) to execute the query.\n\nYou should see results in the panel below the query editor. If you see data, your Elasticsearch data source is working correctly."
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "### Verify successful data access\n\nAfter running your query, you should see:\n\n- Log lines or time series data displayed in the results panel\n- No connection errors or timeouts\n- Data that matches what you expect from your Elasticsearch index\n- The ability to modify the query and run different searches"
+    },
+    {
+      "type": "markdown",
+      "content": "**Congratulations!** You've successfully connected your Elasticsearch instance to Grafana Cloud and verified that data is accessible."
+    }
+  ]
+}

--- a/elasticsearch-data-source-lj/explore-data/manifest.json
+++ b/elasticsearch-data-source-lj/explore-data/manifest.json
@@ -1,0 +1,21 @@
+{
+  "id": "elasticsearch-data-source-explore-data",
+  "type": "guide",
+  "description": "Run a Lucene query in Grafana Explore to verify your Elasticsearch data source is working.",
+  "category": "data-availability",
+  "author": {
+    "name": "Chris Moyer",
+    "team": "Grafana Documentation"
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": [
+    "elasticsearch-data-source-test-connection"
+  ],
+  "recommends": [
+    "elasticsearch-data-source-end-journey"
+  ],
+  "suggests": [],
+  "provides": []
+}

--- a/elasticsearch-data-source-lj/explore-data/website.yaml
+++ b/elasticsearch-data-source-lj/explore-data/website.yaml
@@ -1,0 +1,23 @@
+menuTitle: Explore data
+weight: 600
+step: 7
+layout: single-journey
+cta:
+  type: continue
+keywords:
+- Elasticsearch
+- Lucene
+- query
+- Explore
+- Grafana
+side_journeys:
+  title: More to explore (optional)
+  heading: 'At this point in your journey, you can explore the following paths:'
+  items:
+  - title: Elasticsearch query editor
+    link: /docs/grafana/latest/datasources/elasticsearch/query-editor/
+  - title: Lucene query syntax
+    link: https://www.elastic.co/guide/en/kibana/current/lucene-query.html
+  - title: Grafana Explore
+    link: /docs/grafana/latest/explore/
+description: Run a sample Lucene query in Grafana Explore to verify your Elasticsearch data is accessible.

--- a/elasticsearch-data-source-lj/manifest.json
+++ b/elasticsearch-data-source-lj/manifest.json
@@ -1,0 +1,55 @@
+{
+  "id": "elasticsearch-data-source-lj",
+  "type": "path",
+  "description": "Step-by-step guide: Connect to an Elasticsearch data source in Grafana.",
+  "category": "data-availability",
+  "author": {
+    "name": "Chris Moyer",
+    "team": "Grafana Documentation"
+  },
+  "startingLocation": "/connections/datasources/elasticsearch",
+  "targeting": {
+    "match": {
+      "and": [
+        {
+          "targetPlatform": "cloud"
+        },
+        {
+          "or": [
+            {
+              "and": [
+                {
+                  "urlPrefix": "/connections/datasources"
+                },
+                {
+                  "tag": "selected-datasource:elasticsearch"
+                }
+              ]
+            },
+            {
+              "urlPrefix": "/connections/datasources/elasticsearch"
+            },
+            {
+              "urlPrefix": "/connections/add-new-connection"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "milestones": [
+    "elasticsearch-data-source-verify-elasticsearch",
+    "elasticsearch-data-source-add",
+    "elasticsearch-data-source-configure-connection",
+    "elasticsearch-data-source-test-connection",
+    "elasticsearch-data-source-explore-data",
+    "elasticsearch-data-source-end-journey"
+  ],
+  "depends": [],
+  "recommends": [],
+  "suggests": [],
+  "provides": []
+}

--- a/elasticsearch-data-source-lj/test-connection/content.json
+++ b/elasticsearch-data-source-lj/test-connection/content.json
@@ -1,0 +1,30 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "elasticsearch-data-source-test-connection",
+  "title": "Test the connection",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "Now that you've configured the connection details, save the data source and verify that Grafana can successfully connect to your Elasticsearch instance."
+    },
+    {
+      "type": "section",
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "button",
+          "reftarget": "Save & test",
+          "content": "Click **Save & test**.\n\nA successful connection displays the message: `Elasticsearch data source is healthy.`"
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "### Common connection issues\n\n| Symptom | Likely cause | Solution |\n|---------|-------------|----------|\n| Connection refused | Elasticsearch not running or wrong URL | Verify the URL and port (default `9200`) and that Elasticsearch is accepting connections |\n| Unauthorized (401) | Invalid credentials or API key | Verify the username and password, or regenerate the API key with read access |\n| Forbidden (403) | Missing cluster privileges | Grant the `monitor`, `view_index_metadata`, and `read` privileges to the user or API key |\n| No index found | Incorrect index name or pattern | Verify the index name and, if you use a time pattern, that matching indices exist |\n| Timeout | Grafana Cloud can't reach a private instance | Set up [Private data source connect](https://grafana.com/docs/grafana-cloud/connect-externally-hosted/private-data-source-connect/) |"
+    },
+    {
+      "type": "markdown",
+      "content": "In the next milestone, you'll run a query and explore your Elasticsearch data in Grafana."
+    }
+  ]
+}

--- a/elasticsearch-data-source-lj/test-connection/manifest.json
+++ b/elasticsearch-data-source-lj/test-connection/manifest.json
@@ -1,0 +1,21 @@
+{
+  "id": "elasticsearch-data-source-test-connection",
+  "type": "guide",
+  "description": "Save the data source configuration and verify Grafana can connect to your Elasticsearch instance.",
+  "category": "data-availability",
+  "author": {
+    "name": "Chris Moyer",
+    "team": "Grafana Documentation"
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": [
+    "elasticsearch-data-source-configure-connection"
+  ],
+  "recommends": [
+    "elasticsearch-data-source-explore-data"
+  ],
+  "suggests": [],
+  "provides": []
+}

--- a/elasticsearch-data-source-lj/test-connection/website.yaml
+++ b/elasticsearch-data-source-lj/test-connection/website.yaml
@@ -1,0 +1,20 @@
+menuTitle: Test connection
+weight: 500
+step: 6
+layout: single-journey
+cta:
+  type: success
+keywords:
+- Elasticsearch
+- test connection
+- save
+- troubleshoot
+side_journeys:
+  title: More to explore (optional)
+  heading: 'At this point in your journey, you can explore the following paths:'
+  items:
+  - title: Configure the Elasticsearch data source
+    link: /docs/grafana/latest/datasources/elasticsearch/configure/
+  - title: Troubleshoot the Elasticsearch data source
+    link: /docs/grafana/latest/datasources/elasticsearch/troubleshooting/
+description: Save and test your Elasticsearch data source connection to verify Grafana can reach your instance.

--- a/elasticsearch-data-source-lj/verify-elasticsearch/content.json
+++ b/elasticsearch-data-source-lj/verify-elasticsearch/content.json
@@ -9,7 +9,7 @@
     },
     {
       "type": "markdown",
-      "content": "### Gather connection details\n\nCollect the following values before proceeding:\n\n| Detail | Required | Example |\n|--------|----------|---------|\n| **URL** | Yes | `http://elasticsearch.example.com:9200` |\n| **Index name** | Yes | `logs-*` or `[filebeat-]YYYY.MM.DD` |\n| **Time field name** | Yes | `@timestamp` |\n| **Authentication** | Depends on your setup | Username and password, or API key |\n\nThe Elasticsearch data source supports v7.17 or later, v8.x, v9.x, and Elastic Cloud Serverless."
+      "content": "### Gather connection details\n\nCollect the following values before proceeding:\n\n| Detail | Required | Example |\n|--------|----------|---------|\n| **URL** | Yes | `http://elasticsearch.example.com:9200` |\n| **Index name** | Recommended | `logs-*` or `[filebeat-]YYYY.MM.DD` |\n| **Time field name** | No (defaults to `@timestamp`) | `@timestamp` |\n| **Authentication** | Depends on your setup | Username and password, or API key |\n\nThe URL is the only required connection value. **Index name** and **Time field name** are optional Elasticsearch details — Grafana defaults the time field to `@timestamp` — but setting them makes querying easier. The Elasticsearch data source supports v7.17 or later, v8.x, v9.x, and Elastic Cloud Serverless."
     },
     {
       "type": "markdown",

--- a/elasticsearch-data-source-lj/verify-elasticsearch/content.json
+++ b/elasticsearch-data-source-lj/verify-elasticsearch/content.json
@@ -1,0 +1,27 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "elasticsearch-data-source-verify-elasticsearch",
+  "title": "Verify Elasticsearch is accessible",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "Before you connect Grafana to Elasticsearch, confirm that your Elasticsearch instance is running and that you have the information Grafana needs to establish a connection."
+    },
+    {
+      "type": "markdown",
+      "content": "### Gather connection details\n\nCollect the following values before proceeding:\n\n| Detail | Required | Example |\n|--------|----------|---------|\n| **URL** | Yes | `http://elasticsearch.example.com:9200` |\n| **Index name** | Yes | `logs-*` or `[filebeat-]YYYY.MM.DD` |\n| **Time field name** | Yes | `@timestamp` |\n| **Authentication** | Depends on your setup | Username and password, or API key |\n\nThe Elasticsearch data source supports v7.17 or later, v8.x, v9.x, and Elastic Cloud Serverless."
+    },
+    {
+      "type": "markdown",
+      "content": "### Verify connectivity\n\nConfirm Elasticsearch is reachable by running this command from your terminal:\n\n```bash\ncurl -s -o /dev/null -w \"%{http_code}\" http://YOUR_ELASTICSEARCH_HOST:9200\n```\n\nA `200` response confirms that Elasticsearch is accepting connections. If your instance requires authentication, add credentials with `-u username:password` or an API key header.\n\n**If Elasticsearch is behind a firewall:** You'll need [Private data source connect (PDC)](https://grafana.com/docs/grafana-cloud/connect-externally-hosted/private-data-source-connect/) to allow Grafana Cloud to reach it. Set up PDC before continuing."
+    },
+    {
+      "type": "markdown",
+      "content": "### Confirm read permissions\n\nWhen Elasticsearch security features are enabled, the user or API key that Grafana connects with needs the following cluster privileges:\n\n- **monitor** — Retrieves version information for the connected Elasticsearch instance.\n- **view_index_metadata** — Accesses the mapping definitions of indices.\n- **read** — Performs search and retrieval operations on indices.\n\n**Security tip:** Scope the credentials to the minimum privileges Grafana needs — read access to the indices you want to query. Refer to [Configure the Elasticsearch data source](https://grafana.com/docs/grafana/latest/datasources/elasticsearch/configure/) for details."
+    },
+    {
+      "type": "markdown",
+      "content": "In the next milestone, you'll add Elasticsearch as a data source in Grafana Cloud."
+    }
+  ]
+}

--- a/elasticsearch-data-source-lj/verify-elasticsearch/manifest.json
+++ b/elasticsearch-data-source-lj/verify-elasticsearch/manifest.json
@@ -1,0 +1,19 @@
+{
+  "id": "elasticsearch-data-source-verify-elasticsearch",
+  "type": "guide",
+  "description": "Confirm your Elasticsearch instance is running and gather the connection details Grafana needs.",
+  "category": "data-availability",
+  "author": {
+    "name": "Chris Moyer",
+    "team": "Grafana Documentation"
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": [],
+  "recommends": [
+    "elasticsearch-data-source-add"
+  ],
+  "suggests": [],
+  "provides": []
+}

--- a/elasticsearch-data-source-lj/verify-elasticsearch/website.yaml
+++ b/elasticsearch-data-source-lj/verify-elasticsearch/website.yaml
@@ -1,0 +1,21 @@
+menuTitle: Verify Elasticsearch
+weight: 200
+step: 3
+layout: single-journey
+cta:
+  type: continue
+keywords:
+- Elasticsearch
+- credentials
+- API key
+- index
+- permissions
+side_journeys:
+  title: More to explore (optional)
+  heading: 'At this point in your journey, you can explore the following paths:'
+  items:
+  - title: Configure the Elasticsearch data source
+    link: /docs/grafana/latest/datasources/elasticsearch/configure/
+  - title: Private data source connect
+    link: /docs/grafana-cloud/connect-externally-hosted/private-data-source-connect/
+description: Confirm that your Elasticsearch instance is running and gather the details needed to connect from Grafana.

--- a/elasticsearch-data-source-lj/website.yaml
+++ b/elasticsearch-data-source-lj/website.yaml
@@ -1,0 +1,36 @@
+menuTitle: Connect to Elasticsearch
+weight: 335
+journey:
+  group: data-availability
+  skill: Beginner
+  source: Docs & blog posts
+  logo:
+    src: /static/img/logos/icon_elasticsearch.svg
+    background: '#0068FF'
+    width: 46
+    height: 55
+step: 1
+layout: single-journey
+cascade:
+  layout: single-journey
+cta:
+  type: start
+  title: Are you ready?
+  cta_text: Let's go!
+keywords:
+- Elasticsearch
+- data source
+- Grafana Cloud
+- logs
+- metrics
+- Lucene
+related_journeys:
+  title: Related paths
+  heading: Consider taking the following paths after you complete this journey.
+  items:
+  - title: Explore Elasticsearch logs using Grafana
+    link: /docs/learning-paths/elasticsearch-logs/
+  - title: Create a private connection to a data source
+    link: /docs/learning-paths/private-data-source-connect/
+description: Welcome to the Grafana learning path that shows you how to connect Grafana Cloud to an existing
+  Elasticsearch instance and query your logs and metrics.


### PR DESCRIPTION
## Summary

Adds a new interactive learning path, `elasticsearch-data-source-lj`, that walks a user through connecting Grafana Cloud to an existing Elasticsearch instance and querying its logs/metrics. Structure mirrors the sibling `influxdb-data-source-lj` path.

Created with the `/create-learning-path` workflow. Content is grounded in the canonical docs:
- [Elasticsearch data source](https://grafana.com/docs/grafana/latest/datasources/elasticsearch/)
- [Configure the Elasticsearch data source](https://grafana.com/docs/grafana/latest/datasources/elasticsearch/configure/)

## Milestones

| Order | Dir | In `milestones` | Interactive |
|---|---|:---:|:---:|
| cover | *(path root)* | — | no |
| intro | `business-value` — When to query Elasticsearch directly | no (website-only) | no |
| 1 | `verify-elasticsearch` — Verify Elasticsearch is accessible | ✅ | conceptual |
| 2 | `add-data-source` — Add Elasticsearch as a data source | ✅ | ✅ |
| 3 | `configure-connection` — Configure the Elasticsearch connection | ✅ | ✅ |
| 4 | `test-connection` — Test the connection (success CTA) | ✅ | ✅ |
| 5 | `explore-data` — Explore Elasticsearch data in Grafana | ✅ | ✅ |
| 6 | `end-journey` — Destination reached! (conclusion) | ✅ | no |

## Selector status (for smoke testing)

Reused from already-tested guides (`influxdb-data-source-lj`, `elasticsearch-logs-lj`) — expected stable:
- Nav → Connections → Data sources, Add new data source, search + select **Elasticsearch**
- **Save & test** (button text)
- Explore nav, data-source picker, Lucene query textarea, Run query button

⚠️ **Needs Playwright/Block Editor verification** — Elasticsearch config-editor fields in `configure-connection` are best-guess selectors:
- URL — `input[data-testid='Datasource HTTP settings url']`
- Index name — `input[data-testid='es-config-index-name']` (`skippable`)
- Time field name — `input[data-testid='es-config-time-field']` (`skippable`)

## Validation

- All JSON well-formed; every `content.json` `id` matches its `manifest.json`; all `milestones`/`depends`/`recommends` references resolve.
- `.github/CODEOWNERS` updated.
- Official Pathfinder `validate --packages .` not yet run (no local CLI checkout).

## Next steps

Smoke test each milestone via the Block Builder PR review tool at `learn.grafana.net/?pathfinder-dev=true`, focusing on the flagged config-editor selectors, then report failures for fixes.

<!-- vale = NO -->

Made with [Cursor](https://cursor.com)