### PR TITLE
Add getting-started-with-Explore guide

### DIFF
--- a/explore-getting-started/content.json
+++ b/explore-getting-started/content.json
@@ -317,8 +317,8 @@
         },
         {
           "type": "interactive",
-          "action": "button",
-          "reftarget": "Metrics browser",
+          "action": "highlight",
+          "reftarget": "button[data-testid='data-testid open metrics browser']",
           "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-prom", "exists-reftarget"],
           "doIt": false,
           "skippable": true,
@@ -439,8 +439,8 @@
         },
         {
           "type": "interactive",
-          "action": "button",
-          "reftarget": "Kick start your query",
+          "action": "highlight",
+          "reftarget": "button[data-testid='data-testid Query patterns']",
           "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-logs", "exists-reftarget"],
           "doIt": false,
           "tooltip": "It inserts a ready-made LogQL pattern instead of starting from a blank query.",
@@ -448,8 +448,8 @@
         },
         {
           "type": "interactive",
-          "action": "button",
-          "reftarget": "Label browser",
+          "action": "highlight",
+          "reftarget": "button[data-testid='label-browser-button']",
           "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-logs", "exists-reftarget"],
           "doIt": false,
           "skippable": true,

--- a/explore-getting-started/content.json
+++ b/explore-getting-started/content.json
@@ -59,7 +59,7 @@
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "div[data-testid='data-testid Data source picker select container']",
+          "reftarget": "grafana:components.DataSourcePicker.container",
           "requirements": ["on-page:/explore", "exists-reftarget"],
           "doIt": false,
           "tooltip": "Every query starts here — Prometheus, Loki, Tempo, or anything else you've connected.",
@@ -68,7 +68,7 @@
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "button[data-testid='data-testid explore-toolbar-go-queryless-button']",
+          "reftarget": "grafana:pages.Explore.toolbar.goQueryless",
           "requirements": ["on-page:/explore", "exists-reftarget"],
           "doIt": false,
           "skippable": true,
@@ -79,7 +79,7 @@
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "button[data-testid='data-testid explore-toolbar-split-button']",
+          "reftarget": "grafana:pages.Explore.toolbar.split",
           "requirements": ["on-page:/explore", "exists-reftarget"],
           "content": "Click **Split** to open a second, independent query pane."
         },
@@ -98,7 +98,7 @@
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "button[data-testid='data-testid explore-toolbar-add-dropdown-button']",
+          "reftarget": "grafana:pages.Explore.toolbar.addTo",
           "requirements": ["on-page:/explore", "exists-reftarget"],
           "doIt": false,
           "tooltip": "Use it to open another data source in a new tab without losing your current query.",
@@ -107,7 +107,7 @@
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "button[data-testid='data-testid TimePicker Open Button']",
+          "reftarget": "grafana:components.TimePicker.openButton",
           "requirements": ["on-page:/explore", "exists-reftarget"],
           "doIt": false,
           "tooltip": "The arrows on either side step that same range backward or forward, and the magnifying glass zooms out.",
@@ -116,14 +116,14 @@
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "button[data-testid='data-testid RefreshPicker run button']",
+          "reftarget": "grafana:components.RefreshPicker.runButtonV2",
           "requirements": ["on-page:/explore", "exists-reftarget"],
           "content": "Click **Run query** to execute whatever is in the query editor."
         },
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "button[data-testid='data-testid RefreshPicker interval button']",
+          "reftarget": "grafana:components.RefreshPicker.intervalButtonV2",
           "requirements": ["on-page:/explore", "exists-reftarget"],
           "doIt": false,
           "tooltip": "Handy for watching something unfold in near-real time without clicking Run query yourself.",
@@ -132,7 +132,7 @@
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "button[data-testid='data-testid explore-toolbar-share-button']",
+          "reftarget": "grafana:pages.Explore.toolbar.share",
           "requirements": ["on-page:/explore", "exists-reftarget"],
           "doIt": false,
           "tooltip": "Anyone who opens it lands on the same data source, query, and time range you're looking at.",
@@ -141,14 +141,14 @@
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "button[data-testid='data-testid explore-toolbar-content-outline-button']",
+          "reftarget": "grafana:pages.Explore.toolbar.contentOutline",
           "requirements": ["on-page:/explore", "exists-reftarget"],
           "content": "Click **Outline** to toggle the section-jump sidebar."
         },
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "div[data-testid='data-testid Query editor row']",
+          "reftarget": "grafana:components.QueryEditorRows.rows",
           "requirements": ["on-page:/explore", "exists-reftarget"],
           "doIt": false,
           "tooltip": "Later queries can reference an earlier one's results by that letter — useful for math across queries.",
@@ -157,7 +157,7 @@
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "button[data-testid='data-testid Duplicate query']",
+          "reftarget": "grafana:components.QueryEditorRow.actionButton:Duplicate query",
           "requirements": ["on-page:/explore", "exists-reftarget"],
           "doIt": false,
           "tooltip": "Its neighbors let you view data source help, save the query, hide its results, remove it, or drag it to reorder.",
@@ -166,7 +166,7 @@
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "button[data-testid='data-testid query-history-button']",
+          "reftarget": "grafana:components.QueryTab.queryHistoryButton",
           "requirements": ["on-page:/explore", "exists-reftarget"],
           "content": "Click **Query history** to see every query you've run recently."
         },
@@ -177,7 +177,7 @@
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "button[data-testid='data-testid query-history-button']",
+          "reftarget": "grafana:components.QueryTab.queryHistoryButton",
           "requirements": ["on-page:/explore", "exists-reftarget"],
           "content": "Click **Query history** again to close the panel."
         },
@@ -222,7 +222,7 @@
           "steps": [
             {
               "action": "highlight",
-              "reftarget": "input[data-testid='data-testid Select a data source']",
+              "reftarget": "grafana:components.DataSourcePicker.inputV2",
               "requirements": ["exists-reftarget"]
             },
             {
@@ -235,7 +235,7 @@
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "div[data-testid='data-testid QueryEditorModeToggle'] div[data-testid='data-testid radio-button']:contains('Builder')",
+          "reftarget": "div{grafana:components.DataSource.Prometheus.queryEditor.editorToggle} div{grafana:components.RadioButton.container}:contains('Builder')",
           "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-prom", "exists-reftarget"],
           "tooltip": "The rest of this section uses the visual query builder — if a previous session left this data source in Code mode, this switches it back.",
           "content": "Make sure the query editor is in **Builder** mode."
@@ -243,7 +243,7 @@
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "button[data-testid='data-testid Query patterns']",
+          "reftarget": "grafana:components.QueryBuilder.queryPatterns",
           "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-prom", "exists-reftarget"],
           "doIt": false,
           "tooltip": "A quick way to insert a common query shape — rate, histogram, or similar — instead of starting from a blank editor.",
@@ -252,7 +252,7 @@
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "input[data-testid='data-testid metric select']",
+          "reftarget": "grafana:components.DataSource.Prometheus.queryEditor.builder.metricSelect",
           "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-prom", "exists-reftarget"],
           "doIt": false,
           "tooltip": "Type a few letters and it fuzzy-searches every metric name your Prometheus data source knows about.",
@@ -288,7 +288,7 @@
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "div[data-testid='data-testid prometheus explain switch wrapper'] div[data-testid='data-testid Switch container']",
+          "reftarget": "div{grafana:components.DataSource.Prometheus.queryEditor.explain} div{grafana:components.Switch.container}",
           "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-prom", "exists-reftarget"],
           "content": "Turn on **Explain** to see your query broken down in plain English."
         },
@@ -304,21 +304,21 @@
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "div[data-testid='data-testid prometheus explain switch wrapper'] div[data-testid='data-testid Switch container']",
+          "reftarget": "div{grafana:components.DataSource.Prometheus.queryEditor.explain} div{grafana:components.Switch.container}",
           "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-prom", "exists-reftarget"],
           "content": "Turn **Explain** back off."
         },
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "div[data-testid='data-testid QueryEditorModeToggle'] div[data-testid='data-testid radio-button']:contains('Code')",
+          "reftarget": "div{grafana:components.DataSource.Prometheus.queryEditor.editorToggle} div{grafana:components.RadioButton.container}:contains('Code')",
           "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-prom", "exists-reftarget"],
           "content": "Switch to **Code** mode to write raw PromQL directly."
         },
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "button[data-testid='data-testid open metrics browser']",
+          "reftarget": "grafana:components.DataSource.Prometheus.queryEditor.code.metricsBrowser.openButton",
           "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-prom", "exists-reftarget"],
           "doIt": false,
           "skippable": true,
@@ -328,7 +328,7 @@
         {
           "type": "interactive",
           "action": "formfill",
-          "reftarget": "[data-testid='data-testid prometheus query field'] textarea.inputarea",
+          "reftarget": "{grafana:components.DataSource.Prometheus.queryEditor.code.queryField} textarea.inputarea",
           "targetvalue": "quickpizza_server_http_request_duration_seconds_count",
           "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-prom", "exists-reftarget"],
           "tooltip": "It's a counter from the shared demo app — one of the same metrics every Grafana Cloud user just installed.",
@@ -337,7 +337,7 @@
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "button[data-testid='data-testid RefreshPicker run button']",
+          "reftarget": "grafana:components.RefreshPicker.runButtonV2",
           "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-prom", "exists-reftarget"],
           "content": "Click **Run query**."
         },
@@ -348,7 +348,7 @@
         {
           "type": "interactive",
           "action": "formfill",
-          "reftarget": "[data-testid='data-testid prometheus query field'] textarea.inputarea",
+          "reftarget": "{grafana:components.DataSource.Prometheus.queryEditor.code.queryField} textarea.inputarea",
           "targetvalue": "rate(quickpizza_server_http_request_duration_seconds_count[5m])",
           "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-prom", "exists-reftarget"],
           "content": "Replace the query with `rate(quickpizza_server_http_request_duration_seconds_count[5m])`."
@@ -356,14 +356,14 @@
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "button[data-testid='data-testid RefreshPicker run button']",
+          "reftarget": "grafana:components.RefreshPicker.runButtonV2",
           "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-prom", "exists-reftarget"],
           "content": "Click **Run query** again."
         },
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "section[data-testid='data-testid Panel header Graph']",
+          "reftarget": "grafana:components.Panels.Panel.title:Graph",
           "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-prom", "exists-reftarget"],
           "doIt": false,
           "tooltip": "Lines suit trends over time; bars and points can make sparse or discrete values easier to read.",
@@ -372,7 +372,7 @@
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "div[data-testid='data-testid viz-layout-legend']",
+          "reftarget": "grafana:components.VizLegend.legend",
           "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-prom", "exists-reftarget"],
           "doIt": false,
           "tooltip": "Click one to isolate it, or shift-click to build up a custom comparison of just the series you want.",
@@ -381,7 +381,7 @@
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "section[data-testid='data-testid Panel header Raw']",
+          "reftarget": "grafana:components.Panels.Panel.title:Raw",
           "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-prom", "exists-reftarget"],
           "doIt": false,
           "skippable": true,
@@ -391,14 +391,14 @@
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "div[data-testid='data-testid prometheus options'] button",
+          "reftarget": "div{grafana:components.DataSource.Prometheus.queryEditor.options} button",
           "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-prom", "exists-reftarget"],
           "content": "Expand **Options** to see legend, format, and query-type settings."
         },
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "div[data-testid='data-testid prometheus type']",
+          "reftarget": "grafana:components.DataSource.Prometheus.queryEditor.type",
           "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-prom", "exists-reftarget"],
           "doIt": false,
           "tooltip": "Instant returns one value per series for the end of the time range — useful for current-state checks like this one.",
