### PR TITLE
feat: add core-grafana-concepts-lj prose-only learning path

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -32,7 +32,7 @@
 /billing-usage-lj/                                        @Eve832
 /categorize-collector-fleet-lj/                            @tiffany76
 /connect-prometheus-metrics/                              @tacole02
-/core-grafana-concepts-lj/                                @chri2547 @tacole02 @moxious @Jayclifford345 @tomglenn
+/core-grafana-concepts-lj/                                @moxious
 /create-usage-alert/                                      @Eve832
 /detect-outages-synthetic-monitoring-lj/                  @heitortsergent
 /drilldown-logs-lj/                                       @jstickler

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -32,6 +32,7 @@
 /billing-usage-lj/                                        @Eve832
 /categorize-collector-fleet-lj/                            @tiffany76
 /connect-prometheus-metrics/                              @tacole02
+/core-grafana-concepts-lj/                                @chri2547 @tacole02 @moxious @Jayclifford345 @tomglenn
 /create-usage-alert/                                      @Eve832
 /detect-outages-synthetic-monitoring-lj/                  @heitortsergent
 /drilldown-logs-lj/                                       @jstickler

--- a/core-grafana-concepts-lj/alerting/content.json
+++ b/core-grafana-concepts-lj/alerting/content.json
@@ -1,0 +1,38 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "core-grafana-concepts-alerting",
+  "title": "Alerting",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "In this section, you'll learn how Grafana Alerting evaluates rules and routes notifications when conditions require attention."
+    },
+    {
+      "type": "section",
+      "id": "understand-alerting",
+      "title": "Understand alerting",
+      "autoCollapse": false,
+      "blocks": [
+        {
+          "type": "markdown",
+          "content": "Grafana Alerting continuously evaluates alert rules so important conditions do not depend on someone watching a dashboard. An alert rule contains one or more queries or expressions, a condition, and an evaluation schedule. When the condition is met, each distinct set of labels can produce an alert instance that moves through states such as pending and firing.\n\nAlerting uses the same data-source layer as queries and panels, but it is not a visual property of a dashboard. Notification policies route alert instances by labels and other matchers, while contact points define destinations such as email, Slack, or an incident-management system. Dashboards help people understand a situation; alerting decides when the situation needs attention and sends it to the right place."
+        },
+        {
+          "type": "image",
+          "src": "https://grafana.com/media/docs/alerting/alerting-configure-notifications-v2.png",
+          "alt": "Diagram showing alert rule evaluation, alert instances, notification policies, and contact points"
+        },
+        {
+          "type": "video",
+          "src": "https://www.youtube.com/embed/6W8Nu4b_PXM",
+          "provider": "youtube",
+          "title": "Creating alerts with Grafana"
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "You learned that an alert rule evaluates queries against a condition on a schedule, and that notification policies and contact points route firing alerts to the right destination."
+    }
+  ]
+}

--- a/core-grafana-concepts-lj/alerting/manifest.json
+++ b/core-grafana-concepts-lj/alerting/manifest.json
@@ -1,0 +1,21 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "core-grafana-concepts-alerting",
+  "type": "guide",
+  "description": "Learn how alert rules evaluate conditions on a schedule and how notification policies and contact points route alerts.",
+  "category": "onboarding",
+  "author": {
+    "team": "Grafana Documentation"
+  },
+  "testEnvironment": {
+    "tier": "local"
+  },
+  "depends": [
+    "core-grafana-concepts-dashboards"
+  ],
+  "recommends": [
+    "core-grafana-concepts-end-journey"
+  ],
+  "suggests": [],
+  "provides": []
+}

--- a/core-grafana-concepts-lj/content.json
+++ b/core-grafana-concepts-lj/content.json
@@ -1,0 +1,11 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "core-grafana-concepts-lj",
+  "title": "Core Grafana concepts",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "Grafana helps you connect to many kinds of data, ask focused questions, shape the results, and present them in useful views. This learning path introduces the small set of concepts that make that workflow possible: data sources, queries, Explore, transformations, panels, dashboards, and alerting.\n\nYou'll follow the flow of data through Grafana—from a configured connection to a query result, then through optional transformations into a panel and dashboard, and finally into alert rules that notify people or systems when conditions require attention."
+    }
+  ]
+}

--- a/core-grafana-concepts-lj/dashboards/content.json
+++ b/core-grafana-concepts-lj/dashboards/content.json
@@ -1,0 +1,38 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "core-grafana-concepts-dashboards",
+  "title": "Dashboards",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "In this section, you'll learn how panels combine queries and visualizations, and how a dashboard organizes panels into a shareable view."
+    },
+    {
+      "type": "section",
+      "id": "understand-dashboards",
+      "title": "Understand panels and dashboards",
+      "autoCollapse": false,
+      "blocks": [
+        {
+          "type": "markdown",
+          "content": "A panel is the basic building block of a Grafana dashboard. It combines one or more queries, optional transformations, and a visualization in a single container—so a panel controls both what data is requested and how the result is presented. The visualization is the visual form inside the panel, such as a time series, stat, gauge, table, or heatmap, chosen to match the question and the shape of the data.\n\nA dashboard is a saved collection of one or more panels arranged to provide an at-a-glance view of related information. Panels can be grouped into rows or tabs, and the dashboard supplies shared context such as a time range, refresh behavior, variables, annotations, and links.\n\nA dashboard does not replace the systems that store the data. It coordinates data source connections, queries, transformations, panels, and visualizations into a reusable view that can be saved and shared. Folders help organize dashboards and provide an access-control boundary, but folder administration is a next-step topic rather than a prerequisite for understanding the dashboard itself."
+        },
+        {
+          "type": "image",
+          "src": "https://grafana.com/media/docs/grafana/dashboards/screenshot-edit-mode-imagemap-v13.1.png",
+          "alt": "Annotated Grafana dashboard edit mode showing the dashboard canvas, sidebar, and toolbar"
+        },
+        {
+          "type": "video",
+          "src": "https://www.youtube.com/embed/vTiIkdDwT-0",
+          "provider": "youtube",
+          "title": "Understanding dashboards in Grafana: panels, visualizations, queries, and transformations"
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "You learned that a panel combines queries, optional transformations, and a visualization, and that a dashboard is a saved, shareable collection of panels with shared context."
+    }
+  ]
+}

