### PR TITLE
Surface multi-path LP packages and copy-chip checks in review/preflight

### DIFF
--- a/.cursor/commands/create-learning-path/README.md
+++ b/.cursor/commands/create-learning-path/README.md
@@ -26,7 +26,7 @@ Follow these phases in order:
 6. **Generate manifests.** Create `manifest.json` for the path (`type: "path"`, milestones array, targeting) and each milestone (`type: "guide"`, depends/recommends chain). Refer to `docs/manifest-reference.md`. Where fields can't be derived, ask the user to provide values before generating.
 7. **Discover selectors.** Use Playwright at `learn.grafana.net` to find stable CSS selectors for each interactive element. The user must log in through the Playwright browser window (Okta SAML).
 8. **Test in Pathfinder.** Tell the user which `content.json` to import into the Block Editor at `learn.grafana.net/?pathfinder-dev=true`. Wait for their feedback on each "Show me" / "Do it" button. Fix broken selectors based on their reports.
-9. **Verify and wrap up.** Cross-check all factual claims against live docs. Update `.github/CODEOWNERS`. Provide a summary of all files created.
+9. **Verify and wrap up.** Cross-check all factual claims against live docs. Scan prose for illustrative backticks (copy chips; smell #17). Update `.github/CODEOWNERS`. Provide a summary of all files created.
 
 For background on how this command relates to `/build-interactive-lj`, refer to `.cursor/learning-path-workflows/workflows.md`.
 
@@ -56,6 +56,7 @@ For background on how this command relates to `/build-interactive-lj`, refer to 
 - Never use data-dependent selectors — use `^=` starts-with patterns
 - Never leave placeholder selectors (`"[selector]"`, `"TODO"`)
 - All links in content.json must be absolute URLs (`https://grafana.com/docs/...`), not relative
+- Backticks render copy chips. Use them only for values the learner should paste. Illustrative examples (folder names, branches, URL fragments) stay plain text. See best-practices smell #17.
 
 ---
 

--- a/.cursor/commands/preflight-learning-path.md
+++ b/.cursor/commands/preflight-learning-path.md
@@ -31,6 +31,6 @@ LP packages are **single-repo** (`interactive-tutorials` only). Metadata lives i
 >
 > Preflight reports stay under `.cursor/lp-preflight-state/` (gitignored). Don't force-add them to your PR.
 >
-> **To start:** Share the path package (`{slug}-lj/` directory), or tell me to infer it from your current branch. If you already named the path, I'll begin the static checks now.
+> **To start:** Share the path package (`{slug}-lj/` directory), or tell me to infer it from your current branch. If you already named the path, I'll begin the static checks now. If this branch also has other `*-lj` packages, I'll list them so you know this run covers only the path you named.
 
 If the path is already clear from the user message, skip asking and start identify + static immediately.

--- a/.cursor/commands/review-learning-path-pr.md
+++ b/.cursor/commands/review-learning-path-pr.md
@@ -16,7 +16,7 @@ LP PRs are **single-repo** (`interactive-tutorials` only). Metadata lives in pac
 >
 > | Phase | What happens |
 > |---|---|
-> | 0 | Check out the PR |
+> | 0 | Check out the PR and list every `*-lj` package it touches |
 > | 1 | Static pass (audit + path checks → internal workbook) |
 > | 2 | Live test (required Playwright DOM check + Block Editor smoke test per milestone) |
 > | 3 | Draft comments + summary in chat; you approve before posting |

--- a/.cursor/skills/preflight-learning-path/SKILL.md
+++ b/.cursor/skills/preflight-learning-path/SKILL.md
@@ -205,8 +205,13 @@ Mention once (early, not every pause): reports land under `.cursor/lp-preflight-
 3. Infer `website_slug` = `{path_dir}` minus `-lj` when website repo is in workspace (read-only).
 4. Infer `path_type`: `new`, `conversion`, or `update` per [path type](reference-checks.md#path-type).
 5. List milestones from path `manifest.json` `milestones` and dirs under `{path_dir}/`.
-6. **Verify Playwright MCP** (`user-playwright`). Cover missing, needs-auth, toggled-off, **and configured-but-broken** per [If Playwright MCP is missing or broken](author-testing.md#if-playwright-mcp-is-missing-or-broken). Do not silently skip. Do not edit `mcp.json` until they agree.
-7. Write `.cursor/lp-preflight-state/{slug}.json` ([state schema](reference-checks.md#state-file-schema)).
+6. **Inventory sibling `*-lj` packages on this branch** (required). Diff against the merge base with `main` (or `master`):
+   ```bash
+   git diff --name-only origin/main...HEAD | awk -F/ '/-lj\// {print $1}' | sort -u
+   ```
+   Also include untracked top-level `*-lj` dirs (`git status --porcelain`). Store as `paths_on_branch`. Set `other_paths` = that list minus `{path_dir}`. If `other_paths` is non-empty, tell the author once in plain language that this branch also has those packages and that preflight covers only `{path_dir}` unless they expand. See [Multi-path branches](reference-checks.md#multi-path-branches).
+7. **Verify Playwright MCP** (`user-playwright`). Cover missing, needs-auth, toggled-off, **and configured-but-broken** per [If Playwright MCP is missing or broken](author-testing.md#if-playwright-mcp-is-missing-or-broken). Do not silently skip. Do not edit `mcp.json` until they agree.
+8. Write `.cursor/lp-preflight-state/{slug}.json` ([state schema](reference-checks.md#state-file-schema)), including `paths_on_branch` and `other_paths`.
 
 If MCP is blocked, stop with the blocked shape in author-testing.md (`checkpoint: identify`). Do not run live later until tools work.
 
@@ -222,7 +227,7 @@ If MCP is blocked, stop with the blocked shape in author-testing.md (`checkpoint
 
 1. Snapshot `pre_review_assets`; dispatch [audit-guide](../audit-guide/SKILL.md) per milestone (parallel OK).
 2. Walk shared [review reference-checks](../review-learning-path/reference-checks.md) + [learning-hub-standards.md](../review-learning-path/learning-hub-standards.md).
-3. **Always scan** for framing-in-milestones, [section intro markdown that may number as a step](../review-learning-path/reference-checks.md#section-intro-markdown-numbered-as-a-step), and [false noops](../review-learning-path/reference-checks.md#noop-and-non-interactive-steps).
+3. **Always scan** for framing-in-milestones, [section intro markdown that may number as a step](../review-learning-path/reference-checks.md#section-intro-markdown-numbered-as-a-step), [false noops](../review-learning-path/reference-checks.md#noop-and-non-interactive-steps), and [backticks / copy chips](../review-learning-path/reference-checks.md#backticks--copy-chips-smell-17).
 4. Run Pathfinder CLI `validate --packages {path_dir}` if available.
 5. Run the shared [claim-check](../review-learning-path/claim-check.md) pass (preflight pointer: [claim-check.md](claim-check.md)). Write `{slug}-claim-check.md`. Route Contradicted / Unsupported / Overstated as Fix before PR. Do not edit package JSON here.
 6. Tag findings with review [finding routing](../review-learning-path/reference-checks.md#finding-routing). Keep only review-level items for later author chat.

--- a/.cursor/skills/preflight-learning-path/reference-checks.md
+++ b/.cursor/skills/preflight-learning-path/reference-checks.md
@@ -84,9 +84,12 @@ Apply every section from [../review-learning-path/reference-checks.md](../review
 - Supplementary content
 - Legacy website source (conversion, read-only)
 - noop and non-interactive steps
+- backticks / copy chips (smell #17)
 - CODEOWNERS (discard for author chat)
 
 Then run shared [claim-check.md](../review-learning-path/claim-check.md) across path root + milestone prose. Route Contradicted / Unsupported / Overstated as Fix before PR. Hide Supported from chat. Author-decides items may appear in readiness as open questions.
+
+Illustrative backtick / copy-chip hits are **Fix before PR** (same bar as review post-inline). Paste-justified backticks matching `targetvalue` stay out of author chat.
 
 Tag each finding; keep only post-inline for author-facing output.
 
@@ -101,6 +104,17 @@ Infer from branch diff, directory age, and legacy website source. Record in `{sl
 | **new** | New `{slug}-lj/`; no legacy website folder | Full Playwright; `website.yaml` + path root completeness |
 | **conversion** | Built via `/build-interactive-lj`; prose-heavy | Legacy prose captured in package; Playwright full path |
 | **update** | Changes existing package only | Touched interactive milestones first |
+
+---
+
+## Multi-path branches
+
+A branch can carry more than one `{slug}-lj/` package. Authors who preflight only the path they have open often ship untested siblings (same failure mode as multi-path PR reviews).
+
+1. During identify, build `paths_on_branch` (diff vs `origin/main` plus untracked `*-lj` dirs). Persist `other_paths`.
+2. Tell the author once when siblings exist. Preflight still runs on `{path_dir}` only unless they ask to expand.
+3. In the readiness / results summary, list each package in `other_paths` under a short **Not preflighted on this run** note so they do not open a multi-path PR thinking one pass covered everything.
+4. Mirror: [review multi-path PRs](../review-learning-path/reference-checks.md#multi-path-prs).
 
 ---
 
@@ -174,6 +188,8 @@ Path: `.cursor/lp-preflight-state/{slug}.json`
   "slug": "monitor-azure-resources-lj",
   "website_slug": "monitor-azure-resources",
   "path_type": "conversion",
+  "paths_on_branch": ["monitor-azure-resources-lj"],
+  "other_paths": [],
   "branch": "docs/my-path",
   "head_commit": "abc123",
   "learn_host": "learn.grafana.net",
@@ -194,6 +210,8 @@ Path: `.cursor/lp-preflight-state/{slug}.json`
 
 | Field | Notes |
 |---|---|
+| `paths_on_branch` | Every `*-lj` package touched on this branch (diff + untracked) |
+| `other_paths` | `paths_on_branch` minus `path_dir` (siblings not in this preflight) |
 | `smoke_mode` | `already-tested` \| `walk-me` \| `skip-smoke` \| null |
 | `smoke_notes` | Author notes for already-tested / skip |
 | `pathfinder` | Only when `walk-me`; keys = milestone slug |

--- a/.cursor/skills/review-learning-path/SKILL.md
+++ b/.cursor/skills/review-learning-path/SKILL.md
@@ -124,7 +124,7 @@ If `.cursor/pr-review-state/pr-{n}.json` exists:
 
 ## Phase 0: Setup
 
-**Goal:** Checkout PR, infer path, init state.
+**Goal:** Checkout PR, inventory every learning path package the PR touches, infer the path under review, init state.
 
 ### Tell the reviewer
 
@@ -135,14 +135,33 @@ If `.cursor/pr-review-state/pr-{n}.json` exists:
 ### Agent steps
 
 1. `gh pr view` + `gh pr checkout`
-2. Infer `{path_dir}`, `website_slug`, `pr_type`
-3. Write `pr-{n}.json` with `pull_request_node_id` ([github-review.md](github-review.md))
+2. **Inventory every `*-lj` package touched by the PR** (required). Diff against the PR base:
+   ```bash
+   gh pr diff {n} --name-only | awk -F/ '/-lj\// {print $1}' | sort -u
+   ```
+   Store the full list as `paths_in_pr`. If empty, fall back to top-level `*-lj` dirs present on the branch that differ from base (`git diff --name-only origin/{base}...HEAD`).
+3. Infer primary `{path_dir}` (and `website_slug`, `pr_type`). If `paths_in_pr` has more than one entry and the reviewer did not name a path, **stop and ask** which path to review first. Set `other_paths` = `paths_in_pr` minus `{path_dir}`.
+4. Write `pr-{n}.json` with `pull_request_node_id`, `paths_in_pr`, `other_paths` ([github-review.md](github-review.md))
+
+**Multi-path rule:** One review cycle covers **one** `{path_dir}`. Sibling packages in `other_paths` stay out of Phase 1–2 unless the reviewer expands scope. They must still appear in the Phase 0 checkpoint and in the Phase 3 **Not live-tested** list (as whole packages). See [Multi-path PRs](reference-checks.md#multi-path-prs).
 
 ### Checkpoint
+
+When `other_paths` is empty:
 
 > **Phase 0 complete** — PR #{n} on `{head_branch}` @ `{short_sha}`, path `{path_dir}` ({M} milestones), type `{pr_type}`.
 >
 > **Your turn:** Reply **yes** to start the static pass.
+
+When `other_paths` is non-empty:
+
+> **Phase 0 complete** — PR #{n} on `{head_branch}` @ `{short_sha}`, reviewing `{path_dir}` ({M} milestones), type `{pr_type}`.
+>
+> **This PR also includes other learning paths (not in this review cycle unless you expand):**
+> - `{other_path_1}`
+> - `{other_path_2}`
+>
+> **Your turn:** Reply **yes** to start the static pass on `{path_dir}`, or name a different path (or **all**) to change scope.
 
 ---
 
@@ -162,7 +181,7 @@ Combines the former Phases 1–2 and workbook write.
 
 1. Snapshot `pre_review_assets`; dispatch [audit-guide](../audit-guide/SKILL.md) per milestone (parallel OK).
 2. Walk all [reference-checks.md](reference-checks.md) checklists + [learning-hub-standards.md](learning-hub-standards.md).
-3. **Always scan** for [section intro markdown that may number as a step](reference-checks.md#section-intro-markdown-numbered-as-a-step) and [false noops](reference-checks.md#noop-and-non-interactive-steps). Put matches under **Verify in Block Editor**.
+3. **Always scan** for [section intro markdown that may number as a step](reference-checks.md#section-intro-markdown-numbered-as-a-step), [false noops](reference-checks.md#noop-and-non-interactive-steps), and [backticks / copy chips](reference-checks.md#backticks--copy-chips-smell-17). Put step-numbering matches under **Verify in Block Editor**.
 4. Run Pathfinder CLI validate if available.
 5. Run the shared [claim-check](claim-check.md) pass. Write `pr-{n}-claim-check.md`. Route Contradicted / Unsupported / Overstated as **post inline** (same bar as preflight). Do not edit package JSON here.
 6. Tag every finding with [finding routing](reference-checks.md#finding-routing): **post inline**, **internal**, or **discard**.

--- a/.cursor/skills/review-learning-path/comment-style.md
+++ b/.cursor/skills/review-learning-path/comment-style.md
@@ -81,15 +81,15 @@ Thanks for the PR. I smoke-tested this on {stack_state} in Block Editor.
 
 {If reuse-live: one sentence that Block Editor results were reused from prior evidence, not re-run in this session.}
 
-{If any interactive path milestone has no Phase 2 result (static-only or partial):}
+{If any interactive path milestone has no Phase 2 result (static-only or partial), or the PR has sibling `*-lj` packages not live-tested:}
 
 ### Not live-tested
 
 - {milestone-slug}
-- {milestone-slug}
+- {sibling-path-lj} (entire path — not in this review cycle)
 ```
 
-Derive the list from path `milestones` minus milestones with recorded `pathfinder` results. See [static-only reviews](reference-checks.md#static-only-reviews).
+Derive milestone lines from path `milestones` minus milestones with recorded `pathfinder` results. Derive sibling package lines from `other_paths` in `pr-{n}.json`. See [static-only reviews](reference-checks.md#static-only-reviews) and [multi-path PRs](reference-checks.md#multi-path-prs).
 
 **Target length:** 3–5 sentences plus the Not live-tested list when required. Never paste the workbook into the summary.
 

--- a/.cursor/skills/review-learning-path/github-review.md
+++ b/.cursor/skills/review-learning-path/github-review.md
@@ -78,6 +78,8 @@ Path: `.cursor/pr-review-state/pr-{n}.json`
   "pr_number": 403,
   "pull_request_node_id": "PR_kwDOPf9q6c8AAAAA1234567",
   "path_dir": "monitor-azure-resources-lj",
+  "paths_in_pr": ["monitor-azure-resources-lj"],
+  "other_paths": [],
   "website_slug": "monitor-azure-resources",
   "pr_type": "conversion",
   "head_branch": "monitor-azure-interactive",
@@ -110,6 +112,8 @@ Path: `.cursor/pr-review-state/pr-{n}.json`
 | Field | When set | Notes |
 |---|---|---|
 | `pull_request_node_id` | Phase 0 | For GraphQL mutations |
+| `paths_in_pr` | Phase 0 | Every `*-lj` package touched by the PR (sorted) |
+| `other_paths` | Phase 0 | `paths_in_pr` minus `path_dir` (sibling packages) |
 | `pr_type` | Phase 0 | `new`, `conversion`, `update` |
 | `stack_state` | Phase 1 end | Stack used in Phase 2 |
 | `waive_live_testing` | Phase 1 end | Skips Phase 2 (`static-only`) |

--- a/.cursor/skills/review-learning-path/reference-checks.md
+++ b/.cursor/skills/review-learning-path/reference-checks.md
@@ -24,6 +24,7 @@ Tag every finding when writing the workbook. **Author-facing change requests alw
 | In-section intro that may number as a step (static detect) | Suspected bad link (unverified) | Pathfinder shell UX |
 | False `noop` (learner action, no `reftarget`) | Framing ambiguity (“is this framing?”) until confirmed | Fresh-stack retest notes (unless live failed) |
 | Missing required section bookends (rule 14) | Pure LH wording polish (boilerplate synonym) when structure is fine | |
+| Backticks on illustrative examples (copy chips; smell #17) | Justified paste backticks matching `targetvalue` / PromQL | |
 | Missing / broken required `website.yaml` identity fields (`menuTitle`, `description`, `journey.*`) | Overly broad `targeting.match` without impact | |
 | Learning Hub structure the author must change (missing path intro, wrong group/skill, hard cross-path deps, conversion prose gap) | Landing screenshot / milestone-count notes | |
 | Missing `exists-reftarget`, `navmenu-open` **when live fails** | | |
@@ -76,8 +77,36 @@ Run via [audit-guide](../audit-guide/SKILL.md) plus confirm every row:
 | Multistep singleton, focus-before-formfill, `noop` misuse | post inline if compliance; else internal |
 | Secrets `doIt: true` | post inline |
 | Missing `verify` on save | internal until live fails |
+| Backticks on illustrative examples (copy chips) | **post inline** (see [backticks / copy chips](#backticks--copy-chips-smell-17)) |
 
 LH prose checks: [learning-hub-standards.md](learning-hub-standards.md) — **post inline** when the author must change structure or required fields; **internal** for wording polish only.
+
+---
+
+## Backticks / copy chips (smell #17)
+
+Inline `` `value` `` in Pathfinder prose renders a **copy chip**. Learners click to copy. Reserve backticks for values the learner should paste. Use plain text for illustrative examples (folder names, default branches, URL fragments, "for example …"). Canonical smell: [best-practices.mdc](../../best-practices.mdc) item 17.
+
+### Phase 1 — static detect (workbook)
+
+Scan learner-visible strings in path root + every milestone `content.json` (markdown `content`, interactive `content`, `tooltip`):
+
+| Flag when | Examples |
+|---|---|
+| Backticks around an illustrative name near "for example" / "e.g." / "such as" | `` for example, `Alerts` `` |
+| Backticks around a folder, branch, org, or URL fragment the learner is not told to paste | `` create a folder named `Team` `` |
+| Backticks around UI chrome that should be bold instead | `` click `Save` `` (should be **Save**) |
+
+| Keep / discard when | Examples |
+|---|---|
+| Value matches a nearby `targetvalue` or formfill the learner pastes | `` `quickpizza_server_http_requests_total` `` with that `targetvalue` |
+| PromQL, JSON, exact tokens, datasource UIDs, metric names the step asks them to paste | paste-oriented steps |
+
+Write illustrative hits as **post inline** (path-wide OK when the same pattern repeats). Do not invent hits: only flag real backtick spans.
+
+### Phase 3 — comment shape
+
+> Backticks turn into copy chips in Pathfinder. Use them for values learners paste. For examples (folder names, branches), use plain text or bold UI labels instead. Same pattern in {other milestones}.
 
 ---
 
@@ -205,6 +234,23 @@ Prose not captured in package on conversion → **post inline**. Front matter ma
 
 ---
 
+## Multi-path PRs
+
+A single PR can ship more than one `{slug}-lj/` package. Reviewers and authors miss sibling paths when Phase 0 only names the path under discussion (seen on multi-path alerting PRs).
+
+### Phase 0 (required)
+
+1. Build `paths_in_pr` from the PR file list (see [SKILL.md Phase 0](SKILL.md#phase-0-setup)).
+2. Persist `paths_in_pr` and `other_paths` (`paths_in_pr` minus the path under review).
+3. Surface **every** entry in the Phase 0 checkpoint when `other_paths` is non-empty. Do not hide siblings in the workbook only.
+4. Default scope is one `{path_dir}` per review cycle. Expanding to **all** means separate static + live passes (or explicit reuse-live notes) per path before APPROVE.
+
+### Not live-tested (sibling packages)
+
+When `other_paths` is non-empty and those packages were not fully live-tested in this review, the Phase 3 summary **must** list each sibling under **Not live-tested** as a package line (for example `- alerting-create-silence-lj (entire path — not in this review cycle)`), in addition to any untested milestones inside `{path_dir}`. Cap verdict at **COMMENT** until every interactive path in `paths_in_pr` has a live result (or an explicit static-only waiver where allowed).
+
+---
+
 ## Static-only reviews
 
 `static-only: <reason>` at end of Phase 1 skips Phase 2.
@@ -228,11 +274,12 @@ Record `waive_live_testing: true` and `static_only_reason` only when allowed. Ne
 
 ### Not live-tested disclosure (required)
 
-Whenever Phase 2 did not record a result for every interactive path milestone (static-only, partial live, or any other skip), the review summary **must** include a **Not live-tested** list:
+Whenever Phase 2 did not record a result for every interactive path milestone (static-only, partial live, or any other skip), **or** `other_paths` still lacks a live pass, the review summary **must** include a **Not live-tested** list:
 
 1. Start from interactive milestones in path `manifest.json` `milestones`.
 2. Subtract any milestone with a recorded Phase 2 result in `pathfinder.{milestone}` (including `pass (reused — …)` when `reuse_live` is true).
 3. List every remaining slug under a `### Not live-tested` heading in the summary body.
+4. Append every package in `other_paths` that was not live-tested in this review (whole-path lines). See [Multi-path PRs](#multi-path-prs).
 
 Cap verdict at **COMMENT**. Do not use a single vague “milestones were not live-tested” sentence in place of the list.
 ---


### PR DESCRIPTION
## Summary
- Phase 0 (review) and identify (preflight) now inventory every `*-lj` package on the PR/branch, persist siblings as `other_paths`, and require them in Not live-tested / Not preflighted disclosures so multi-path PRs cannot silently skip a package.
- Static passes always scan for illustrative backticks that become Pathfinder copy chips (best-practices smell #17), with create-learning-path anti-pattern coverage.

## Test plan
- [ ] Skim Phase 0 checkpoint text in `review-learning-path/SKILL.md` for a multi-path PR (e.g. #377) and confirm siblings would be listed
- [ ] Confirm smell #17 section routes illustrative backticks to post-inline / Fix before PR
- [ ] No package `content.json` changes in this PR (skills/commands only)

Made with [Cursor](https://cursor.com)