@@ -427,7 +427,7 @@
           "steps": [
             {
               "action": "highlight",
-              "reftarget": "input[data-testid='data-testid Select a data source']",
+              "reftarget": "grafana:components.DataSourcePicker.inputV2",
               "requirements": ["exists-reftarget"]
             },
             {
@@ -440,7 +440,7 @@
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "button[data-testid='data-testid Query patterns']",
+          "reftarget": "grafana:components.QueryBuilder.queryPatterns",
           "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-logs", "exists-reftarget"],
           "doIt": false,
           "tooltip": "It inserts a ready-made LogQL pattern instead of starting from a blank query.",
@@ -459,7 +459,7 @@
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "div[data-testid='data-testid Select label']",
+          "reftarget": "grafana:components.QueryBuilder.labelSelect",
           "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-logs", "exists-reftarget"],
           "content": "Click **Select label** to see the labels available on your logs."
         },
@@ -487,7 +487,7 @@
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "button[data-testid='data-testid RefreshPicker run button']",
+          "reftarget": "grafana:components.RefreshPicker.runButtonV2",
           "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-logs", "exists-reftarget"],
           "content": "Click **Run query**."
         },
@@ -498,7 +498,7 @@
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "section[data-testid='data-testid Panel header Logs volume']",
+          "reftarget": "grafana:components.Panels.Panel.title:Logs volume",
           "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-logs", "exists-reftarget"],
           "doIt": false,
           "skippable": true,
@@ -529,14 +529,14 @@
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "button[data-testid='data-testid explore-toolbar-live-button']",
+          "reftarget": "grafana:pages.Explore.toolbar.live",
           "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-logs", "exists-reftarget"],
           "content": "Click **Live** to start tailing new log lines as they arrive."
         },
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "button[data-testid='data-testid explore-toolbar-live-button']",
+          "reftarget": "grafana:pages.Explore.toolbar.live",
           "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-logs", "exists-reftarget"],
           "content": "Click it again to stop and return to a normal query."
         },
@@ -572,7 +572,7 @@
           "steps": [
             {
               "action": "highlight",
-              "reftarget": "input[data-testid='data-testid Select a data source']",
+              "reftarget": "grafana:components.DataSourcePicker.inputV2",
               "requirements": ["exists-reftarget"]
             },
             {
@@ -585,7 +585,7 @@
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "div[data-testid='data-testid RadioGroup container']",
+          "reftarget": "grafana:components.RadioGroup.container",
           "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-traces", "exists-reftarget"],
           "doIt": false,
           "tooltip": "Search is form-based, TraceQL is a query language for precise filters, and Service Graph shows dependencies between services.",
@@ -594,7 +594,7 @@
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "div[data-testid='data-testid Query editor row tempo A'] div[data-testid='data-testid RadioGroup container'] div[data-testid='data-testid radio-button']:contains('Search')",
+          "reftarget": "div[data-testid='data-testid Query editor row tempo A'] div{grafana:components.RadioGroup.container} div{grafana:components.RadioButton.container}:contains('Search')",
           "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-traces", "exists-reftarget"],
           "content": "Select **Search** for a form-based way to find traces."
         },
@@ -614,14 +614,14 @@
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "button[data-testid='data-testid RefreshPicker run button']",
+          "reftarget": "grafana:components.RefreshPicker.runButtonV2",
           "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-traces", "exists-reftarget"],
           "content": "Click **Run query** to search for matching traces."
         },
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "section[data-testid='data-testid Panel header Table - Traces']",
+          "reftarget": "grafana:components.Panels.Panel.title:Table - Traces",
           "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-traces", "exists-reftarget"],
           "doIt": false,
           "skippable": true,
@@ -631,7 +631,7 @@
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "[data-testid='data-testid Data link']:nth-match(1)",
+          "reftarget": "{grafana:components.DataLinksContextMenu.singleLink}:nth-match(1)",
           "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-traces", "exists-reftarget"],
           "skippable": true,
           "hint": "No traces matched — widen the time range or clear the Service Name filter, then try again.",
@@ -640,7 +640,7 @@
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "section[data-testid='data-testid Panel header Trace']",
+          "reftarget": "grafana:components.Panels.Panel.title:Trace",
           "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-traces", "exists-reftarget"],
           "doIt": false,
           "skippable": true,
@@ -664,7 +664,7 @@
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "div[data-testid='data-testid SpanBar--wrapper']:nth-match(1)",
+          "reftarget": "div{grafana:components.TraceViewer.spanBar}:nth-match(1)",
           "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-traces", "exists-reftarget"],
           "skippable": true,
           "content": "Click the first span to expand its details."
@@ -676,14 +676,14 @@
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "div[data-testid='data-testid Query editor row tempo A'] div[data-testid='data-testid RadioGroup container'] div[data-testid='data-testid radio-button']:contains('Service Graph')",
+          "reftarget": "div[data-testid='data-testid Query editor row tempo A'] div{grafana:components.RadioGroup.container} div{grafana:components.RadioButton.container}:contains('Service Graph')",
           "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-traces", "exists-reftarget"],
           "content": "Switch to **Service Graph** to see how services depend on each other."
         },
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "button[data-testid='data-testid RefreshPicker run button']",
+          "reftarget": "grafana:components.RefreshPicker.runButtonV2",
           "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-traces", "exists-reftarget"],
           "content": "Click **Run query** to build the graph."
         },

--- a/explore-getting-started/content.json
+++ b/explore-getting-started/content.json
@@ -4,11 +4,11 @@
   "blocks": [
     {
       "type": "markdown",
-      "content": "Explore is Grafana's ad-hoc query and investigation workspace — no dashboard required. This guide walks through:\n\n- Installing a shared set of demo data sources, so every step below works identically for everyone\n- The shared interface: toolbar, query row, and results controls that work the same everywhere\n- Querying **metrics** with PromQL\n- Querying **logs** with LogQL\n- Querying **traces** with TraceQL\n\nEach section ends with links to go deeper."
+      "content": "Explore is Grafana's ad-hoc query and investigation workspace — no dashboard required. This guide walks through:\n\n- Installing a set of demo data sources to use for the rest of the guide\n- The shared interface: toolbar, query row, and results controls that work the same everywhere\n- Querying **metrics** with PromQL\n- Querying **logs** with LogQL\n- Querying **traces** with TraceQL\n\nEach section ends with links to go deeper."
     },
     {
       "type": "markdown",
-      "content": "Install a small set of free, Grafana-hosted demo data sources first — real metrics, logs, and traces from the same sample app, so this guide behaves identically no matter what you've already connected."
+      "content": "Install a small set of free, Grafana-hosted demo data sources first — real metrics, logs, and traces from the same sample app."
     },
     {
       "type": "section",
@@ -36,7 +36,7 @@
     },
     {
       "type": "markdown",
-      "content": "You now have **grafanacloud-play-prom**, **grafanacloud-play-logs**, and **grafanacloud-play-traces** — the same real demo data used in every section below."
+      "content": "You now have **grafanacloud-play-prom**, **grafanacloud-play-logs**, and **grafanacloud-play-traces** — real demo data you'll use throughout this guide."
     },
     {
       "type": "markdown",

--- a/explore-getting-started/content.json
+++ b/explore-getting-started/content.json
@@ -73,11 +73,8 @@
           "action": "highlight",
           "reftarget": "grafana:pages.Explore.toolbar.split",
           "requirements": ["on-page:/explore", "exists-reftarget"],
+          "tooltip": "Split view is ideal for comparing two queries, two data sources, or two time ranges side by side.",
           "content": "Click **Split** to open a second, independent query pane."
-        },
-        {
-          "type": "markdown",
-          "content": "Split view is ideal for comparing two queries, two data sources, or two time ranges side by side."
         },
         {
           "type": "interactive",
@@ -156,40 +153,42 @@
           "content": "Icons on the query row include a duplicate-query shortcut, shown here."
         },
         {
-          "type": "interactive",
-          "action": "highlight",
-          "reftarget": "grafana:components.QueryTab.queryHistoryButton",
-          "requirements": ["on-page:/explore", "exists-reftarget"],
-          "content": "Click **Query history** to see every query you've run recently."
+          "type": "guided",
+          "requirements": ["on-page:/explore"],
+          "content": "**Query history** lists every query you've run recently — browse by day, star favorites, or filter by data source. Open it, take a look, then close it again.",
+          "steps": [
+            {
+              "action": "highlight",
+              "reftarget": "grafana:components.QueryTab.queryHistoryButton",
+              "requirements": ["exists-reftarget"],
+              "description": "Click Query history to open the panel"
+            },
+            {
+              "action": "highlight",
+              "reftarget": "grafana:components.QueryTab.queryHistoryButton",
+              "requirements": ["exists-reftarget"],
+              "description": "Click it again to close the panel"
+            }
+          ]
         },
         {
-          "type": "markdown",
-          "content": "Browse history by day, star favorites, or filter by data source."
-        },
-        {
-          "type": "interactive",
-          "action": "highlight",
-          "reftarget": "grafana:components.QueryTab.queryHistoryButton",
-          "requirements": ["on-page:/explore", "exists-reftarget"],
-          "content": "Click **Query history** again to close the panel."
-        },
-        {
-          "type": "interactive",
-          "action": "button",
-          "reftarget": "Query inspector",
-          "requirements": ["on-page:/explore", "exists-reftarget"],
-          "content": "Click **Query inspector** to inspect the raw request and response."
-        },
-        {
-          "type": "markdown",
-          "content": "Its Stats, Query, JSON, and Data tabs show timing, the exact request sent, and the payload returned — invaluable when a query doesn't behave as expected."
-        },
-        {
-          "type": "interactive",
-          "action": "button",
-          "reftarget": "Query inspector",
-          "requirements": ["on-page:/explore", "exists-reftarget"],
-          "content": "Click **Query inspector** again to close it."
+          "type": "guided",
+          "requirements": ["on-page:/explore"],
+          "content": "**Query inspector** exposes the raw request and response. Its Stats, Query, JSON, and Data tabs show timing, the exact request sent, and the payload returned — invaluable when a query doesn't behave as expected. Open it, look around, then close it.",
+          "steps": [
+            {
+              "action": "highlight",
+              "reftarget": "button[aria-label='Query inspector']",
+              "requirements": ["exists-reftarget"],
+              "description": "Click Query inspector to open it"
+            },
+            {
+              "action": "highlight",
+              "reftarget": "button[aria-label='Query inspector']",
+              "requirements": ["exists-reftarget"],
+              "description": "Click it again to close it"
+            }
+          ]
         }
       ]
     },
@@ -228,13 +227,14 @@
         {
           "type": "guided",
           "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-prom"],
+          "skippable": true,
           "content": "Make sure the query editor is in **Builder** mode — the rest of this section uses the visual query builder.",
           "steps": [
             {
               "action": "highlight",
-              "reftarget": "div{grafana:components.DataSource.Prometheus.queryEditor.editorToggle} div{grafana:components.RadioButton.container}:contains('Builder')",
+              "reftarget": "div{grafana:components.DataSource.Prometheus.queryEditor.editorToggle} div{grafana:components.RadioButton.container}:has(input[title='Builder'])",
               "requirements": ["exists-reftarget"],
-              "tooltip": "If a previous session left this data source in Code mode, this switches it back.",
+              "tooltip": "Already in Builder mode? Skip this step — nothing needs to change.",
               "description": "Select Builder mode"
             }
           ]