--- a/core-grafana-concepts-lj/dashboards/manifest.json
+++ b/core-grafana-concepts-lj/dashboards/manifest.json
@@ -1,0 +1,21 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "core-grafana-concepts-dashboards",
+  "type": "guide",
+  "description": "Learn how panels combine queries and visualizations and how dashboards organize panels into a shareable view.",
+  "category": "onboarding",
+  "author": {
+    "team": "Grafana Documentation"
+  },
+  "testEnvironment": {
+    "tier": "local"
+  },
+  "depends": [
+    "core-grafana-concepts-transformations"
+  ],
+  "recommends": [
+    "core-grafana-concepts-alerting"
+  ],
+  "suggests": [],
+  "provides": []
+}

--- a/core-grafana-concepts-lj/data-sources/content.json
+++ b/core-grafana-concepts-lj/data-sources/content.json
@@ -1,0 +1,38 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "core-grafana-concepts-data-sources",
+  "title": "Data sources",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "In this section, you'll learn how a data source connects Grafana to the system that holds your data."
+    },
+    {
+      "type": "section",
+      "id": "understand-data-sources",
+      "title": "Understand data sources",
+      "autoCollapse": false,
+      "blocks": [
+        {
+          "type": "markdown",
+          "content": "A data source is a configured connection between Grafana and a system that holds data, such as Prometheus, Loki, an SQL database, a cloud service, an API, or a file. In the normal query flow, the data remains in that external system. Grafana sends a query through the data source connection and receives results to explore, visualize, or evaluate.\n\nA data source plugin supplies the connection settings and the query editor for a particular technology. An administrator usually configures the connection and credentials once; authors then choose that data source in Explore, a panel, or an alert rule. This separation lets one Grafana instance work with many backends without requiring every backend to use the same query language or data model."
+        },
+        {
+          "type": "image",
+          "src": "https://grafana.com/media/docs/datasources/concepts-diagram-1.png",
+          "alt": "Diagram showing custom data source and integration paths for working with data in Grafana"
+        },
+        {
+          "type": "video",
+          "src": "https://www.youtube.com/embed/cqHO0oYW6Ic",
+          "provider": "youtube",
+          "title": "Adding data sources to Grafana (Loki, Tempo, and Mimir)"
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "You learned that a data source is Grafana's configured connection to an external backend and that its plugin provides the backend-specific query experience."
+    }
+  ]
+}

--- a/core-grafana-concepts-lj/data-sources/manifest.json
+++ b/core-grafana-concepts-lj/data-sources/manifest.json
@@ -1,0 +1,19 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "core-grafana-concepts-data-sources",
+  "type": "guide",
+  "description": "Learn how data source connections and plugins let Grafana query external systems.",
+  "category": "onboarding",
+  "author": {
+    "team": "Grafana Documentation"
+  },
+  "testEnvironment": {
+    "tier": "local"
+  },
+  "depends": [],
+  "recommends": [
+    "core-grafana-concepts-queries"
+  ],
+  "suggests": [],
+  "provides": []
+}

--- a/core-grafana-concepts-lj/end-journey/content.json
+++ b/core-grafana-concepts-lj/end-journey/content.json
@@ -1,0 +1,31 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "core-grafana-concepts-end-journey",
+  "title": "You understand the core Grafana concepts",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "In this section, you'll recap how the core concepts fit together and find links to keep learning."
+    },
+    {
+      "type": "section",
+      "id": "recap-core-concepts",
+      "title": "Recap and next steps",
+      "autoCollapse": false,
+      "blocks": [
+        {
+          "type": "markdown",
+          "content": "You've followed data through Grafana from end to end. A **data source** is the configured connection to a system that holds your data. A **query** asks that source a focused question, and **Explore** is where you iterate on queries before committing them. **Transformations** reshape the returned results in a defined order. A **panel** combines queries, optional transformations, and a **visualization**, and a **dashboard** organizes panels into a saved, shareable view. Finally, **alerting** evaluates the same data against conditions on a schedule and routes notifications to the right place when attention is needed.\n\nWith that flow in mind—source → query → transform → panel and dashboard → alert—you have the mental model that most Grafana features build on."
+        },
+        {
+          "type": "markdown",
+          "content": "**Next steps**\n\n- [Grafana fundamentals tutorial](https://grafana.com/tutorials/grafana-fundamentals/)\n- [Users, roles, and permissions](https://grafana.com/docs/grafana/latest/administration/roles-and-permissions/)\n- [Dashboard best practices](https://grafana.com/docs/grafana/latest/visualizations/dashboards/build-dashboards/best-practices/)"
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "You've reached the end of this learning path and have a working mental model of how data moves through Grafana."
+    }
+  ]
+}

--- a/core-grafana-concepts-lj/end-journey/manifest.json
+++ b/core-grafana-concepts-lj/end-journey/manifest.json
@@ -1,0 +1,19 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "core-grafana-concepts-end-journey",
+  "type": "guide",
+  "description": "Recap how data sources, queries, transformations, dashboards, and alerting fit together, with links to keep learning.",
+  "category": "onboarding",
+  "author": {
+    "team": "Grafana Documentation"
+  },
+  "testEnvironment": {
+    "tier": "local"
+  },
+  "depends": [
+    "core-grafana-concepts-alerting"
+  ],
+  "recommends": [],
+  "suggests": [],
+  "provides": []
+}

