### PR TITLE
Add duration metadata for k6 learning paths

### DIFF
--- a/docs/website-yaml-reference.md
+++ b/docs/website-yaml-reference.md
@@ -35,6 +35,7 @@ There are two kinds of `website.yaml`:
 | Field                            | Type   | Notes                                                                                                                            |
 | -------------------------------- | ------ | -------------------------------------------------------------------------------------------------------------------------------- |
 | `show_play`                      | bool   | Set to `false` to hide the play button. Defaults to shown when omitted. Read by `single-journey-main.html` and `path-card.html`. |
+| `journey.duration`               | string | Estimated learner time for the path, for example `45-60 minutes`. Consumed by the Learning Hub catalog as the Duration stat; missing values render as `—`. |
 | `related_journeys.title`         | string | Heading for the related paths block. Conventionally `Related paths`. Rendered by `related-journeys.html`.                        |
 | `related_journeys.heading`       | string | Lead-in sentence above the list.                                                                                                 |
 | `related_journeys.items[].title` | string | Display title of the related path.                                                                                               |

--- a/establish-k6-baseline-lj/website.yaml
+++ b/establish-k6-baseline-lj/website.yaml
@@ -5,6 +5,7 @@ description: Welcome to the Grafana learning path that shows you how to establis
 journey:
   group: take-action
   skill: Beginner
+  duration: 30-45 minutes
   source: Docs & blog posts
   logo:
     src: /media/docs/k6/GrafanaLogo_k6_orange_icon.svg

--- a/find-k6-limits-lj/website.yaml
+++ b/find-k6-limits-lj/website.yaml
@@ -5,6 +5,7 @@ description: Welcome to the Grafana learning path that shows you how to find sys
 journey:
   group: take-action
   skill: Intermediate
+  duration: 30-45 minutes
   source: Docs & blog posts
   logo:
     src: /media/docs/k6/GrafanaLogo_k6_orange_icon.svg

--- a/k6-soak-testing-lj/website.yaml
+++ b/k6-soak-testing-lj/website.yaml
@@ -6,6 +6,7 @@ description: Welcome to the Grafana learning path that shows you how to test sys
 journey:
   group: take-action
   skill: Intermediate
+  duration: 45-60 minutes
   source: Docs & blog posts
   logo:
     src: /media/docs/k6/GrafanaLogo_k6_orange_icon.svg

--- a/run-first-k6-test-lj/website.yaml
+++ b/run-first-k6-test-lj/website.yaml
@@ -2,6 +2,7 @@ weight: 2300
 journey:
   group: take-action
   skill: Beginner
+  duration: 20-30 minutes
   source: Docs & blog posts
   logo:
     src: /media/docs/k6/GrafanaLogo_k6_orange_icon.svg


### PR DESCRIPTION
## Summary
- Set `journey.duration` on the k6 soak, first-test, baseline, and find-limits paths so the Learning Hub catalog no longer shows `—` for Duration.
- Document `journey.duration` in the website.yaml reference so future paths include it.

Estimates:
- Run your first k6 test: `20-30 minutes`
- Establish a k6 baseline: `30-45 minutes`
- Find system limits with k6: `30-45 minutes` (stress ~15–20 min plus optional breakpoint runtime)
- k6 soak testing: `45-60 minutes` (includes the 30-minute learning soak)

## Test plan
- [ ] Confirm Learning Hub deploy preview / next website sync shows these durations instead of `—` on each path detail panel
- [ ] Spot-check that skill and track metadata are unchanged