@@ -277,8 +277,8 @@
         },
         {
           "type": "interactive",
-          "action": "button",
-          "reftarget": "Operations",
+          "action": "highlight",
+          "reftarget": "div[data-testid='data-testid Query editor row prometheus A'] button[title='Add operation']",
           "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-prom", "exists-reftarget"],
           "doIt": false,
           "tooltip": "This is the same function library PromQL uses — rate, sum, histogram_quantile, and dozens more — applied visually.",
@@ -287,7 +287,7 @@
         {
           "type": "guided",
           "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-prom"],
-          "content": "Turn on **Explain** to see your query broken down in plain English.",
+          "content": "Turn on **Explain** to see your query broken down in plain English. Every clause then gets its own numbered, plain-language explanation above the editor — useful while you're still learning PromQL.",
           "steps": [
             {
               "action": "highlight",
@@ -296,15 +296,6 @@
               "description": "Turn on Explain"
             }
           ]
-        },
-        {
-          "type": "interactive",
-          "action": "highlight",
-          "reftarget": "div[data-testid='data-testid Query editor row prometheus A']",
-          "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-prom", "exists-reftarget"],
-          "doIt": false,
-          "tooltip": "Each clause gets its own numbered, plain-language explanation — useful while you're still learning PromQL.",
-          "content": "Explain mode annotates every part of the query above the editor."
         },
         {
           "type": "guided",
@@ -327,7 +318,7 @@
           "steps": [
             {
               "action": "highlight",
-              "reftarget": "div{grafana:components.DataSource.Prometheus.queryEditor.editorToggle} div{grafana:components.RadioButton.container}:contains('Code')",
+              "reftarget": "div{grafana:components.DataSource.Prometheus.queryEditor.editorToggle} div{grafana:components.RadioButton.container}:has(input[title='Code'])",
               "requirements": ["exists-reftarget"],
               "description": "Select Code mode"
             }
@@ -360,16 +351,13 @@
           "content": "Click **Run query**."
         },
         {
-          "type": "markdown",
-          "content": "A counter like this only ever goes up, so it's more useful as a rate. Wrap it in `rate(...)` to see requests per second instead."
-        },
-        {
           "type": "interactive",
           "action": "formfill",
           "reftarget": "{grafana:components.DataSource.Prometheus.queryEditor.code.queryField} textarea.inputarea",
           "targetvalue": "rate(quickpizza_server_http_request_duration_seconds_count[5m])",
           "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-prom", "exists-reftarget"],
-          "content": "Replace the query with `rate(quickpizza_server_http_request_duration_seconds_count[5m])`."
+          "tooltip": "A counter like this only ever goes up, so it's more useful as a rate.",
+          "content": "Wrap the counter in `rate(...)` to see requests per second instead — replace the query with `rate(quickpizza_server_http_request_duration_seconds_count[5m])`."
         },
         {
           "type": "interactive",
@@ -399,10 +387,11 @@
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "grafana:components.Panels.Panel.title:Raw",
+          "reftarget": "{grafana:components.Panels.Panel.title:Raw} {grafana:components.Panels.Panel.headerContainer}",
           "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-prom", "exists-reftarget"],
           "doIt": false,
           "skippable": true,
+          "hint": "The Raw results panel only appears when the query type includes Instant — continue if it isn't there.",
           "tooltip": "Toggle to Table for a spreadsheet-style view of the exact same data.",
           "content": "**Raw** shows the underlying data frame — every returned series and its labels."
         },
@@ -419,6 +408,8 @@
           "reftarget": "grafana:components.DataSource.Prometheus.queryEditor.type",
           "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-prom", "exists-reftarget"],
           "doIt": false,
+          "skippable": true,
+          "hint": "This lives inside the Options row — expand it first if the highlight can't find it.",
           "tooltip": "Instant returns one value per series for the end of the time range — useful for current-state checks like this one.",
           "content": "**Type** switches between a full time series (**Range**), a single point (**Instant**), or **Both**."
         }
@@ -459,13 +450,14 @@
         {
           "type": "guided",
           "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-logs"],
+          "skippable": true,
           "content": "Make sure the query editor is in **Builder** mode — the next few steps describe the visual builder.",
           "steps": [
             {
               "action": "highlight",
-              "reftarget": "div[data-testid='data-testid Query editor row loki A'] {grafana:components.RadioButton.container}:contains('Builder')",
+              "reftarget": "div[data-testid='data-testid Query editor row loki A'] div{grafana:components.RadioButton.container}:has(input[title='Builder'])",
               "requirements": ["exists-reftarget"],
-              "tooltip": "If a previous session left this data source in Code mode, this switches it back.",
+              "tooltip": "The metrics section left the editor in Code mode, so this usually needs one click. If Builder is already selected, skip the step.",
               "description": "Select Builder mode"
             }
           ]
@@ -496,11 +488,7 @@
           "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-logs", "exists-reftarget"],
           "doIt": false,
           "tooltip": "Pick a label, an operator, and a value — the builder writes the selector for you.",
-          "content": "**Label filters** scope the query to a set of streams."
-        },
-        {
-          "type": "markdown",
-          "content": "Every Loki query starts with a label selector like this in curly braces."
+          "content": "**Label filters** scope the query to a set of streams. Every Loki query starts with a label selector like this, in curly braces."
         },
         {
           "type": "interactive",
@@ -518,7 +506,7 @@
           "steps": [
             {
               "action": "highlight",
-              "reftarget": "div[data-testid='data-testid Query editor row loki A'] {grafana:components.RadioButton.container}:contains('Code')",
+              "reftarget": "div[data-testid='data-testid Query editor row loki A'] div{grafana:components.RadioButton.container}:has(input[title='Code'])",
               "requirements": ["exists-reftarget"],
               "description": "Select Code mode"
             }
@@ -538,11 +526,8 @@
           "action": "highlight",
           "reftarget": "grafana:components.RefreshPicker.runButtonV2",
           "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-logs", "exists-reftarget"],
+          "tooltip": "Above the results, Loki reports how much it scanned and often suggests hints like **add json parser** — QuickPizza's logs are JSON, and carry the `traceID` you'll follow in the next section.",
           "content": "Click **Run query**."
-        },
-        {
-          "type": "markdown",
-          "content": "Above the results, Loki shows how much data it scanned and often suggests hints like **add json parser** — one click adds a parser for structured log lines. QuickPizza's logs are JSON and include a `traceID` field — the same trace you'll open in the next section."
         },
         {
           "type": "interactive",
@@ -569,11 +554,8 @@
           "action": "highlight",
           "reftarget": "button[aria-label='Log menu']:nth-match(1)",
           "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-logs", "exists-reftarget"],
+          "tooltip": "From here you can show full log details, view surrounding context lines, pin the line, copy it as text or JSON, or ask Grafana Assistant to explain it.",
           "content": "Click the menu icon on a log line to see what you can do with it."
-        },
-        {
-          "type": "markdown",
-          "content": "From here you can show full log details, view surrounding context lines, pin the line, copy it as text or JSON, or ask Grafana Assistant to explain it."
         },
         {
           "type": "guided",
@@ -593,16 +575,16 @@
               "description": "Click it again to stop"
             }
           ]
-        },
-        {
-          "type": "markdown",
-          "content": "Below the query editor, the collapsed **Options** row holds the line limit and read direction — expand it if you want to cap how many lines come back, or read oldest-first instead of newest-first."
         }
       ]
     },
     {
       "type": "markdown",
       "content": "You built a label selector, filtered lines by content, inspected fields, and tailed logs live."
+    },
+    {
+      "type": "markdown",
+      "content": "One control worth knowing about before moving on: below the query editor, the collapsed **Options** row holds the line limit and read direction — expand it if you want to cap how many lines come back, or read oldest-first instead of newest-first."
     },
     {
       "type": "markdown",
@@ -644,12 +626,14 @@
         {
           "type": "guided",
           "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-traces"],
+          "skippable": true,
           "content": "Select **Search** for a form-based way to find traces.",
           "steps": [
             {
               "action": "highlight",
-              "reftarget": "div[data-testid='data-testid Query editor row tempo A'] div{grafana:components.RadioGroup.container} div{grafana:components.RadioButton.container}:contains('Search')",
+              "reftarget": "div[data-testid='data-testid Query editor row tempo A'] div{grafana:components.RadioGroup.container} div{grafana:components.RadioButton.container}:has(input[title='Search'])",
               "requirements": ["exists-reftarget"],
+              "tooltip": "Search is Tempo's default query type, so this is usually already selected — skip the step if it is.",
               "description": "Select the Search query type"
             }
           ]
@@ -660,21 +644,8 @@
           "reftarget": "input#service-name-value",
           "targetvalue": "quickpizza-public-api",
           "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-traces", "exists-reftarget"],
-          "tooltip": "A real, traced service in the shared demo dataset.",
-          "content": "Set **Service Name** to `quickpizza-public-api`."
-        },
-        {
-          "type": "markdown",
-          "content": "**Span Name**, **Status**, **Duration**, and **Tags** filter further the same way."
-        },
-        {
-          "type": "interactive",
-          "action": "button",
-          "reftarget": "Edit in TraceQL",
-          "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-traces", "exists-reftarget"],
-          "doIt": false,
-          "tooltip": "Every filter you set in the form above is expressed as a single TraceQL expression here.",
-          "content": "**Edit in TraceQL** drops you into the raw query behind your form selections."
+          "tooltip": "**Span Name**, **Status**, **Duration**, and **Tags** filter further the same way, and **Edit in TraceQL** turns whatever you set in the form into the equivalent raw TraceQL expression.",
+          "content": "Set **Service Name** to `quickpizza-public-api`, a real traced service in the shared demo dataset."
         },
         {
           "type": "interactive",
@@ -686,7 +657,7 @@
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "grafana:components.Panels.Panel.title:Table - Traces",
+          "reftarget": "{grafana:components.Panels.Panel.title:Table - Traces} {grafana:components.Panels.Panel.headerContainer}",
           "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-traces", "exists-reftarget"],
           "doIt": false,
           "skippable": true,
@@ -709,12 +680,8 @@
           "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-traces", "exists-reftarget"],
           "doIt": false,
           "skippable": true,
-          "tooltip": "The route is the entry span's name — usually the endpoint or operation the request started at.",
+          "tooltip": "The route is the entry span's name, and just below it **Overview** draws a mini waterfall of the whole trace — collapse that once you've found the section you want to zoom into.",
           "content": "The trace header shows total duration, how many services were involved, and the route."
-        },
-        {
-          "type": "markdown",
-          "content": "Just below the header, **Overview** shows a mini waterfall of the whole trace for quick orientation — collapse it once you've found the section you want to zoom into."
         },
         {
           "type": "interactive",
@@ -732,11 +699,8 @@
           "reftarget": "div{grafana:components.TraceViewer.spanBar}:nth-match(1)",
           "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-traces", "exists-reftarget"],
           "skippable": true,
+          "tooltip": "A span's details include its own attributes, resource attributes (service, cluster, region, and more), and a **Related logs** button that jumps straight to log lines from the same request.",
           "content": "Click the first span to expand its details."