--- a/core-grafana-concepts-lj/manifest.json
+++ b/core-grafana-concepts-lj/manifest.json
@@ -1,0 +1,31 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "core-grafana-concepts-lj",
+  "type": "path",
+  "description": "Learn how Grafana connects to data, queries and transforms results, presents them in dashboards, and evaluates alert rules.",
+  "category": "onboarding",
+  "author": {
+    "team": "Grafana Documentation"
+  },
+  "startingLocation": "/a/grafana-pathfinder-app",
+  "targeting": {
+    "match": {
+      "urlPrefix": "/a/grafana-pathfinder-app"
+    }
+  },
+  "testEnvironment": {
+    "tier": "local"
+  },
+  "milestones": [
+    "core-grafana-concepts-data-sources",
+    "core-grafana-concepts-queries",
+    "core-grafana-concepts-transformations",
+    "core-grafana-concepts-dashboards",
+    "core-grafana-concepts-alerting",
+    "core-grafana-concepts-end-journey"
+  ],
+  "depends": [],
+  "recommends": [],
+  "suggests": [],
+  "provides": []
+}

--- a/core-grafana-concepts-lj/queries/content.json
+++ b/core-grafana-concepts-lj/queries/content.json
@@ -1,0 +1,38 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "core-grafana-concepts-queries",
+  "title": "Queries",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "In this section, you'll learn how a query asks a data source a focused question and how Explore helps you iterate on it."
+    },
+    {
+      "type": "section",
+      "id": "understand-queries",
+      "title": "Understand queries and Explore",
+      "autoCollapse": false,
+      "blocks": [
+        {
+          "type": "markdown",
+          "content": "A query is the question Grafana sends to a selected data source. The query's language and editor come from that data source plugin: Prometheus uses PromQL, Loki uses LogQL, SQL sources use SQL, and other plugins provide their own builders or code editors. The result is a focused dataset that Grafana can display, transform, or use in an alert rule.\n\nExplore is Grafana's workspace for ad hoc querying and investigation. It is a good place to iterate on a query, inspect raw results, and move between metrics, logs, traces, or profiles before deciding that a view deserves a permanent panel. A panel can retain one or more queries; Explore supports the discovery work that produces them."
+        },
+        {
+          "type": "image",
+          "src": "https://grafana.com/media/docs/grafana/panels-visualizations/screenshot-query-editor-imagemap-v13.1.png",
+          "alt": "Annotated Grafana panel query editor showing data source, query rows, options, and result controls"
+        },
+        {
+          "type": "video",
+          "src": "https://www.youtube.com/embed/1q3YzX2DDM4",
+          "provider": "youtube",
+          "title": "Exploring logs, metrics, and traces with Grafana"
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "You learned that a query is the question sent to a data source and that Explore is the workspace where you iterate on queries before committing them to a panel."
+    }
+  ]
+}

--- a/core-grafana-concepts-lj/queries/manifest.json
+++ b/core-grafana-concepts-lj/queries/manifest.json
@@ -1,0 +1,21 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "core-grafana-concepts-queries",
+  "type": "guide",
+  "description": "Learn how queries ask a data source a focused question and how Explore supports iteration.",
+  "category": "onboarding",
+  "author": {
+    "team": "Grafana Documentation"
+  },
+  "testEnvironment": {
+    "tier": "local"
+  },
+  "depends": [
+    "core-grafana-concepts-data-sources"
+  ],
+  "recommends": [
+    "core-grafana-concepts-transformations"
+  ],
+  "suggests": [],
+  "provides": []
+}

--- a/core-grafana-concepts-lj/transformations/content.json
+++ b/core-grafana-concepts-lj/transformations/content.json
@@ -1,0 +1,38 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "core-grafana-concepts-transformations",
+  "title": "Transformations",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "In this section, you'll learn how transformations reshape query results before a visualization uses them."
+    },
+    {
+      "type": "section",
+      "id": "understand-transformations",
+      "title": "Understand transformations",
+      "autoCollapse": false,
+      "blocks": [
+        {
+          "type": "markdown",
+          "content": "A transformation changes the data returned by one or more queries before a visualization uses it. Transformations can rename or filter fields, calculate new values, join results, reorganize tables, and perform other result-shaping work without changing the source system or its stored data.\n\nTransformations run in the order shown, so the output of one becomes the input to the next. Use them when a query result is correct but not yet in the form a panel needs—for example, joining two result sets or calculating a percentage. They complement source queries; they are not a reason to retrieve far more data than the view needs."
+        },
+        {
+          "type": "image",
+          "src": "https://grafana.com/media/docs/grafana/transformations/screenshot-grafana-11-2-transpose-transformation.png",
+          "alt": "Before-and-after example of a transpose transformation changing the shape of query results"
+        },
+        {
+          "type": "video",
+          "src": "https://www.youtube.com/embed/g1DXq_IuJ7I",
+          "provider": "youtube",
+          "title": "Transform data in a Grafana Cloud dashboard"
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "You learned that transformations reshape query results in a defined order, without changing the data stored in the source system."
+    }
+  ]
+}

--- a/core-grafana-concepts-lj/transformations/manifest.json
+++ b/core-grafana-concepts-lj/transformations/manifest.json
@@ -1,0 +1,21 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "core-grafana-concepts-transformations",
+  "type": "guide",
+  "description": "Learn how transformations reshape query results in a defined order before visualization.",
+  "category": "onboarding",
+  "author": {
+    "team": "Grafana Documentation"
+  },
+  "testEnvironment": {
+    "tier": "local"
+  },
+  "depends": [
+    "core-grafana-concepts-queries"
+  ],
+  "recommends": [
+    "core-grafana-concepts-dashboards"
+  ],
+  "suggests": [],
+  "provides": []
+}