-        },
-        {
-          "type": "markdown",
-          "content": "A span's details include its own attributes, resource attributes (service, cluster, region, and more), and a **Related logs** button that jumps straight to log lines from the same request."
         },
         {
           "type": "interactive",
@@ -754,7 +718,7 @@
           "steps": [
             {
               "action": "highlight",
-              "reftarget": "div[data-testid='data-testid Query editor row tempo A'] div{grafana:components.RadioGroup.container} div{grafana:components.RadioButton.container}:contains('Service Graph')",
+              "reftarget": "div[data-testid='data-testid Query editor row tempo A'] div{grafana:components.RadioGroup.container} div{grafana:components.RadioButton.container}:has(input[title='Service Graph'])",
               "requirements": ["exists-reftarget"],
               "description": "Select the Service Graph query type"
             }
@@ -765,11 +729,8 @@
           "action": "highlight",
           "reftarget": "grafana:components.RefreshPicker.runButtonV2",
           "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-traces", "exists-reftarget"],
+          "tooltip": "Each node shows request rate and error rate for one service and each edge is a dependency — a fast way to spot where errors or latency concentrate across a whole system.",
           "content": "Click **Run query** to build the graph."
-        },
-        {
-          "type": "markdown",
-          "content": "Each node shows request rate and error rate for that service, and each edge is a dependency between two services — a fast way to spot where errors or latency are concentrated across a whole system."
         }
       ]
     },

--- a/explore-getting-started/content.json
+++ b/explore-getting-started/content.json
@@ -1,0 +1,697 @@
+{
+  "id": "explore-getting-started",
+  "title": "Getting started with Explore",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "Explore is Grafana's ad-hoc query and investigation workspace — no dashboard required. This guide walks through:\n\n- Installing a shared set of demo data sources, so every step below works identically for everyone\n- The shared interface: toolbar, query row, and results controls that work the same everywhere\n- Querying **metrics** with PromQL\n- Querying **logs** with LogQL\n- Querying **traces** with TraceQL\n\nEach section ends with links to go deeper."
+    },
+    {
+      "type": "markdown",
+      "content": "Install a small set of free, Grafana-hosted demo data sources first — real metrics, logs, and traces from the same sample app, so this guide behaves identically no matter what you've already connected."
+    },
+    {
+      "type": "section",
+      "id": "install-demo-datasources",
+      "title": "Install the shared demo data sources",
+      "objectives": ["has-datasource:grafanacloud-play-prom"],
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "a[data-testid='data-testid Nav menu item'][href='/a/grafana-demodashboards-app']",
+          "requirements": ["navmenu-open", "exists-reftarget"],
+          "content": "Click **Demo Data Dashboards** in the main menu."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "button[data-testid='install-quickpizza']",
+          "requirements": ["exists-reftarget"],
+          "completeEarly": true,
+          "tooltip": "QuickPizza is a small, fully-instrumented demo app hosted by Grafana — querying it never counts toward your usage.",
+          "content": "Click **Install the Quick Pizza SRE demo**. This adds matching Prometheus, Loki, and Tempo data sources and refreshes the page."
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "You now have **grafanacloud-play-prom**, **grafanacloud-play-logs**, and **grafanacloud-play-traces** — the same real demo data used in every section below."
+    },
+    {
+      "type": "markdown",
+      "content": "Start by touring the controls that stay the same no matter which data source you query."
+    },
+    {
+      "type": "section",
+      "id": "explore-tour",
+      "title": "Tour the Explore interface",
+      "requirements": ["on-page:/explore"],
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "a[data-testid='data-testid Nav menu item'][href='/explore']",
+          "requirements": ["navmenu-open"],
+          "verify": "on-page:/explore",
+          "content": "Click **Explore** in the main menu."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "div[data-testid='data-testid Data source picker select container']",
+          "requirements": ["on-page:/explore", "exists-reftarget"],
+          "doIt": false,
+          "tooltip": "Every query starts here — Prometheus, Loki, Tempo, or anything else you've connected.",
+          "content": "Find the data source picker at the top left of the toolbar."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "button[data-testid='data-testid explore-toolbar-go-queryless-button']",
+          "requirements": ["on-page:/explore", "exists-reftarget"],
+          "doIt": false,
+          "skippable": true,
+          "hint": "This shortcut only appears for data sources with a matching drilldown app installed.",
+          "tooltip": "It opens a purpose-built drilldown view for the same data source without writing a query.",
+          "content": "Notice the **Go queryless** shortcut next to the data source picker."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "button[data-testid='data-testid explore-toolbar-split-button']",
+          "requirements": ["on-page:/explore", "exists-reftarget"],
+          "content": "Click **Split** to open a second, independent query pane."
+        },
+        {
+          "type": "markdown",
+          "content": "Split view is ideal for comparing two queries, two data sources, or two time ranges side by side."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "button[aria-label='Close split pane']:nth-match(2)",
+          "requirements": ["on-page:/explore", "exists-reftarget"],
+          "skippable": true,
+          "content": "Click the close icon on the new pane to return to a single pane."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "button[data-testid='data-testid explore-toolbar-add-dropdown-button']",
+          "requirements": ["on-page:/explore", "exists-reftarget"],
+          "doIt": false,
+          "tooltip": "Use it to open another data source in a new tab without losing your current query.",
+          "content": "Notice **Add**, for opening additional Explore tabs."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "button[data-testid='data-testid TimePicker Open Button']",
+          "requirements": ["on-page:/explore", "exists-reftarget"],
+          "doIt": false,
+          "tooltip": "The arrows on either side step that same range backward or forward, and the magnifying glass zooms out.",
+          "content": "The time range picker controls the window every query runs against."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "button[data-testid='data-testid RefreshPicker run button']",
+          "requirements": ["on-page:/explore", "exists-reftarget"],
+          "content": "Click **Run query** to execute whatever is in the query editor."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "button[data-testid='data-testid RefreshPicker interval button']",
+          "requirements": ["on-page:/explore", "exists-reftarget"],
+          "doIt": false,
+          "tooltip": "Handy for watching something unfold in near-real time without clicking Run query yourself.",
+          "content": "Next to it, the refresh-interval control turns on auto-refresh."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "button[data-testid='data-testid explore-toolbar-share-button']",
+          "requirements": ["on-page:/explore", "exists-reftarget"],
+          "doIt": false,
+          "tooltip": "Anyone who opens it lands on the same data source, query, and time range you're looking at.",
+          "content": "**Share** copies a link that reproduces this exact query and time range."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "button[data-testid='data-testid explore-toolbar-content-outline-button']",
+          "requirements": ["on-page:/explore", "exists-reftarget"],
+          "content": "Click **Outline** to toggle the section-jump sidebar."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "div[data-testid='data-testid Query editor row']",
+          "requirements": ["on-page:/explore", "exists-reftarget"],
+          "doIt": false,
+          "tooltip": "Later queries can reference an earlier one's results by that letter — useful for math across queries.",
+          "content": "Each query lives in its own row, labeled **A**, **B**, and so on."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "button[data-testid='data-testid Duplicate query']",
+          "requirements": ["on-page:/explore", "exists-reftarget"],
+          "doIt": false,
+          "tooltip": "Its neighbors let you view data source help, save the query, hide its results, remove it, or drag it to reorder.",
+          "content": "Icons on the query row include a duplicate-query shortcut, shown here."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "button[data-testid='data-testid query-history-button']",
+          "requirements": ["on-page:/explore", "exists-reftarget"],
+          "content": "Click **Query history** to see every query you've run recently."
+        },
+        {
+          "type": "markdown",
+          "content": "Browse history by day, star favorites, or filter by data source."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "button[data-testid='data-testid query-history-button']",
+          "requirements": ["on-page:/explore", "exists-reftarget"],
+          "content": "Click **Query history** again to close the panel."
+        },
+        {
+          "type": "interactive",
+          "action": "button",
+          "reftarget": "Query inspector",
+          "requirements": ["on-page:/explore", "exists-reftarget"],
+          "content": "Click **Query inspector** to inspect the raw request and response."
+        },
+        {
+          "type": "markdown",
+          "content": "Its Stats, Query, JSON, and Data tabs show timing, the exact request sent, and the payload returned — invaluable when a query doesn't behave as expected."
+        },
+        {
+          "type": "interactive",
+          "action": "button",
+          "reftarget": "Query inspector",
+          "requirements": ["on-page:/explore", "exists-reftarget"],
+          "content": "Click **Query inspector** again to close it."
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "You now know every shared control in Explore — from picking a data source to comparing two queries side by side."
+    },
+    {
+      "type": "markdown",
+      "content": "Prometheus and other metrics data sources speak PromQL. Select one to build your first metrics query."
+    },
+    {
+      "type": "section",
+      "id": "explore-metrics",
+      "title": "Query metrics",
+      "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-prom"],
+      "blocks": [
+        {
+          "type": "multistep",
+          "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-prom"],
+          "content": "Open the data source picker and select **grafanacloud-play-prom**.",
+          "steps": [
+            {
+              "action": "highlight",
+              "reftarget": "input[data-testid='data-testid Select a data source']",
+              "requirements": ["exists-reftarget"]
+            },
+            {
+              "action": "button",
+              "reftarget": "grafanacloud-play-prom Prometheus",
+              "requirements": ["exists-reftarget"]
+            }
+          ]
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "button[data-testid='data-testid Query patterns']",
+          "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-prom", "exists-reftarget"],
+          "doIt": false,
+          "tooltip": "A quick way to insert a common query shape — rate, histogram, or similar — instead of starting from a blank editor.",
+          "content": "**Kick start your query** offers ready-made PromQL patterns."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "input[data-testid='data-testid metric select']",
+          "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-prom", "exists-reftarget"],
+          "doIt": false,
+          "tooltip": "Type a few letters and it fuzzy-searches every metric name your Prometheus data source knows about.",
+          "content": "In **Builder** mode, the Metric field searches available metric names as you type."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "button[aria-label='Open metrics explorer']",
+          "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-prom", "exists-reftarget"],
+          "doIt": false,
+          "tooltip": "Browse by name or type, and read each metric's description before you commit to it.",
+          "content": "The book icon opens a full, searchable catalog of every available metric."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "div[data-testid='prometheus-dimensions-filter-item']",
+          "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-prom", "exists-reftarget"],
+          "doIt": false,
+          "tooltip": "Label filters narrow a metric down to a specific service, instance, or any other dimension it's tagged with.",
+          "content": "**Label filters** let you scope a metric to exactly the series you care about."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "button[aria-label='Operations']",
+          "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-prom", "exists-reftarget"],
+          "doIt": false,
+          "tooltip": "This is the same function library PromQL uses — rate, sum, histogram_quantile, and dozens more — applied visually.",
+          "content": "**Operations** adds functions to your query without typing PromQL by hand."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "div[data-testid='data-testid prometheus explain switch wrapper'] div[data-testid='data-testid Switch container']",
+          "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-prom", "exists-reftarget"],
+          "content": "Turn on **Explain** to see your query broken down in plain English."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "div[data-testid='data-testid Query editor row prometheus A']",
+          "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-prom", "exists-reftarget"],
+          "doIt": false,
+          "tooltip": "Each clause gets its own numbered, plain-language explanation — useful while you're still learning PromQL.",
+          "content": "Explain mode annotates every part of the query above the editor."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "div[data-testid='data-testid prometheus explain switch wrapper'] div[data-testid='data-testid Switch container']",
+          "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-prom", "exists-reftarget"],
+          "content": "Turn **Explain** back off."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "div[data-testid='data-testid QueryEditorModeToggle'] div[data-testid='data-testid radio-button']:contains('Code')",
+          "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-prom", "exists-reftarget"],
+          "content": "Switch to **Code** mode to write raw PromQL directly."
+        },
+        {
+          "type": "interactive",
+          "action": "button",
+          "reftarget": "Metrics browser",
+          "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-prom", "exists-reftarget"],
+          "doIt": false,
+          "skippable": true,
+          "tooltip": "It walks you through picking a metric, then narrowing it down by label, without memorizing PromQL syntax.",
+          "content": "**Metrics browser** builds a query for you from labels, step by step."
+        },
+        {
+          "type": "interactive",
+          "action": "formfill",
+          "reftarget": "textarea.inputarea",
+          "targetvalue": "quickpizza_server_http_request_duration_seconds_count",
+          "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-prom", "exists-reftarget"],
+          "tooltip": "It's a counter from the shared demo app — one of the same metrics every Grafana Cloud user just installed.",
+          "content": "Type `quickpizza_server_http_request_duration_seconds_count`."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "button[data-testid='data-testid RefreshPicker run button']",
+          "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-prom", "exists-reftarget"],
+          "content": "Click **Run query**."
+        },
+        {
+          "type": "markdown",
+          "content": "A counter like this only ever goes up, so it's more useful as a rate. Wrap it in `rate(...)` to see requests per second instead."
+        },
+        {
+          "type": "interactive",
+          "action": "formfill",
+          "reftarget": "textarea.inputarea",
+          "targetvalue": "rate(quickpizza_server_http_request_duration_seconds_count[5m])",
+          "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-prom", "exists-reftarget"],
+          "content": "Replace the query with `rate(quickpizza_server_http_request_duration_seconds_count[5m])`."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "button[data-testid='data-testid RefreshPicker run button']",
+          "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-prom", "exists-reftarget"],
+          "content": "Click **Run query** again."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "div[data-testid='data-testid Panel header Graph']",
+          "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-prom", "exists-reftarget"],
+          "doIt": false,
+          "tooltip": "Lines suit trends over time; bars and points can make sparse or discrete values easier to read.",
+          "content": "Results render as a **Graph**, with Lines, Bars, Points, and stacked variants in the top-right corner."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "div[data-testid='data-testid viz-layout-legend']",
+          "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-prom", "exists-reftarget"],
+          "doIt": false,
+          "tooltip": "Click one to isolate it, or shift-click to build up a custom comparison of just the series you want.",
+          "content": "The legend below the graph lists every series, with its full label set."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "div[data-testid='data-testid Panel header Raw']",
+          "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-prom", "exists-reftarget"],
+          "doIt": false,
+          "skippable": true,
+          "tooltip": "Toggle to Table for a spreadsheet-style view of the exact same data.",
+          "content": "**Raw** shows the underlying data frame — every returned series and its labels."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "div[data-testid='data-testid prometheus options'] button",
+          "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-prom", "exists-reftarget"],
+          "content": "Expand **Options** to see legend, format, and query-type settings."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "fieldset[data-testid='data-testid prometheus type']",
+          "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-prom", "exists-reftarget"],
+          "doIt": false,
+          "tooltip": "Instant returns one value per series for the end of the time range — useful for current-state checks like this one.",
+          "content": "**Type** switches between a full time series (**Range**), a single point (**Instant**), or **Both**."
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "You wrote, explained, and visualized a PromQL query, and know where its display and query-type options live."
+    },
+    {
+      "type": "markdown",
+      "content": "Loki and other log data sources speak LogQL. Select one to search and filter real log lines."
+    },
+    {
+      "type": "section",
+      "id": "explore-logs",
+      "title": "Query logs",
+      "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-logs"],
+      "blocks": [
+        {
+          "type": "multistep",
+          "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-logs"],
+          "content": "Open the data source picker and select **grafanacloud-play-logs**.",
+          "steps": [
+            {
+              "action": "highlight",
+              "reftarget": "input[data-testid='data-testid Select a data source']",
+              "requirements": ["exists-reftarget"]
+            },
+            {
+              "action": "button",
+              "reftarget": "grafanacloud-play-logs Loki",
+              "requirements": ["exists-reftarget"]
+            }
+          ]
+        },
+        {
+          "type": "interactive",
+          "action": "button",
+          "reftarget": "Kick start your query",
+          "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-logs", "exists-reftarget"],
+          "doIt": false,
+          "tooltip": "It inserts a ready-made LogQL pattern instead of starting from a blank query.",
+          "content": "**Kick start your query** offers common LogQL patterns here too."
+        },
+        {
+          "type": "interactive",
+          "action": "button",
+          "reftarget": "Label browser",
+          "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-logs", "exists-reftarget"],
+          "doIt": false,
+          "skippable": true,
+          "tooltip": "It lists every label Loki knows about, with autocomplete for values, so you can build a selector without memorizing names.",
+          "content": "**Label browser** is Loki's dedicated tool for discovering labels and values."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "div[data-testid='data-testid Select label']",
+          "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-logs", "exists-reftarget"],
+          "content": "Click **Select label** to see the labels available on your logs."
+        },
+        {
+          "type": "markdown",
+          "content": "Choose **service_name**, then set its value to **quickpizza-catalog** — a real service in the shared demo dataset. Every Loki query starts with a label selector like this in curly braces."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "div[data-testid='operations.0.wrapper']",
+          "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-logs", "exists-reftarget"],
+          "doIt": false,
+          "tooltip": "It's the LogQL equivalent of grep — keep only lines that contain (or don't contain) a given string.",
+          "content": "Every new query starts with a **Line contains** filter, ready to narrow results further."
+        },
+        {
+          "type": "interactive",
+          "action": "formfill",
+          "reftarget": "div[data-testid='operations.0.wrapper'] input",
+          "targetvalue": "doughs",
+          "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-logs", "exists-reftarget"],
+          "content": "Type `doughs` into the line filter — one of QuickPizza's real API paths — to match only lines containing it."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "button[data-testid='data-testid RefreshPicker run button']",
+          "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-logs", "exists-reftarget"],
+          "content": "Click **Run query**."
+        },
+        {
+          "type": "markdown",
+          "content": "Above the results, Loki shows how much data it scanned and often suggests hints like **add json parser** — one click adds a parser for structured log lines. QuickPizza's logs are JSON and include a `traceID` field — the same trace you'll open in the next section."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "div[data-testid='data-testid Panel header Logs volume']",
+          "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-logs", "exists-reftarget"],
+          "doIt": false,
+          "skippable": true,
+          "hint": "Some Loki versions label this panel slightly differently — continue if it isn't found.",
+          "tooltip": "Spikes and quiet periods here often point straight at when an incident started.",
+          "content": "**Logs volume** charts how many lines matched per time bucket, broken down by level."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "input[placeholder='Search fields by name']",
+          "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-logs", "exists-reftarget"],
+          "doIt": false,
+          "tooltip": "Checking one adds it as its own column, and the percentage shows how many of the returned lines actually have it.",
+          "content": "The left-hand fields panel lists every field detected in your log lines."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "button[aria-label='Log menu']:nth-match(1)",
+          "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-logs", "exists-reftarget"],
+          "content": "Click the menu icon on a log line to see what you can do with it."
+        },
+        {
+          "type": "markdown",
+          "content": "From here you can show full log details, view surrounding context lines, pin the line, copy it as text or JSON, or ask Grafana Assistant to explain it."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "button[data-testid='data-testid explore-toolbar-live-button']",
+          "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-logs", "exists-reftarget"],
+          "content": "Click **Live** to start tailing new log lines as they arrive."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "button[data-testid='data-testid explore-toolbar-live-button']",
+          "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-logs", "exists-reftarget"],
+          "content": "Click it again to stop and return to a normal query."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "div[data-testid='data-testid loki options'] button",
+          "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-logs", "exists-reftarget"],
+          "skippable": true,
+          "hint": "If this isn't found, look for a similar collapsed **Options** row above the results.",
+          "content": "Expand **Options** to see the line limit and read direction."
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "You built a label selector, filtered lines by content, inspected fields, and tailed logs live."
+    },
+    {
+      "type": "markdown",
+      "content": "Tempo and other tracing data sources speak TraceQL. Select one to search traces and drill into individual spans."
+    },
+    {
+      "type": "section",
+      "id": "explore-traces",
+      "title": "Query traces",
+      "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-traces"],
+      "blocks": [
+        {
+          "type": "multistep",
+          "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-traces"],
+          "content": "Open the data source picker and select **grafanacloud-play-traces**.",
+          "steps": [
+            {
+              "action": "highlight",
+              "reftarget": "input[data-testid='data-testid Select a data source']",
+              "requirements": ["exists-reftarget"]
+            },
+            {
+              "action": "button",
+              "reftarget": "grafanacloud-play-traces Tempo",
+              "requirements": ["exists-reftarget"]
+            }
+          ]
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "div[data-testid='data-testid RadioGroup container']",
+          "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-traces", "exists-reftarget"],
+          "doIt": false,
+          "tooltip": "Search is form-based, TraceQL is a query language for precise filters, and Service Graph shows dependencies between services.",
+          "content": "Tempo offers three query types: **Search**, **TraceQL**, and **Service Graph**."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "div[data-testid='data-testid Query editor row tempo A'] div[data-testid='data-testid RadioGroup container'] div[data-testid='data-testid radio-button']:contains('Search')",
+          "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-traces", "exists-reftarget"],
+          "content": "Select **Search** for a form-based way to find traces."
+        },
+        {
+          "type": "markdown",
+          "content": "Set **Service Name** to `quickpizza-public-api` — a real, traced service in the shared demo dataset. **Span Name**, **Status**, **Duration**, and **Tags** filter further the same way."
+        },
+        {
+          "type": "interactive",
+          "action": "button",
+          "reftarget": "Edit in TraceQL",
+          "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-traces", "exists-reftarget"],
+          "doIt": false,
+          "tooltip": "Every filter you set in the form above is expressed as a single TraceQL expression here.",
+          "content": "**Edit in TraceQL** drops you into the raw query behind your form selections."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "button[data-testid='data-testid RefreshPicker run button']",
+          "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-traces", "exists-reftarget"],
+          "content": "Click **Run query** to search for matching traces."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "div[data-testid='data-testid Panel header Table - Traces']",
+          "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-traces", "exists-reftarget"],
+          "doIt": false,
+          "skippable": true,
+          "tooltip": "Each row is one trace: a single end-to-end request across every service it touched.",
+          "content": "Matching traces list as a table, with trace ID, start time, service, name, and duration."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='data-testid Data link']:nth-match(1)",
+          "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-traces", "exists-reftarget"],
+          "skippable": true,
+          "hint": "No traces matched — widen the time range or clear the Service Name filter, then try again.",
+          "content": "Click the first **Trace ID** to open its full waterfall view."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "div[data-testid='data-testid Panel header Trace']",
+          "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-traces", "exists-reftarget"],
+          "doIt": false,
+          "skippable": true,
+          "tooltip": "The route is the entry span's name — usually the endpoint or operation the request started at.",
+          "content": "The trace header shows total duration, how many services were involved, and the route."
+        },
+        {
+          "type": "markdown",
+          "content": "Just below the header, **Overview** shows a mini waterfall of the whole trace for quick orientation — collapse it once you've found the section you want to zoom into."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "input[placeholder='Filter by attribute or text']",
+          "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-traces", "exists-reftarget"],
+          "doIt": false,
+          "skippable": true,
+          "tooltip": "Critical path highlights the spans that actually determined total trace duration; the others surface likely problem spots.",
+          "content": "Filter spans by attribute or text, or use the **Critical path**, **Errors**, and **High latency** shortcuts."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "div[data-testid='data-testid SpanBar--wrapper']:nth-match(1)",
+          "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-traces", "exists-reftarget"],
+          "skippable": true,
+          "content": "Click the first span to expand its details."
+        },
+        {
+          "type": "markdown",
+          "content": "A span's details include its own attributes, resource attributes (service, cluster, region, and more), and a **Related logs** button that jumps straight to log lines from the same request."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "div[data-testid='data-testid Query editor row tempo A'] div[data-testid='data-testid RadioGroup container'] div[data-testid='data-testid radio-button']:contains('Service Graph')",
+          "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-traces", "exists-reftarget"],
+          "content": "Switch to **Service Graph** to see how services depend on each other."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "button[data-testid='data-testid RefreshPicker run button']",
+          "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-traces", "exists-reftarget"],
+          "content": "Click **Run query** to build the graph."
+        },
+        {
+          "type": "markdown",
+          "content": "Each node shows request rate and error rate for that service, and each edge is a dependency between two services — a fast way to spot where errors or latency are concentrated across a whole system."
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "You searched for traces, opened a trace's waterfall, inspected a span's attributes, and viewed the service dependency graph."
+    },
+    {
+      "type": "markdown",
+      "content": "---\n\n### More to explore\n\n- [Explore documentation](https://grafana.com/docs/grafana/latest/explore/)\n- [PromQL basics](https://grafana.com/docs/grafana/latest/datasources/prometheus/query-editor/)\n- [LogQL basics](https://grafana.com/docs/loki/latest/query/)\n- [TraceQL basics](https://grafana.com/docs/tempo/latest/traceql/)"
+    }
+  ]
+}