### PR DESCRIPTION
## Intent

Author a NEW prose-only learning path 'core-grafana-concepts-lj/' teaching the core Grafana concepts, per an external research report + captain decisions. It doubles as a non-interactive Pathfinder test fixture. Structure: a cover (content.json + manifest.json type:path) plus SIX milestones in dependency build order: data-sources -> queries -> transformations -> dashboards -> alerting -> end-journey (conclusion). Deliberate decisions a reviewer should know: (1) There is intentionally NO Panels/visualizations module — the captain chose five concepts + conclusion; the panels/visualizations idea is bridged inline in the Dashboards module prose instead. (2) The second module is titled 'Queries' (not 'Queries and Explore'); Explore is described within its prose. (3) Each concept module intentionally contains exactly ONE non-empty all-passive 'section' (markdown + image + video only) — this is REQUIRED, because a 100%-passive section is exactly what makes Pathfinder render the 'Mark section as complete' button; it is the whole point of the fixture. Media (image/video) blocks are passive content and allowed inside the section. (4) NO interactive/guided/multistep/noop/quiz/input/terminal/code blocks anywhere — prose-only is a hard requirement. (5) Root manifest targeting.match.urlPrefix and startingLocation are both '/a/grafana-pathfinder-app' with NO targetPlatform clause (applies to both Cloud and OSS) — this is in-app targeting, deliberately not '/connections'. (6) NO website.yaml files are shipped at any level — this pathway is in-app only, not published to the Grafana website/Learning Hub; CI does not require website.yaml. The child-guide 'targeting not specified' warnings from the Pathfinder CLI are expected because targeting lives only on the root. (7) schemaVersion is exactly '1.1.0' everywhere (never legacy '1.0.0'). (8) All media URLs are absolute https docs images + youtube.com/embed URLs, each re-verified HTTP 200 and authored by Grafana; no substitutions were needed. (9) A '/core-grafana-concepts-lj/' entry was added to .github/CODEOWNERS matching the content/manifest owner set. (10) index.json is intentionally untouched (CI hard-fails on changes to it). Slug is '-lj' because repo issue #472 (the -lj->-lp rename) is still open on the default branch. Validated locally against the CI-pinned Pathfinder CLI (commit 342121e): all content passes validate --strict, all packages pass validate --package, repository and dependency-graph builds are clean with no cycles or unresolved milestones. This is a firstmate-authored draft PR; a separate human reviewer will merge it.

## What Changed

- Added a new prose-only learning path `core-grafana-concepts-lj/` with a `type:path` cover plus six milestones in dependency build order (data-sources → queries → transformations → dashboards → alerting → end-journey); each concept module contains exactly one all-passive section (markdown + image + video only) so Pathfinder renders the "Mark section as complete" affordance, doubling as a non-interactive test fixture.
- Configured in-app-only targeting on the root manifest (`targeting.match.urlPrefix` and `startingLocation` both `/a/grafana-pathfinder-app`, no `targetPlatform`), with `schemaVersion` 1.1.0 across all 14 JSON files, no interactive/guided/quiz/code blocks anywhere, and no `website.yaml` at any level.
- Added a `/core-grafana-concepts-lj/` owner entry to `.github/CODEOWNERS` and left `index.json` untouched.

## Risk Assessment

✅ Low: Additive, prose-only learning-path content with no executable code; every source-verifiable acceptance criterion in the intent is satisfied and the package structure (IDs, milestones, dependency chain, required fields) is internally consistent.

## Testing