--- a/explore-getting-started/content.json
+++ b/explore-getting-started/content.json
@@ -287,21 +287,31 @@
         {
           "type": "guided",
           "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-prom"],
-          "content": "Turn on **Explain** to see your query broken down in plain English, then turn it back off.",
+          "content": "Turn on **Explain** to see your query broken down in plain English.",
           "steps": [
             {
               "action": "highlight",
               "reftarget": "div{grafana:components.DataSource.Prometheus.queryEditor.explain} div{grafana:components.Switch.container}",
               "requirements": ["exists-reftarget"],
               "description": "Turn on Explain"
-            },
-            {
-              "action": "highlight",
-              "reftarget": "div[data-testid='data-testid Query editor row prometheus A']",
-              "requirements": ["exists-reftarget"],
-              "tooltip": "Each clause gets its own numbered, plain-language explanation — useful while you're still learning PromQL.",
-              "description": "Read the annotations above the editor"
-            },
+            }
+          ]
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "div[data-testid='data-testid Query editor row prometheus A']",
+          "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-prom", "exists-reftarget"],
+          "doIt": false,
+          "tooltip": "Each clause gets its own numbered, plain-language explanation — useful while you're still learning PromQL.",
+          "content": "Explain mode annotates every part of the query above the editor."
+        },
+        {
+          "type": "guided",
+          "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-prom"],
+          "skippable": true,
+          "content": "Turn **Explain** back off — or leave it on if you find the annotations useful.",
+          "steps": [
             {
               "action": "highlight",
               "reftarget": "div{grafana:components.DataSource.Prometheus.queryEditor.explain} div{grafana:components.Switch.container}",
@@ -447,6 +457,20 @@
           ]
         },
         {
+          "type": "guided",
+          "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-logs"],
+          "content": "Make sure the query editor is in **Builder** mode — the next few steps describe the visual builder.",
+          "steps": [
+            {
+              "action": "highlight",
+              "reftarget": "div[data-testid='data-testid Query editor row loki A'] {grafana:components.RadioButton.container}:contains('Builder')",
+              "requirements": ["exists-reftarget"],
+              "tooltip": "If a previous session left this data source in Code mode, this switches it back.",
+              "description": "Select Builder mode"
+            }
+          ]
+        },
+        {
           "type": "interactive",
           "action": "highlight",
           "reftarget": "grafana:components.QueryBuilder.queryPatterns",
@@ -466,23 +490,13 @@
           "content": "**Label browser** is Loki's dedicated tool for discovering labels and values."
         },
         {
-          "type": "multistep",
-          "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-logs"],
-          "content": "Set the label filter to **service_name = quickpizza-catalog** — a real service in the shared demo dataset.",
-          "steps": [
-            {
-              "action": "formfill",
-              "reftarget": "grafana:components.QueryBuilder.inputSelect",
-              "targetvalue": "service_name",
-              "requirements": ["exists-reftarget"]
-            },
-            {
-              "action": "formfill",
-              "reftarget": "div{grafana:components.QueryBuilder.valueSelect} input",
-              "targetvalue": "quickpizza-catalog",
-              "requirements": ["exists-reftarget"]
-            }
-          ]
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "grafana:components.QueryBuilder.labelSelect",
+          "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-logs", "exists-reftarget"],
+          "doIt": false,
+          "tooltip": "Pick a label, an operator, and a value — the builder writes the selector for you.",
+          "content": "**Label filters** scope the query to a set of streams."
         },
         {
           "type": "markdown",
@@ -498,12 +512,26 @@
           "content": "Every new query starts with a **Line contains** filter, ready to narrow results further."
         },
         {
+          "type": "guided",
+          "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-logs"],
+          "content": "Switch to **Code** mode so you can write the whole LogQL query at once.",
+          "steps": [
+            {
+              "action": "highlight",
+              "reftarget": "div[data-testid='data-testid Query editor row loki A'] {grafana:components.RadioButton.container}:contains('Code')",
+              "requirements": ["exists-reftarget"],
+              "description": "Select Code mode"
+            }
+          ]
+        },
+        {
           "type": "interactive",
           "action": "formfill",
-          "reftarget": "div[data-testid='operations.0.wrapper'] input",
-          "targetvalue": "doughs",
+          "reftarget": "{grafana:components.QueryField.container} textarea.inputarea",
+          "targetvalue": "{service_name=\"quickpizza-catalog\"} |= \"doughs\"",
           "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-logs", "exists-reftarget"],
-          "content": "Type `doughs` into the line filter — one of QuickPizza's real API paths — to match only lines containing it."
+          "tooltip": "The label selector picks the stream; `|=` keeps only lines containing `doughs`, one of QuickPizza's real API paths.",
+          "content": "Type `{service_name=\"quickpizza-catalog\"} |= \"doughs\"`."
         },
         {
           "type": "interactive",

--- a/explore-getting-started/content.json
+++ b/explore-getting-started/content.json
@@ -135,7 +135,6 @@
           "action": "highlight",
           "reftarget": "grafana:pages.Explore.toolbar.contentOutline",
           "requirements": ["on-page:/explore", "exists-reftarget"],
-          "doIt": false,
           "content": "Click **Outline** to toggle the section-jump sidebar."
         },
         {
@@ -161,7 +160,6 @@
           "action": "highlight",
           "reftarget": "grafana:components.QueryTab.queryHistoryButton",
           "requirements": ["on-page:/explore", "exists-reftarget"],
-          "doIt": false,
           "content": "Click **Query history** to see every query you've run recently."
         },
         {
@@ -173,14 +171,12 @@
           "action": "highlight",
           "reftarget": "grafana:components.QueryTab.queryHistoryButton",
           "requirements": ["on-page:/explore", "exists-reftarget"],
-          "doIt": false,
           "content": "Click **Query history** again to close the panel."
         },
         {
           "type": "interactive",
           "action": "button",
           "reftarget": "Query inspector",
-          "doIt": false,
           "requirements": ["on-page:/explore", "exists-reftarget"],
           "content": "Click **Query inspector** to inspect the raw request and response."
         },
@@ -192,7 +188,6 @@
           "type": "interactive",
           "action": "button",
           "reftarget": "Query inspector",
-          "doIt": false,
           "requirements": ["on-page:/explore", "exists-reftarget"],
           "content": "Click **Query inspector** again to close it."
         }
@@ -227,22 +222,22 @@
               "reftarget": "grafana:components.DataSourcePicker.inputV2",
               "targetvalue": "grafanacloud-play-prom",
               "requirements": ["exists-reftarget"]
-            },
-            {
-              "action": "highlight",
-              "reftarget": "div[data-testid='data-source-card']",
-              "requirements": ["exists-reftarget"]
             }
           ]
         },
         {
-          "type": "interactive",
-          "action": "highlight",
-          "reftarget": "div{grafana:components.DataSource.Prometheus.queryEditor.editorToggle} div{grafana:components.RadioButton.container}:contains('Builder')",
-          "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-prom", "exists-reftarget"],
-          "doIt": false,
-          "tooltip": "The rest of this section uses the visual query builder — if a previous session left this data source in Code mode, this switches it back.",
-          "content": "Make sure the query editor is in **Builder** mode."
+          "type": "guided",
+          "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-prom"],
+          "content": "Make sure the query editor is in **Builder** mode — the rest of this section uses the visual query builder.",
+          "steps": [
+            {
+              "action": "highlight",
+              "reftarget": "div{grafana:components.DataSource.Prometheus.queryEditor.editorToggle} div{grafana:components.RadioButton.container}:contains('Builder')",
+              "requirements": ["exists-reftarget"],
+              "tooltip": "If a previous session left this data source in Code mode, this switches it back.",
+              "description": "Select Builder mode"
+            }
+          ]
         },
         {
           "type": "interactive",
@@ -290,37 +285,43 @@
           "content": "**Operations** adds functions to your query without typing PromQL by hand."
         },
         {
-          "type": "interactive",
-          "action": "highlight",
-          "reftarget": "div{grafana:components.DataSource.Prometheus.queryEditor.explain} div{grafana:components.Switch.container}",
-          "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-prom", "exists-reftarget"],
-          "doIt": false,
-          "content": "Turn on **Explain** to see your query broken down in plain English."
+          "type": "guided",
+          "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-prom"],
+          "content": "Turn on **Explain** to see your query broken down in plain English, then turn it back off.",
+          "steps": [
+            {
+              "action": "highlight",
+              "reftarget": "div{grafana:components.DataSource.Prometheus.queryEditor.explain} div{grafana:components.Switch.container}",
+              "requirements": ["exists-reftarget"],
+              "description": "Turn on Explain"
+            },
+            {
+              "action": "highlight",
+              "reftarget": "div[data-testid='data-testid Query editor row prometheus A']",
+              "requirements": ["exists-reftarget"],
+              "tooltip": "Each clause gets its own numbered, plain-language explanation — useful while you're still learning PromQL.",
+              "description": "Read the annotations above the editor"
+            },
+            {
+              "action": "highlight",
+              "reftarget": "div{grafana:components.DataSource.Prometheus.queryEditor.explain} div{grafana:components.Switch.container}",
+              "requirements": ["exists-reftarget"],
+              "description": "Turn Explain back off"
+            }
+          ]
         },
         {
-          "type": "interactive",
-          "action": "highlight",
-          "reftarget": "div[data-testid='data-testid Query editor row prometheus A']",
-          "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-prom", "exists-reftarget"],
-          "doIt": false,
-          "tooltip": "Each clause gets its own numbered, plain-language explanation — useful while you're still learning PromQL.",
-          "content": "Explain mode annotates every part of the query above the editor."
-        },
-        {
-          "type": "interactive",
-          "action": "highlight",
-          "reftarget": "div{grafana:components.DataSource.Prometheus.queryEditor.explain} div{grafana:components.Switch.container}",
-          "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-prom", "exists-reftarget"],
-          "doIt": false,
-          "content": "Turn **Explain** back off."
-        },
-        {
-          "type": "interactive",
-          "action": "highlight",
-          "reftarget": "div{grafana:components.DataSource.Prometheus.queryEditor.editorToggle} div{grafana:components.RadioButton.container}:contains('Code')",
-          "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-prom", "exists-reftarget"],
-          "doIt": false,
-          "content": "Switch to **Code** mode to write raw PromQL directly."
+          "type": "guided",
+          "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-prom"],
+          "content": "Switch to **Code** mode to write raw PromQL directly.",
+          "steps": [
+            {
+              "action": "highlight",
+              "reftarget": "div{grafana:components.DataSource.Prometheus.queryEditor.editorToggle} div{grafana:components.RadioButton.container}:contains('Code')",
+              "requirements": ["exists-reftarget"],
+              "description": "Select Code mode"
+            }
+          ]
         },
         {
           "type": "interactive",
@@ -442,11 +443,6 @@
               "reftarget": "grafana:components.DataSourcePicker.inputV2",
               "targetvalue": "grafanacloud-play-logs",
               "requirements": ["exists-reftarget"]
-            },
-            {
-              "action": "highlight",
-              "reftarget": "div[data-testid='data-source-card']",
-              "requirements": ["exists-reftarget"]
             }
           ]
         },
@@ -552,20 +548,23 @@
           "content": "From here you can show full log details, view surrounding context lines, pin the line, copy it as text or JSON, or ask Grafana Assistant to explain it."
         },
         {
-          "type": "interactive",
-          "action": "highlight",
-          "reftarget": "grafana:pages.Explore.toolbar.live",
-          "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-logs", "exists-reftarget"],
-          "doIt": false,
-          "content": "Click **Live** to start tailing new log lines as they arrive."
-        },
-        {
-          "type": "interactive",
-          "action": "highlight",
-          "reftarget": "grafana:pages.Explore.toolbar.live",
-          "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-logs", "exists-reftarget"],
-          "doIt": false,
-          "content": "Click it again to stop and return to a normal query."
+          "type": "guided",
+          "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-logs"],
+          "content": "**Live** tails new log lines as they arrive. Start it, watch a few lines land, then stop it.",
+          "steps": [
+            {
+              "action": "highlight",
+              "reftarget": "grafana:pages.Explore.toolbar.live",
+              "requirements": ["exists-reftarget"],
+              "description": "Click Live to start tailing"
+            },
+            {
+              "action": "highlight",
+              "reftarget": "grafana:pages.Explore.toolbar.live",
+              "requirements": ["exists-reftarget"],
+              "description": "Click it again to stop"
+            }
+          ]
         },
         {
           "type": "markdown",
@@ -602,11 +601,6 @@
               "reftarget": "grafana:components.DataSourcePicker.inputV2",
               "targetvalue": "grafanacloud-play-traces",
               "requirements": ["exists-reftarget"]
-            },
-            {
-              "action": "highlight",
-              "reftarget": "div[data-testid='data-source-card']",
-              "requirements": ["exists-reftarget"]
             }
           ]
         },
@@ -620,12 +614,17 @@
           "content": "Tempo offers three query types: **Search**, **TraceQL**, and **Service Graph**."
         },
         {
-          "type": "interactive",
-          "action": "highlight",
-          "reftarget": "div[data-testid='data-testid Query editor row tempo A'] div{grafana:components.RadioGroup.container} div{grafana:components.RadioButton.container}:contains('Search')",
-          "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-traces", "exists-reftarget"],
-          "doIt": false,
-          "content": "Select **Search** for a form-based way to find traces."
+          "type": "guided",
+          "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-traces"],
+          "content": "Select **Search** for a form-based way to find traces.",
+          "steps": [
+            {
+              "action": "highlight",
+              "reftarget": "div[data-testid='data-testid Query editor row tempo A'] div{grafana:components.RadioGroup.container} div{grafana:components.RadioButton.container}:contains('Search')",
+              "requirements": ["exists-reftarget"],
+              "description": "Select the Search query type"
+            }
+          ]
         },
         {
           "type": "interactive",
@@ -712,12 +711,17 @@
           "content": "A span's details include its own attributes, resource attributes (service, cluster, region, and more), and a **Related logs** button that jumps straight to log lines from the same request."
         },
         {
-          "type": "interactive",
-          "action": "highlight",
-          "reftarget": "div[data-testid='data-testid Query editor row tempo A'] div{grafana:components.RadioGroup.container} div{grafana:components.RadioButton.container}:contains('Service Graph')",
-          "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-traces", "exists-reftarget"],
-          "doIt": false,
-          "content": "Switch to **Service Graph** to see how services depend on each other."
+          "type": "guided",
+          "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-traces"],
+          "content": "Switch to **Service Graph** to see how services depend on each other.",
+          "steps": [
+            {
+              "action": "highlight",
+              "reftarget": "div[data-testid='data-testid Query editor row tempo A'] div{grafana:components.RadioGroup.container} div{grafana:components.RadioButton.container}:contains('Service Graph')",
+              "requirements": ["exists-reftarget"],
+              "description": "Select the Service Graph query type"
+            }
+          ]
         },
         {
           "type": "interactive",

--- a/explore-getting-started/content.json
+++ b/explore-getting-started/content.json
@@ -161,13 +161,14 @@
               "action": "highlight",
               "reftarget": "grafana:components.QueryTab.queryHistoryButton",
               "requirements": ["exists-reftarget"],
+              "skippable": true,
               "description": "Click Query history to open the panel"
             },
             {
               "action": "highlight",
-              "reftarget": "grafana:components.QueryTab.queryHistoryButton",
+              "reftarget": "{grafana:pages.Explore.QueryHistory.container} button:has(svg[data-testid='icon-times'])",
               "requirements": ["exists-reftarget"],
-              "description": "Click it again to close the panel"
+              "description": "Close the panel with the X at its top right"
             }
           ]
         },
@@ -178,15 +179,16 @@
           "steps": [
             {
               "action": "highlight",
-              "reftarget": "button[aria-label='Query inspector']",
+              "reftarget": "grafana:components.QueryTab.queryInspectorButton",
               "requirements": ["exists-reftarget"],
+              "skippable": true,
               "description": "Click Query inspector to open it"
             },
             {
               "action": "highlight",
-              "reftarget": "button[aria-label='Query inspector']",
+              "reftarget": "{grafana:pages.Explore.General.container} [role='tablist'] button:has(svg[data-testid='icon-times'])",
               "requirements": ["exists-reftarget"],
-              "description": "Click it again to close it"
+              "description": "Close the inspector with the X at its top right"
             }
           ]
         }

--- a/explore-getting-started/content.json
+++ b/explore-getting-started/content.json
@@ -226,11 +226,19 @@
               "requirements": ["exists-reftarget"]
             },
             {
-              "action": "button",
-              "reftarget": "grafanacloud-play-prom Prometheus",
+              "action": "highlight",
+              "reftarget": "div[role='option'][aria-label='grafanacloud-play-prom']",
               "requirements": ["exists-reftarget"]
             }
           ]
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "div[data-testid='data-testid QueryEditorModeToggle'] div[data-testid='data-testid radio-button']:contains('Builder')",
+          "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-prom", "exists-reftarget"],
+          "tooltip": "The rest of this section uses the visual query builder — if a previous session left this data source in Code mode, this switches it back.",
+          "content": "Make sure the query editor is in **Builder** mode."
         },
         {
           "type": "interactive",
@@ -270,8 +278,8 @@
         },
         {
           "type": "interactive",
-          "action": "highlight",
-          "reftarget": "button[aria-label='Operations']",
+          "action": "button",
+          "reftarget": "Operations",
           "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-prom", "exists-reftarget"],
           "doIt": false,
           "tooltip": "This is the same function library PromQL uses — rate, sum, histogram_quantile, and dozens more — applied visually.",
@@ -355,7 +363,7 @@
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "div[data-testid='data-testid Panel header Graph']",
+          "reftarget": "section[data-testid='data-testid Panel header Graph']",
           "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-prom", "exists-reftarget"],
           "doIt": false,
           "tooltip": "Lines suit trends over time; bars and points can make sparse or discrete values easier to read.",
@@ -373,7 +381,7 @@
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "div[data-testid='data-testid Panel header Raw']",
+          "reftarget": "section[data-testid='data-testid Panel header Raw']",
           "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-prom", "exists-reftarget"],
           "doIt": false,
           "skippable": true,
@@ -390,7 +398,7 @@
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "fieldset[data-testid='data-testid prometheus type']",
+          "reftarget": "div[data-testid='data-testid prometheus type']",
           "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-prom", "exists-reftarget"],
           "doIt": false,
           "tooltip": "Instant returns one value per series for the end of the time range — useful for current-state checks like this one.",
@@ -423,8 +431,8 @@
               "requirements": ["exists-reftarget"]
             },
             {
-              "action": "button",
-              "reftarget": "grafanacloud-play-logs Loki",
+              "action": "highlight",
+              "reftarget": "div[role='option'][aria-label='grafanacloud-play-logs']",
               "requirements": ["exists-reftarget"]
             }
           ]
@@ -490,7 +498,7 @@
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "div[data-testid='data-testid Panel header Logs volume']",
+          "reftarget": "section[data-testid='data-testid Panel header Logs volume']",
           "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-logs", "exists-reftarget"],
           "doIt": false,
           "skippable": true,
@@ -568,8 +576,8 @@
               "requirements": ["exists-reftarget"]
             },
             {
-              "action": "button",
-              "reftarget": "grafanacloud-play-traces Tempo",
+              "action": "highlight",
+              "reftarget": "div[role='option'][aria-label='grafanacloud-play-traces']",
               "requirements": ["exists-reftarget"]
             }
           ]
@@ -613,7 +621,7 @@
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "div[data-testid='data-testid Panel header Table - Traces']",
+          "reftarget": "section[data-testid='data-testid Panel header Table - Traces']",
           "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-traces", "exists-reftarget"],
           "doIt": false,
           "skippable": true,
@@ -632,7 +640,7 @@
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "div[data-testid='data-testid Panel header Trace']",
+          "reftarget": "section[data-testid='data-testid Panel header Trace']",
           "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-traces", "exists-reftarget"],
           "doIt": false,
           "skippable": true,

--- a/explore-getting-started/content.json
+++ b/explore-getting-started/content.json
@@ -739,6 +739,15 @@
           "content": "A span's details include its own attributes, resource attributes (service, cluster, region, and more), and a **Related logs** button that jumps straight to log lines from the same request."
         },
         {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "button[aria-label='Close split pane']:nth-match(2)",
+          "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-traces", "exists-reftarget"],
+          "skippable": true,
+          "tooltip": "Opening a trace puts it in a second pane, which halves the width of the query form — on a narrow screen that pushes it out of view.",
+          "content": "Close the trace pane to give the query editor the full width back."
+        },
+        {
           "type": "guided",
           "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-traces"],
           "content": "Switch to **Service Graph** to see how services depend on each other.",

--- a/explore-getting-started/content.json
+++ b/explore-getting-started/content.json
@@ -328,7 +328,7 @@
         {
           "type": "interactive",
           "action": "formfill",
-          "reftarget": "textarea.inputarea",
+          "reftarget": "[data-testid='data-testid prometheus query field'] textarea.inputarea",
           "targetvalue": "quickpizza_server_http_request_duration_seconds_count",
           "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-prom", "exists-reftarget"],
           "tooltip": "It's a counter from the shared demo app — one of the same metrics every Grafana Cloud user just installed.",
@@ -348,7 +348,7 @@
         {
           "type": "interactive",
           "action": "formfill",
-          "reftarget": "textarea.inputarea",
+          "reftarget": "[data-testid='data-testid prometheus query field'] textarea.inputarea",
           "targetvalue": "rate(quickpizza_server_http_request_duration_seconds_count[5m])",
           "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-prom", "exists-reftarget"],
           "content": "Replace the query with `rate(quickpizza_server_http_request_duration_seconds_count[5m])`."