Rebuilt the exact CI-pinned Pathfinder CLI (@342121e) from source and ran the full CI validation chain against the new path: validate --strict on all 7 content.json (all valid), validate --package on the cover and all 6 milestones (all PASS, with the expected child-only "targeting not specified" warnings), and build-repository + build-graph (both exit 0, new path resolves cleanly with no cycles or unresolved milestones). I independently confirmed every authoritative intent constraint — prose-only with no interactive blocks, exactly one non-empty all-passive section per concept module, schemaVersion 1.1.0 everywhere, root-only in-app targeting on /a/grafana-pathfinder-app with no targetPlatform, no website.yaml at any level, CODEOWNERS entry added, index.json untouched, -lj slug — and verified all 10 media URLs return HTTP 200. For reviewer-visible evidence I rendered the actual content prose and real media to HTML and captured screenshots showing the six modules and the green "Mark section as complete" button that a 100%-passive section produces (the fixture's whole point); this is a faithful content render rather than live Pathfinder app chrome because rendering the real surface needs a running Grafana + the Pathfinder plugin (an external repo, out of scope for this content-only repo) and the locally available app checkout is at a different commit than CI pins. The YouTube frames in the screenshots show "Error 153" — that is YouTube refusing playback inside a file:// iframe in headless Chrome, not a broken link; every embed URL returned HTTP 200 in the separate curl check. Overall: all targeted validation passed and the user intent is demonstrably satisfied.

<details>
<summary>Evidence: Intent verification checklist (all 10 constraints PASS)</summary>

```text
# core-grafana-concepts-lj — intent verification (test phase)

Validated with the CI-pinned Pathfinder CLI (grafana-pathfinder-app @ 342121e), built fresh from source.

| # | Intent constraint | Result |
|---|-------------------|--------|
| structure | cover (content.json + manifest type:path) + 6 milestones in build order | PASS — data-sources→queries→transformations→dashboards→alerting→end-journey |
| 1 | NO Panels module; panels bridged in Dashboards prose | PASS — 5 concepts + conclusion; dashboards section "Understand panels and dashboards" |
| 2 | 2nd module titled "Queries" (not "Queries and Explore"); Explore in prose | PASS — title "Queries"; Explore described in section prose |
| 3 | each concept module = exactly ONE non-empty all-passive section (md+img+video) | PASS — 5/5 modules, childTypes=[markdown,image,video] |
| 4 | NO interactive/guided/multistep/noop/quiz/input/terminal/code blocks | PASS — none found anywhere |
| 5 | root urlPrefix & startingLocation both /a/grafana-pathfinder-app, no targetPlatform | PASS — verified in root manifest.json |
| 6 | NO website.yaml anywhere; child "targeting not specified" warns expected | PASS — 0 website.yaml; each child emits 1 targeting warning, root emits 0 |
| 7 | schemaVersion exactly 1.1.0 everywhere | PASS — all 14 JSON files |
| 8 | media URLs absolute https docs images + youtube.com/embed, all HTTP 200 | PASS — 10/10 return 200 |
| 9 | /core-grafana-concepts-lj/ entry added to CODEOWNERS | PASS — @chri2547 @tacole02 @moxious @Jayclifford345 @tomglenn |
| 10 | index.json untouched | PASS — not in diff |
| slug | slug is -lj (issue #472 rename still open) | PASS |
| CLI | validate --strict (content), validate --package, build-repository, build-graph clean | PASS — no cycles, no unresolved milestones, build-graph exit 0 |

Note on visual evidence: the "Error 153 / Video player configuration error" seen in the YouTube
frames of the screenshots is YouTube refusing playback inside a file:// origin iframe in headless
Chrome (embed-origin restriction), NOT a broken URL. All 5 embed URLs independently returned HTTP 200
(see 04-media-urls-http-status.txt).
```
</details>
- Evidence: Rendered content preview — cover + Data sources module with all-passive section (real grafana.com diagram) (local file: <code>/var/folders/hg/34vhzxxj0xd92_m7gnjz5zrw0000gn/T/no-mistakes-evidence/01KYVS7R3EEBE6ZZGK2EX78EY8/content-preview-top.png</code>)
- Evidence: Rendered content preview — &#39;Mark section as complete&#39; button at end of all-passive section + Queries/Explore module (local file: <code>/var/folders/hg/34vhzxxj0xd92_m7gnjz5zrw0000gn/T/no-mistakes-evidence/01KYVS7R3EEBE6ZZGK2EX78EY8/content-preview-section-markcomplete.png</code>)
<details>
<summary>Evidence: Self-contained HTML render of the content.json prose + real media</summary>

```text
<!doctype html><html><head><meta charset="utf-8"><title>Core Grafana concepts — content preview</title>
<style>
body{background:#0b0c0e;color:#d8d9da;font:15px/1.6 -apple-system,Segoe UI,Roboto,sans-serif;margin:0;padding:24px 0}
.wrap{max-width:820px;margin:0 auto;padding:0 24px}
.note{background:#1f2226;border:1px solid #33383e;border-radius:6px;padding:10px 14px;color:#9aa0a6;font-size:12.5px;margin-bottom:24px}
h1{color:#fff;font-size:28px;border-bottom:2px solid #f55f3e;padding-bottom:8px}
.mod{background:#141619;border:1px solid #2c3235;border-radius:8px;padding:18px 22px;margin:20px 0}
.mod>h2{color:#f55f3e;margin:0 0 4px;font-size:20px}
.mid{color:#6e7681;font-size:12px;font-family:monospace;margin-bottom:10px}
.section{border:1px dashed #f55f3e66;border-radius:6px;padding:12px 16px;margin:14px 0;background:#0f1113}
.sechdr{margin-bottom:8px}
.badge{background:#f55f3e;color:#111;font-size:10px;font-weight:700;padding:2px 6px;border-radius:3px}
.passive{color:#7fd18b;font-size:11.5px}
.markbtn{margin-top:12px;display:inline-block;background:#1a7f37;color:#fff;padding:7px 14px;border-radius:5px;font-weight:600;font-size:13px}
a{color:#6cb2 f0;color:#6cb2f0}
figure{margin:14px 0}
img{max-width:100%;border:1px solid #2c3235;border-radius:6px}
.vid iframe{width:100%;height:400px;border:0;border-radius:6px}
figcaption{color:#6e7681;font-size:11.5px;margin-top:4px}
strong{color:#fff}
</style></head><body><div class="wrap">
<div class="note">⚠️ Reviewer note: this is a <b>faithful static render of the content.json prose + real media</b> (markdown→HTML, actual grafana.com images and YouTube embeds). It is <b>not</b> the Pathfinder app chrome. The green “Mark section as complete” affordance is annotated to show where Pathfinder renders it for a 100%-passive section — the fixture's stated purpose.</div>
<h1>Core Grafana concepts</h1><p>Grafana helps you connect to many kinds of data, ask focused questions, shape the results, and present them in useful views. This learning path introduces the small set of concepts that make that workflow possible: data sources, queries, Explore, transformations, panels, dashboards, and alerting.</p>
<p>You'll follow the flow of data through Grafana—from a configured connection to a query result, then through optional transformations into a panel and dashboard, and finally into alert rules that notify people or systems when conditions require attention.</p><div class="mod"><h2>Data sources</h2><div class="mid">core-grafana-concepts-data-sources · schemaVersion 1.1.0</div><p>In this section, you'll learn how a data source connects Grafana to the system that holds your data.</p>
<div class="section"><div class="sechdr"><span class="badge">SECTION</span> <strong>Understand data sources</strong> <span class="passive">100% passive → renders “Mark section as complete”</span></div><p>A data source is a configured connection between Grafana and a system that holds data, such as Prometheus, Loki, an SQL database, a cloud service, an API, or a file. In the normal query flow, the data remains in that external system. Grafana sends a query through the data source connection and receives results to explore, visualize, or evaluate.</p>
<p>A data source plugin supplies the connection settings and the query editor for a particular technology. An administrator usually configures the connection and credentials once; authors then choose that data source in Explore, a panel, or an alert rule. This separation lets one Grafana instance work with many backends without requiring every backend to use the same query language or data model.</p>
<figure><img src="https://grafana.com/media/docs/datasources/concepts-diagram-1.png" alt="Diagram showing custom data source and integration paths for working with data in Grafana"><figcaption>image · Diagram showing custom data source and integration paths for working with data in Grafana</figcaption></figure>
<figure class="vid"><iframe src="https://www.youtube.com/embed/cqHO0oYW6Ic" allowfullscreen loading="lazy"></iframe><figcaption>video · Adding data sources to Grafana (Loki, Tempo, and Mimir)</figcaption></figure><div class="markbtn">✓ Mark section as complete</div></div>
<p>You learned that a data source is Grafana's configured connection to an external backend and that its plugin provides the backend-specific query experience.</p></div><div class="mod"><h2>Queries</h2><div class="mid">core-grafana-concepts-queries · schemaVersion 1.1.0</div><p>In this section, you'll learn how a query asks a data source a focused question and how Explore helps you iterate on it.</p>
<div class="section"><div class="sechdr"><span class="badge">SECTION</span> <strong>Understand queries and Explore</strong> <span class="passive">100% passive → renders “Mark section as complete”</span></div><p>A query is the question Grafana sends to a selected data source. The query's language and editor come from that data source plugin: Prometheus uses PromQL, Loki uses LogQL, SQL sources use SQL, and other plugins provide their own builders or code editors. The result is a focused dataset that Grafana can display, transform, or use in an alert rule.</p>
<p>Explore is Grafana's workspace for ad hoc querying and investigation. It is a good place to iterate on a query, inspect raw results, and move between metrics, logs, traces, or profiles before deciding that a view deserves a permanent panel. A panel can retain one or more queries; Explore supports the discovery work that produces them.</p>
<figure><img src="https://grafana.com/media/docs/grafana/panels-visualizations/screenshot-query-editor-imagemap-v13.1.png" alt="Annotated Grafana panel query editor showing data source, query rows, options, and result controls"><figcaption>image · Annotated Grafana panel query editor showing data source, query rows, options, and result controls</figcaption></figure>
<figure class="vid"><iframe src="https://www.youtube.com/embed/1q3YzX2DDM4" allowfullscreen loading="lazy"></iframe><figcaption>video · Exploring logs, metrics, and traces with Grafana</figcaption></figure><div class="markbtn">✓ Mark section as complete</div></div>
<p>You learned that a query is the question sent to a data source and that Explore is the workspace where you iterate on queries before committing them to a panel.</p></div><div class="mod"><h2>Transformations</h2><div class="mid">core-grafana-concepts-transformations · schemaVersion 1.1.0</div><p>In this section, you'll learn how transformations reshape query results before a visualization uses them.</p>
<div class="section"><div class="sechdr"><span class="badge">SECTION</span> <strong>Understand transformations</strong> <span class="passive">100% passive → renders “Mark section as complete”</span></div><p>A transformation changes the data returned by one or more queries before a visualization uses it. Transformations can rename or filter fields, calculate new values, join results, reorganize tables, and perform other result-shaping work without changing the source system or its stored data.</p>
<p>Transformations run in the order shown, so the output of one becomes the input to the next. Use them when a query result is correct but not yet in the form a panel needs—for example, joining two result sets or calculating a percentage. They complement source queries; they are not a reason to retrieve far more data than the view needs.</p>
<figure><img src="https://grafana.com/media/docs/grafana/transformations/screenshot-grafana-11-2-transpose-transformation.png" alt="Before-and-after example of a transpose transformation changing the shape of query results"><figcaption>image · Before-and-after example of a transpose transformation changing the shape of query results</figcaption></figure>
<figure class="vid"><iframe src="https://www.youtube.com/embed/g1DXq_IuJ7I" allowfullscreen loading="lazy"></iframe><figcaption>video · Transform data in a Grafana Cloud dashboard</figcaption></figure><div class="markbtn">✓ Mark section as complete</div></div>
<p>You learned that transformations reshape query results in a defined order, without changing the data stored in the source system.</p></div><div class="mod"><h2>Dashboards</h2><div class="mid">core-grafana-concepts-dashboards · schemaVersion 1.1.0</div><p>In this section, you'll learn how panels combine queries and visualizations, and how a dashboard organizes panels into a shareable view.</p>
<div class="section"><div class="sechdr"><span class="badge">SECTION</span> <strong>Understand panels and dashboards</strong> <span class="passive">100% passive → renders “Mark section as complete”</span></div><p>A panel is the basic building block of a Grafana dashboard. It combines one or more queries, optional transformations, and a visualization in a single container—so a panel controls both what data is requested and how the result is presented. The visualization is the visual form inside the panel, such as a time series, stat, gauge, table, or heatmap, chosen to match the question and the shape of the data.</p>
<p>A dashboard is a saved collection of one or more panels arranged to provide an at-a-glance view of related information. Panels can be grouped into rows or tabs, and the dashboard supplies shared context such as a time range, refresh behavior, variables, annotations, and links.</p>
<p>A dashboard does not replace the systems that store the data. It coordinates data source connections, queries, transformations, panels, and visualizations into a reusable view that can be saved and shared. Folders help organize dashboards and provide an access-control boundary, but folder administration is a next-step topic rather than a prerequisite for understanding the dashboard itself.</p>
<figure><img src="https://grafana.com/media/docs/grafana/dashboards/screenshot-edit-mode-imagemap-v13.1.png" alt="Annotated Grafana dashboard edit mode showing the dashboard canvas, sidebar, and toolbar"><figcaption>image · Annotated Grafana dashboard edit mode showing the dashboard canvas, sidebar, and toolbar</figcaption></figure>
<figure class="vid"><iframe src="https://www.youtube.com/embed/vTiIkdDwT-0" allowfullscreen loading="lazy"></iframe><figcaption>video · Understanding dashboards in Grafana: panels, visualizations, queries, and transformations</figcaption></figure><div class="markbtn">✓ Mark section as complete</div></div>
<p>You learned that a panel combines queries, optional transformations, and a visualization, and that a dashboard is a saved, shareable collection of panels with shared context.</p></div><div class="mod"><h2>Alerting</h2><div class="mid">core-grafana-concepts-alerting · schemaVersion 1.1.0</div><p>In this section, you'll learn how Grafana Alerting evaluates rules and routes notifications when conditions require attention.</p>
<div class="section"><div class="sechdr"><span class="badge">SECTION</span> <strong>Understand alerting</strong> <span class="passive">100% passive → renders “Mark section as complete”</span></div><p>Grafana Alerting continuously evaluates alert rules so important conditions do not depend on someone watching a dashboard. An alert rule contains one or more queries or expressions, a condition, and an evaluation schedule. When the condition is met, each distinct set of labels can produce an alert instance that moves through states such as pending and firing.</p>
<p>Alerting uses the same data-source layer as queries and panels, but it is not a visual property of a dashboard. Notification policies route alert instances by labels and other matchers, while contact points define destinations such as email, Slack, or an incident-management system. Dashboards help people understand a situation; alerting decides when the situation needs attention and sends it to the right place.</p>
<figure><img src="https://grafana.com/media/docs/alerting/alerting-configure-notifications-v2.png" alt="Diagram showing alert rule evaluation, alert instances, notification policies, and contact points"><figcaption>image · Diagram showing alert rule evaluation, alert instances, notification policies, and contact points</figcaption></figure>
<figure class="vid"><iframe src="https://www.youtube.com/embed/6W8Nu4b_PXM" allowfullscreen loading="lazy"></iframe><figcaption>video · Creating alerts with Grafana</figcaption></figure><div class="markbtn">✓ Mark section as complete</div></div>
<p>You learned that an alert rule evaluates queries against a condition on a schedule, and that notification policies and contact points route firing alerts to the right destination.</p></div><div class="mod"><h2>You understand the core Grafana concepts</h2><div class="mid">core-grafana-concepts-end-journey · schemaVersion 1.1.0</div><p>In this section, you'll recap how the core concepts fit together and find links to keep learning.</p>
<div class="section"><div class="sechdr"><span class="badge">SECTION</span> <strong>Recap and next steps</strong> <span class="passive">100% passive → renders “Mark section as complete”</span></div><p>You've followed data through Grafana from end to end. A <strong>data source</strong> is the configured connection to a system that holds your data. A <strong>query</strong> asks that source a focused question, and <strong>Explore</strong> is where you iterate on queries before committing them. <strong>Transformations</strong> reshape the returned results in a defined order. A <strong>panel</strong> combines queries, optional transformations, and a <strong>visualization</strong>, and a <strong>dashboard</strong> organizes panels into a saved, shareable view. Finally, <strong>alerting</strong> evaluates the same data against conditions on a schedule and routes notifications to the right place when attention is needed.</p>
<p>With that flow in mind—source → query → transform → panel and dashboard → alert—you have the mental model that most Grafana features build on.</p>
<p><strong>Next steps</strong></p>
<ul><li><a href="https://grafana.com/tutorials/grafana-fundamentals/">Grafana fundamentals tutorial</a></li><li><a href="https://grafana.com/docs/grafana/latest/administration/roles-and-permissions/">Users, roles, and permissions</a></li><li><a href="https://grafana.com/docs/grafana/latest/visualizations/dashboards/build-dashboards/best-practices/">Dashboard best practices</a></li></ul><div class="markbtn">✓ Mark section as complete</div></div>
<p>You've reached the end of this learning path and have a working mental model of how data moves through Grafana.</p></div></div></body></html>
```
</details>
<details>
<summary>Evidence: CLI validate --package results (cover PASS 0 targeting-warns; 6 children PASS 1 expected targeting-warn each)</summary>

<code>core-grafana-concepts-lj -&gt; ✅ PASS (targeting-not-specified warnings: 0)&#10;data-sources/queries/transformations/dashboards/alerting/end-journey -&gt; ✅ PASS (1 each — expected, targeting lives on root only)</code>

```text
# validate --package on cover + 6 milestones (child 'targeting not specified' WARN is expected — targeting lives on root only)
  core-grafana-concepts-lj -> ✅ PASS  (targeting-not-specified warnings: 0)
  core-grafana-concepts-lj/data-sources -> ✅ PASS  (targeting-not-specified warnings: 1)
  core-grafana-concepts-lj/queries -> ✅ PASS  (targeting-not-specified warnings: 1)
  core-grafana-concepts-lj/transformations -> ✅ PASS  (targeting-not-specified warnings: 1)
  core-grafana-concepts-lj/dashboards -> ✅ PASS  (targeting-not-specified warnings: 1)
  core-grafana-concepts-lj/alerting -> ✅ PASS  (targeting-not-specified warnings: 1)
  core-grafana-concepts-lj/end-journey -> ✅ PASS  (targeting-not-specified warnings: 1)
```
</details>
<details>
<summary>Evidence: build-repository + build-graph: new path resolves clean, no cycles/unresolved milestones, exit 0</summary>

```text
# Repository + dependency-graph build (CI-pinned Pathfinder CLI @342121e)
✅ Wrote repository.json to /tmp/repository.json (545 packages)
build-graph exit code: 0

## Warnings referencing the new path (expect NONE = clean resolution, no cycles/unresolved milestones):
  (none — new path resolved with zero warnings)

## New-path dependency edges emitted into the graph:
   core-grafana-concepts-lj	 core-grafana-concepts-data-sources
   core-grafana-concepts-lj	 core-grafana-concepts-queries
   core-grafana-concepts-lj	 core-grafana-concepts-transformations
   core-grafana-concepts-lj	 core-grafana-concepts-dashboards
   core-grafana-concepts-lj	 core-grafana-concepts-alerting
   core-grafana-concepts-lj	 core-grafana-concepts-end-journey
   core-grafana-concepts-alerting	 core-grafana-concepts-dashboards
   core-grafana-concepts-alerting	 core-grafana-concepts-end-journey
   core-grafana-concepts-dashboards	 core-grafana-concepts-transformations
   core-grafana-concepts-dashboards	 core-grafana-concepts-alerting
   core-grafana-concepts-data-sources	 core-grafana-concepts-queries
   core-grafana-concepts-end-journey	 core-grafana-concepts-alerting
   core-grafana-concepts-queries	 core-grafana-concepts-data-sources
   core-grafana-concepts-queries	 core-grafana-concepts-transformations
   core-grafana-concepts-transformations	 core-grafana-concepts-queries
   core-grafana-concepts-transformations	 core-grafana-concepts-dashboards

  total-repo "nodeCount": 546,
  total-repo "edgeCount": 1292
```
</details>
<details>
<summary>Evidence: Media URL HTTP status — 10/10 return 200</summary>

```text
# Media URL HTTP status (intent point 8: absolute https docs images + youtube.com/embed, all 200)
  200  https://grafana.com/media/docs/alerting/alerting-configure-notifications-v2.png
  200  https://grafana.com/media/docs/datasources/concepts-diagram-1.png
  200  https://grafana.com/media/docs/grafana/dashboards/screenshot-edit-mode-imagemap-v13.1.png
  200  https://grafana.com/media/docs/grafana/panels-visualizations/screenshot-query-editor-imagemap-v13.1.png
  200  https://grafana.com/media/docs/grafana/transformations/screenshot-grafana-11-2-transpose-transformation.png
  200  https://www.youtube.com/embed/1q3YzX2DDM4
  200  https://www.youtube.com/embed/6W8Nu4b_PXM
  200  https://www.youtube.com/embed/cqHO0oYW6Ic
  200  https://www.youtube.com/embed/g1DXq_IuJ7I
  200  https://www.youtube.com/embed/vTiIkdDwT-0
```
</details>
<details>
<summary>Evidence: Block-structure proof — prose-only, one all-passive section per concept module</summary>

```text
# Block-structure proof (prose-only; each concept module = exactly ONE non-empty all-passive section)
  [data-sources] title="Data sources"
     top-level=[markdown, section, markdown]  sections=1
     section#understand-data-sources childTypes=[markdown, image, video]  all-passive=true  non-empty=true
  [queries] title="Queries"
     top-level=[markdown, section, markdown]  sections=1
     section#understand-queries childTypes=[markdown, image, video]  all-passive=true  non-empty=true
  [transformations] title="Transformations"
     top-level=[markdown, section, markdown]  sections=1
     section#understand-transformations childTypes=[markdown, image, video]  all-passive=true  non-empty=true
  [dashboards] title="Dashboards"
     top-level=[markdown, section, markdown]  sections=1
     section#understand-dashboards childTypes=[markdown, image, video]  all-passive=true  non-empty=true
  [alerting] title="Alerting"
     top-level=[markdown, section, markdown]  sections=1
     section#understand-alerting childTypes=[markdown, image, video]  all-passive=true  non-empty=true
  [end-journey] title="You understand the core Grafana concepts"
     top-level=[markdown, section, markdown]  sections=1
     section#recap-core-concepts childTypes=[markdown, markdown]  all-passive=true  non-empty=true
  Forbidden block types (interactive/guided/multistep/noop/quiz/input/terminal/code): NONE found anywhere
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Built CI-pinned Pathfinder CLI from source: git clone @342121e6ef884afeddcc680f2a8f6ca60b687488, `npm ci`, `npm run build:cli`</code>
- <code>`validate --strict` on all 7 content.json files (CI&#39;s content-validation step) — all valid</code>
- <code>`validate --package` on core-grafana-concepts-lj + data-sources/queries/transformations/dashboards/alerting/end-journey — all PASS; root 0 targeting warnings, each child exactly 1 (expected)</code>
- <code>`build-repository . --exclude pathfinder-app --exclude shared` (545 packages) then `build-graph interactive-tutorials:repository.json` — both exit 0, new path has zero warnings/cycles/unresolved milestones</code>
- `curl -I on all 10 media src URLs (5 grafana.com docs images + 5 youtube.com/embed) — all HTTP 200`
- `Node script analysis of block types: verified prose-only (no forbidden blocks), exactly one non-empty all-passive section per concept module, schemaVersion 1.1.0 on all 14 JSON files`
- `Rendered content.json prose+media to HTML and screenshotted via chrome-devtools-axi, capturing the 'Mark section as complete' affordance and loaded grafana.com images`
- `git diff checks: CODEOWNERS entry added, index.json untouched, no website.yaml files`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