--- a/explore-getting-started/content.json
+++ b/explore-getting-started/content.json
@@ -51,14 +51,6 @@
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "a[data-testid='data-testid Nav menu item'][href='/explore']",
-          "requirements": ["navmenu-open"],
-          "verify": "on-page:/explore",
-          "content": "Click **Explore** in the main menu."
-        },
-        {
-          "type": "interactive",
-          "action": "highlight",
           "reftarget": "grafana:components.DataSourcePicker.container",
           "requirements": ["on-page:/explore", "exists-reftarget"],
           "doIt": false,
@@ -143,6 +135,7 @@
           "action": "highlight",
           "reftarget": "grafana:pages.Explore.toolbar.contentOutline",
           "requirements": ["on-page:/explore", "exists-reftarget"],
+          "doIt": false,
           "content": "Click **Outline** to toggle the section-jump sidebar."
         },
         {
@@ -168,6 +161,7 @@
           "action": "highlight",
           "reftarget": "grafana:components.QueryTab.queryHistoryButton",
           "requirements": ["on-page:/explore", "exists-reftarget"],
+          "doIt": false,
           "content": "Click **Query history** to see every query you've run recently."
         },
         {
@@ -179,12 +173,14 @@
           "action": "highlight",
           "reftarget": "grafana:components.QueryTab.queryHistoryButton",
           "requirements": ["on-page:/explore", "exists-reftarget"],
+          "doIt": false,
           "content": "Click **Query history** again to close the panel."
         },
         {
           "type": "interactive",
           "action": "button",
           "reftarget": "Query inspector",
+          "doIt": false,
           "requirements": ["on-page:/explore", "exists-reftarget"],
           "content": "Click **Query inspector** to inspect the raw request and response."
         },
@@ -196,6 +192,7 @@
           "type": "interactive",
           "action": "button",
           "reftarget": "Query inspector",
+          "doIt": false,
           "requirements": ["on-page:/explore", "exists-reftarget"],
           "content": "Click **Query inspector** again to close it."
         }
@@ -226,8 +223,14 @@
               "requirements": ["exists-reftarget"]
             },
             {
+              "action": "formfill",
+              "reftarget": "grafana:components.DataSourcePicker.inputV2",
+              "targetvalue": "grafanacloud-play-prom",
+              "requirements": ["exists-reftarget"]
+            },
+            {
               "action": "highlight",
-              "reftarget": "div[role='option'][aria-label='grafanacloud-play-prom']",
+              "reftarget": "div[data-testid='data-source-card']",
               "requirements": ["exists-reftarget"]
             }
           ]
@@ -237,6 +240,7 @@
           "action": "highlight",
           "reftarget": "div{grafana:components.DataSource.Prometheus.queryEditor.editorToggle} div{grafana:components.RadioButton.container}:contains('Builder')",
           "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-prom", "exists-reftarget"],
+          "doIt": false,
           "tooltip": "The rest of this section uses the visual query builder — if a previous session left this data source in Code mode, this switches it back.",
           "content": "Make sure the query editor is in **Builder** mode."
         },
@@ -290,6 +294,7 @@
           "action": "highlight",
           "reftarget": "div{grafana:components.DataSource.Prometheus.queryEditor.explain} div{grafana:components.Switch.container}",
           "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-prom", "exists-reftarget"],
+          "doIt": false,
           "content": "Turn on **Explain** to see your query broken down in plain English."
         },
         {
@@ -306,6 +311,7 @@
           "action": "highlight",
           "reftarget": "div{grafana:components.DataSource.Prometheus.queryEditor.explain} div{grafana:components.Switch.container}",
           "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-prom", "exists-reftarget"],
+          "doIt": false,
           "content": "Turn **Explain** back off."
         },
         {
@@ -313,6 +319,7 @@
           "action": "highlight",
           "reftarget": "div{grafana:components.DataSource.Prometheus.queryEditor.editorToggle} div{grafana:components.RadioButton.container}:contains('Code')",
           "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-prom", "exists-reftarget"],
+          "doIt": false,
           "content": "Switch to **Code** mode to write raw PromQL directly."
         },
         {
@@ -431,8 +438,14 @@
               "requirements": ["exists-reftarget"]
             },
             {
+              "action": "formfill",
+              "reftarget": "grafana:components.DataSourcePicker.inputV2",
+              "targetvalue": "grafanacloud-play-logs",
+              "requirements": ["exists-reftarget"]
+            },
+            {
               "action": "highlight",
-              "reftarget": "div[role='option'][aria-label='grafanacloud-play-logs']",
+              "reftarget": "div[data-testid='data-source-card']",
               "requirements": ["exists-reftarget"]
             }
           ]
@@ -457,15 +470,27 @@
           "content": "**Label browser** is Loki's dedicated tool for discovering labels and values."
         },
         {
-          "type": "interactive",
-          "action": "highlight",
-          "reftarget": "grafana:components.QueryBuilder.labelSelect",
-          "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-logs", "exists-reftarget"],
-          "content": "Click **Select label** to see the labels available on your logs."
+          "type": "multistep",
+          "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-logs"],
+          "content": "Set the label filter to **service_name = quickpizza-catalog** — a real service in the shared demo dataset.",
+          "steps": [
+            {
+              "action": "formfill",
+              "reftarget": "grafana:components.QueryBuilder.inputSelect",
+              "targetvalue": "service_name",
+              "requirements": ["exists-reftarget"]
+            },
+            {
+              "action": "formfill",
+              "reftarget": "div{grafana:components.QueryBuilder.valueSelect} input",
+              "targetvalue": "quickpizza-catalog",
+              "requirements": ["exists-reftarget"]
+            }
+          ]
         },
         {
           "type": "markdown",
-          "content": "Choose **service_name**, then set its value to **quickpizza-catalog** — a real service in the shared demo dataset. Every Loki query starts with a label selector like this in curly braces."
+          "content": "Every Loki query starts with a label selector like this in curly braces."
         },
         {
           "type": "interactive",
@@ -531,6 +556,7 @@
           "action": "highlight",
           "reftarget": "grafana:pages.Explore.toolbar.live",
           "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-logs", "exists-reftarget"],
+          "doIt": false,
           "content": "Click **Live** to start tailing new log lines as they arrive."
         },
         {
@@ -538,16 +564,12 @@
           "action": "highlight",
           "reftarget": "grafana:pages.Explore.toolbar.live",
           "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-logs", "exists-reftarget"],
+          "doIt": false,
           "content": "Click it again to stop and return to a normal query."
         },
         {
-          "type": "interactive",
-          "action": "highlight",
-          "reftarget": "div[data-testid='data-testid loki options'] button",
-          "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-logs", "exists-reftarget"],
-          "skippable": true,
-          "hint": "If this isn't found, look for a similar collapsed **Options** row above the results.",
-          "content": "Expand **Options** to see the line limit and read direction."
+          "type": "markdown",
+          "content": "Below the query editor, the collapsed **Options** row holds the line limit and read direction — expand it if you want to cap how many lines come back, or read oldest-first instead of newest-first."
         }
       ]
     },
@@ -576,8 +598,14 @@
               "requirements": ["exists-reftarget"]
             },
             {
+              "action": "formfill",
+              "reftarget": "grafana:components.DataSourcePicker.inputV2",
+              "targetvalue": "grafanacloud-play-traces",
+              "requirements": ["exists-reftarget"]
+            },
+            {
               "action": "highlight",
-              "reftarget": "div[role='option'][aria-label='grafanacloud-play-traces']",
+              "reftarget": "div[data-testid='data-source-card']",
               "requirements": ["exists-reftarget"]
             }
           ]
@@ -585,7 +613,7 @@
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "grafana:components.RadioGroup.container",
+          "reftarget": "div[data-testid='data-testid Query editor row tempo A'] {grafana:components.RadioGroup.container}",
           "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-traces", "exists-reftarget"],
           "doIt": false,
           "tooltip": "Search is form-based, TraceQL is a query language for precise filters, and Service Graph shows dependencies between services.",
@@ -596,11 +624,21 @@
           "action": "highlight",
           "reftarget": "div[data-testid='data-testid Query editor row tempo A'] div{grafana:components.RadioGroup.container} div{grafana:components.RadioButton.container}:contains('Search')",
           "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-traces", "exists-reftarget"],
+          "doIt": false,
           "content": "Select **Search** for a form-based way to find traces."
         },
         {
+          "type": "interactive",
+          "action": "formfill",
+          "reftarget": "input#service-name-value",
+          "targetvalue": "quickpizza-public-api",
+          "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-traces", "exists-reftarget"],
+          "tooltip": "A real, traced service in the shared demo dataset.",
+          "content": "Set **Service Name** to `quickpizza-public-api`."
+        },
+        {
           "type": "markdown",
-          "content": "Set **Service Name** to `quickpizza-public-api` — a real, traced service in the shared demo dataset. **Span Name**, **Status**, **Duration**, and **Tags** filter further the same way."
+          "content": "**Span Name**, **Status**, **Duration**, and **Tags** filter further the same way."
         },
         {
           "type": "interactive",
@@ -678,6 +716,7 @@
           "action": "highlight",
           "reftarget": "div[data-testid='data-testid Query editor row tempo A'] div{grafana:components.RadioGroup.container} div{grafana:components.RadioButton.container}:contains('Service Graph')",
           "requirements": ["on-page:/explore", "has-datasource:grafanacloud-play-traces", "exists-reftarget"],
+          "doIt": false,
           "content": "Switch to **Service Graph** to see how services depend on each other."
         },
         {

--- a/explore-getting-started/manifest.json
+++ b/explore-getting-started/manifest.json
@@ -1,0 +1,27 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "explore-getting-started",
+  "type": "guide",
+  "description": "Hands-on tour of Grafana Explore: the shared interface, then querying metrics, logs, and traces.",
+  "category": "general",
+  "author": {
+    "team": "interactive-learning",
+    "name": "Jayclifford345"
+  },
+  "startingLocation": "/explore",
+  "targeting": {
+    "match": {
+      "and": [
+        { "targetPlatform": "cloud" },
+        { "urlPrefix": "/explore" }
+      ]
+    }
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": [],
+  "recommends": ["saved-queries-explore"],
+  "suggests": [],
+  "provides": []
+}


### PR DESCRIPTION
## Summary
- New standalone interactive guide, `explore-getting-started`, targeted at `/explore` on Grafana Cloud
- Tours the shared Explore interface (toolbar, query row, results controls), then walks through a full write-a-query-to-navigate-the-results flow for **metrics** (PromQL), **logs** (LogQL), and **traces** (TraceQL)
- First section installs the shared QuickPizza demo data sources (`grafanacloud-play-prom`/`-logs`/`-traces`) via the existing Demo Data Dashboards flow, so every later step and example query is identical for any Grafana Cloud user — auto-skips if already installed
- Recommends `saved-queries-explore` as a natural follow-up

## Why
Requested as an extensive, ground-up "getting started with Explore" guide covering general UI orientation plus a deep, hands-on flow for each signal type — standardized on shared demo data instead of guessing at whatever data sources a given org happens to have, so the guide behaves the same for everyone.

## How this was verified
- Selectors captured live against a real Grafana Cloud Explore session (Playwright), not guessed
- `pathfinder-cli validate --package explore-getting-started` passes clean
- Example queries (`quickpizza_server_http_request_duration_seconds_count`, `service_name="quickpizza-catalog"`, `quickpizza-public-api`) confirmed live against the actual QuickPizza demo dataset

## Test plan
- [ ] Open in the Pathfinder Block Editor against a live Grafana Cloud stack and click through end-to-end
- [ ] Confirm the two Loki-specific selectors inferred by naming-pattern (`Panel header Logs volume`, `loki options`) resolve correctly — flagged with `skippable`/`hint` in case they don't
- [ ] Confirm `install-demo-datasources` section correctly auto-skips on a stack that already has the QuickPizza demo installed, and correctly installs it on one that doesn't

Marked as draft pending that live click-through pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)