### PR TITLE
Add Get started with Grafana Assistant learning path

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -106,6 +106,7 @@
 /visualization-metrics-lj/                                @knylander-grafana
 /visualization-traces-lj/                                 @knylander-grafana
 /git-sync-dashboards-lj/                                  @bonnywelsford-source
+/get-started-grafana-assistant-lj/                        @bonnywelsford-source
 /interactive-dashboards-lj/                               @bonnywelsford-source
 /welcome-to-play/                                         @Jayclifford345 @mdcruz
 /windows-integration/                                     @chri2547

--- a/get-started-grafana-assistant-lj/assets/selector-notes.md
+++ b/get-started-grafana-assistant-lj/assets/selector-notes.md
@@ -1,0 +1,19 @@
+# Selector notes - get-started-grafana-assistant-lj
+
+Live DOM checks on `learn.grafana.net` (2026-08-04).
+
+| Element | Selector | Notes |
+| --- | --- | --- |
+| Plugins search | `div[data-testid='input-wrapper'] input[placeholder='Search Grafana plugins']` | exists |
+| Assistant plugin card | `a[href^='/plugins/grafana-assistant-app']` | exists after search |
+| Enable checkbox | `input[type='checkbox']` (skippable) | missing when Assistant already enabled |
+| Save | button text `Save` (skippable) | missing when already enabled |
+| Open Assistant toolbar | `div[data-testid='data-testid Nav toolbar'] button[data-testid='extension-toolbar-button-open']` | exists |
+| Chat panel | `[data-testid='grafana-assistant-chat']` | scope chat controls here (homepage has a second prompt) |
+| Prompt input | `[data-testid='grafana-assistant-chat'] [data-testid='prompt-input-body'] [role='textbox'][contenteditable='true']` | TipTap contenteditable. Pathfinder `formfill` cannot fill it (sets `textContent` without editor events). Guides use `highlight` + `doIt: false` and ask the learner to paste. |
+| Send | `[data-testid='grafana-assistant-chat'] button[aria-label='Send message']` | exists |
+| Mode pill | `[data-testid='grafana-assistant-chat'] [data-testid='pde-lab-mode-selector-pill']` | label shows current mode |
+| Learn menu item | `[role='menuitem']:contains('Learn')` | no dedicated testid yet |
+| Assistant menu item | `[role='menuitem']:text('Assistant')` | switch back from Learn |
+
+AI reply review / lesson pick stay `noop` (non-deterministic). Mention picker has no durable listbox testid; steps use `highlight` + `doIt: false` on the prompt.

--- a/get-started-grafana-assistant-lj/content.json
+++ b/get-started-grafana-assistant-lj/content.json
@@ -1,0 +1,27 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "get-started-grafana-assistant-lj",
+  "title": "Get started with Grafana Assistant",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "Grafana Assistant is an AI assistant that brings a conversational interface to Grafana. You describe what you need in natural language, and Assistant generates queries, finds dashboards, and explains what your data shows, without requiring you to memorize syntax."
+    },
+    {
+      "type": "markdown",
+      "content": "## Here's what to expect\n\nWhen you complete this path, you'll be able to:\n\n- Open the Grafana Assistant plugin in Grafana Cloud\n- Enable Assistant for your stack when the enable page is shown\n- Open Assistant and send your first prompt\n- Use `@` mentions so Assistant targets the right data source\n- Find Learn mode in the Assistant panel"
+    },
+    {
+      "type": "markdown",
+      "content": "## Before you begin\n\n- A Grafana Cloud account (Free tier is enough). [Create an account](https://grafana.com/signup/cloud/connect-account) if you need one.\n- Administrator permissions in your Grafana Cloud stack if you need to enable Assistant from plugin settings.\n- Data sources configured (recommended). Assistant works best with monitoring data in place. Refer to [Query data](https://grafana.com/docs/grafana-cloud/machine-learning/assistant/guides/querying/) for supported data sources.\n\nFor full setup details, refer to [Set up Grafana Assistant in Grafana Cloud](https://grafana.com/docs/grafana-cloud/machine-learning/assistant/get-started/grafana-cloud/)."
+    },
+    {
+      "type": "markdown",
+      "content": "## Troubleshooting\n\nIf you get stuck, we've got your back! Where appropriate, troubleshooting information is just a click away."
+    },
+    {
+      "type": "markdown",
+      "content": "## More to explore\n\nWe understand you might want to explore other capabilities not strictly on this path. We'll provide you opportunities where it makes sense."
+    }
+  ]
+}

--- a/get-started-grafana-assistant-lj/content.json
+++ b/get-started-grafana-assistant-lj/content.json
@@ -9,7 +9,7 @@
     },
     {
       "type": "markdown",
-      "content": "## Here's what to expect\n\nWhen you complete this path, you'll be able to:\n\n- Open the Grafana Assistant plugin in Grafana Cloud\n- Enable Assistant for your stack when the enable page is shown\n- Open Assistant and send your first prompt\n- Use `@` mentions so Assistant targets the right data source\n- Find Learn mode in the Assistant panel"
+      "content": "## Here's what to expect\n\nWhen you complete this path, you'll be able to:\n\n- Open the Grafana Assistant plugin in Grafana Cloud\n- Enable Assistant for your stack when the enable page is shown\n- Send a first prompt and judge whether the reply is specific enough\n- Decide when to use an `@` mention versus exploring without one\n- Choose Learn mode for coaching or Assistant for day-to-day work"
     },
     {
       "type": "markdown",

--- a/get-started-grafana-assistant-lj/end-journey/content.json
+++ b/get-started-grafana-assistant-lj/end-journey/content.json
@@ -1,0 +1,15 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "get-started-grafana-assistant-end-journey",
+  "title": "Destination reached!",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "Congratulations on completing this path! You:\n\n- Opened the Grafana Assistant plugin in Grafana Cloud\n- Enabled Assistant when your stack required it\n- Opened Assistant and sent a first prompt\n- Used an `@` mention to target a data source\n- Found Learn mode in the Assistant panel"
+    },
+    {
+      "type": "markdown",
+      "content": "---\n\n### More to explore (optional)\n\nContinue practicing Assistant workflows:\n\n- [Work with Grafana Assistant](https://grafana.com/docs/learning-paths/work-with-grafana-assistant/) to navigate resources, query data, and manage dashboards\n- [Navigate Grafana resources](https://grafana.com/docs/grafana-cloud/machine-learning/assistant/guides/navigation/)\n- [Query data](https://grafana.com/docs/grafana-cloud/machine-learning/assistant/guides/querying/)\n- [Manage dashboards](https://grafana.com/docs/grafana-cloud/machine-learning/assistant/guides/dashboarding/)\n- [Introduction to Grafana Assistant](https://grafana.com/docs/learning-hub/intro-to-grafana-assistant/) journey"
+    }
+  ]
+}

--- a/get-started-grafana-assistant-lj/end-journey/content.json
+++ b/get-started-grafana-assistant-lj/end-journey/content.json
@@ -5,7 +5,7 @@
   "blocks": [
     {
       "type": "markdown",
-      "content": "Congratulations on completing this path! You:\n\n- Opened the Grafana Assistant plugin in Grafana Cloud\n- Enabled Assistant when your stack required it\n- Opened Assistant and sent a first prompt\n- Used an `@` mention to target a data source\n- Found Learn mode in the Assistant panel"
+      "content": "Congratulations on completing this path! You:\n\n- Opened the Grafana Assistant plugin in Grafana Cloud\n- Enabled Assistant when your stack required it\n- Sent a first prompt and judged whether the reply was specific enough\n- Decided when an `@` mention improves focus\n- Chose between Learn mode (coaching) and Assistant (day-to-day work)"
     },
     {
       "type": "markdown",

--- a/get-started-grafana-assistant-lj/end-journey/manifest.json
+++ b/get-started-grafana-assistant-lj/end-journey/manifest.json
@@ -1,0 +1,17 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "get-started-grafana-assistant-end-journey",
+  "type": "guide",
+  "description": "Wrap up the Get started with Grafana Assistant path and explore next workflows.",
+  "category": "onboarding",
+  "author": {
+    "name": "bonnywelsford-source",
+    "team": "Grafana Documentation"
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": ["get-started-grafana-assistant-try-learn-mode"],
+  "recommends": [],
+  "suggests": ["work-with-grafana-assistant-lj"]
+}

--- a/get-started-grafana-assistant-lj/end-journey/website.yaml
+++ b/get-started-grafana-assistant-lj/end-journey/website.yaml
@@ -1,0 +1,23 @@
+menuTitle: Destination reached!
+weight: 700
+step: 7
+layout: single-journey
+cta:
+  type: conclusion
+keywords:
+  - Grafana Assistant
+  - completion
+  - next steps
+side_journeys:
+  title: More to explore (optional)
+  heading: 'Continue practicing Assistant workflows:'
+  items:
+    - title: Work with Grafana Assistant
+      link: /docs/learning-paths/work-with-grafana-assistant/
+    - title: Navigate Grafana resources
+      link: /docs/grafana-cloud/machine-learning/assistant/guides/navigation/
+    - title: Query data
+      link: /docs/grafana-cloud/machine-learning/assistant/guides/querying/
+    - title: Manage dashboards
+      link: /docs/grafana-cloud/machine-learning/assistant/guides/dashboarding/
+description: Wrap up the Get started with Grafana Assistant path and explore next workflows.

--- a/get-started-grafana-assistant-lj/first-prompt/content.json
+++ b/get-started-grafana-assistant-lj/first-prompt/content.json
@@ -5,7 +5,7 @@
   "blocks": [
     {
       "type": "markdown",
-      "content": "Start with a simple question so Assistant can detect a data source, generate a query, and present results. Treat the reply as a draft you can refine.\n\nThe first time you open Assistant, a tutorial option may appear. You can reopen it anytime from the chat menu (**Open tutorial**).\n\nIf this guide is docked, pop it out so Assistant does not cover the steps."
+      "content": "Start with a simple question so Assistant can detect a data source, generate a query, and present results. Treat the reply as a draft you can refine.\n\nThe first time you open Assistant, a tutorial option may appear. You can reopen it anytime from the chat menu (**Open tutorial**)."
     },
     {
       "type": "conditional",

--- a/get-started-grafana-assistant-lj/first-prompt/content.json
+++ b/get-started-grafana-assistant-lj/first-prompt/content.json
@@ -43,7 +43,7 @@
           "action": "highlight",
           "reftarget": "[data-testid='grafana-assistant-chat'] [data-testid='prompt-input-body'] [role='textbox'][contenteditable='true']",
           "doIt": false,
-          "content": "In the chat input, paste or type a starter prompt:\n\n> List the data sources available to me\n\nIf you have metrics in your stack, you can use:\n\n> Show me CPU usage for the API service"
+          "content": "In the chat input, paste or type a starter prompt:\n\n> List the data sources available to me\n\nIf you have metrics in your stack, you can use:\n\n> Show me CPU usage for the API service",
           "requirements": ["exists-reftarget"]
         },
         {

--- a/get-started-grafana-assistant-lj/first-prompt/content.json
+++ b/get-started-grafana-assistant-lj/first-prompt/content.json
@@ -5,7 +5,7 @@
   "blocks": [
     {
       "type": "markdown",
-      "content": "Start with a simple question so Assistant can detect a data source, generate a query, and present results. Treat the reply as a draft, then judge whether it is specific enough or needs narrowing.\n\nThe first time you open Assistant, a tutorial option may appear. You can reopen it anytime from the chat menu (**Open tutorial**)."
+      "content": "Start with a short question that can return a data source list, a query, or results. Treat the reply as a draft, then judge whether it is specific enough or needs narrowing.\n\nThe first time you open Assistant, a tutorial option may appear. You can reopen it anytime from the chat menu (**Open tutorial**)."
     },
     {
       "type": "conditional",
@@ -56,13 +56,13 @@
         {
           "type": "interactive",
           "action": "noop",
-          "content": "Judge whether the reply is good enough for a first win:\n\n- **Useful:** It lists or names data sources, shows a query, opens Explore, or summarizes something concrete from your stack.\n- **Needs narrowing:** It stays generic, seems off-target, or mostly asks clarifying questions.\n\nTreat the reply as a draft either way. Use thumbs up or thumbs down when those controls appear."
+          "content": "Judge whether the reply is specific enough to continue:\n\n- **Useful:** It lists or names data sources, includes a query, opens Explore, or summarizes something concrete from your stack.\n- **Needs narrowing:** It stays generic, seems off-target, or mostly includes clarifying questions.\n\nTreat the reply as a draft either way. Use thumbs up or thumbs down when those controls appear."
         }
       ]
     },
     {
       "type": "markdown",
-      "content": "You sent a first prompt and checked whether the reply was specific enough.\n\nIf it needed narrowing, the next milestone shows how an `@` mention focuses Assistant on the right data source.\n\nFor product details, refer to [Start your first conversation](https://grafana.com/docs/grafana-cloud/machine-learning/assistant/get-started/grafana-cloud/#start-your-first-conversation)."
+      "content": "You sent a first prompt and checked whether the reply was specific enough.\n\nIf it needed narrowing, the next milestone shows how an `@` mention scopes the request to a specific data source.\n\nFor product details, refer to [Start your first conversation](https://grafana.com/docs/grafana-cloud/machine-learning/assistant/get-started/grafana-cloud/#start-your-first-conversation)."
     },
     {
       "type": "conditional",
@@ -79,7 +79,7 @@
     },
     {
       "type": "markdown",
-      "content": "In the next milestone, you'll use an `@` mention so Assistant targets a specific data source."
+      "content": "In the next milestone, you'll use an `@` mention to target a specific data source."
     }
   ]
 }

--- a/get-started-grafana-assistant-lj/first-prompt/content.json
+++ b/get-started-grafana-assistant-lj/first-prompt/content.json
@@ -5,7 +5,7 @@
   "blocks": [
     {
       "type": "markdown",
-      "content": "Start with a simple question so Assistant can detect a data source, generate a query, and present results. Treat the reply as a draft you can refine.\n\nThe first time you open Assistant, a tutorial option may appear. You can reopen it anytime from the chat menu (**Open tutorial**)."
+      "content": "Start with a simple question so Assistant can detect a data source, generate a query, and present results. Treat the reply as a draft, then judge whether it is specific enough or needs narrowing.\n\nThe first time you open Assistant, a tutorial option may appear. You can reopen it anytime from the chat menu (**Open tutorial**)."
     },
     {
       "type": "conditional",
@@ -56,13 +56,13 @@
         {
           "type": "interactive",
           "action": "noop",
-          "content": "Review the reply.\n\nAssistant may generate a query, open Explore, or summarize what it found. Use thumbs up or thumbs down when those controls appear. Feedback helps improve answer quality."
+          "content": "Judge whether the reply is good enough for a first win:\n\n- **Useful:** It lists or names data sources, shows a query, opens Explore, or summarizes something concrete from your stack.\n- **Needs narrowing:** It stays generic, seems off-target, or mostly asks clarifying questions.\n\nTreat the reply as a draft either way. Use thumbs up or thumbs down when those controls appear."
         }
       ]
     },
     {
       "type": "markdown",
-      "content": "You should see a response in the chat.\n\nFor product details, refer to [Start your first conversation](https://grafana.com/docs/grafana-cloud/machine-learning/assistant/get-started/grafana-cloud/#start-your-first-conversation)."
+      "content": "You sent a first prompt and checked whether the reply was specific enough.\n\nIf it needed narrowing, the next milestone shows how an `@` mention focuses Assistant on the right data source.\n\nFor product details, refer to [Start your first conversation](https://grafana.com/docs/grafana-cloud/machine-learning/assistant/get-started/grafana-cloud/#start-your-first-conversation)."
     },
     {
       "type": "conditional",

--- a/get-started-grafana-assistant-lj/first-prompt/content.json
+++ b/get-started-grafana-assistant-lj/first-prompt/content.json
@@ -1,0 +1,85 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "get-started-grafana-assistant-first-prompt",
+  "title": "Send your first prompt",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "Start with a simple question so Assistant can detect a data source, generate a query, and present results. Treat the reply as a draft you can refine.\n\nThe first time you open Assistant, a tutorial option may appear. You can reopen it anytime from the chat menu (**Open tutorial**).\n\nIf this guide is docked, pop it out so Assistant does not cover the steps."
+    },
+    {
+      "type": "conditional",
+      "conditions": ["renderer:pathfinder"],
+      "whenTrue": [
+        {
+          "type": "interactive",
+          "action": "popout",
+          "targetvalue": "floating",
+          "content": "If this guide is docked in the sidebar, pop it out into a floating window so it stays visible when **Assistant** opens."
+        }
+      ],
+      "whenFalse": []
+    },
+    {
+      "type": "markdown",
+      "content": "To send your first prompt, complete the following steps:"
+    },
+    {
+      "type": "section",
+      "id": "send-first-prompt",
+      "title": "Ask a starter question",
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "div[data-testid='data-testid Nav toolbar'] button[data-testid='extension-toolbar-button-open']",
+          "content": "Open **Assistant** from the top toolbar (sparkle icon). You can also select **Assistant** from the left navigation.",
+          "requirements": ["exists-reftarget"],
+          "skippable": true,
+          "hint": "Skip if the Assistant panel is already open. If you do not see the control, confirm Assistant is enabled for your stack."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='grafana-assistant-chat'] [data-testid='prompt-input-body'] [role='textbox'][contenteditable='true']",
+          "doIt": false,
+          "content": "In the chat input, paste or type a starter prompt:\n\n> List the data sources available to me\n\nIf you have metrics in your stack, you can use:\n\n> Show me CPU usage for the API service"
+          "requirements": ["exists-reftarget"]
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='grafana-assistant-chat'] button[aria-label='Send message']",
+          "content": "Click **Send** (the arrow next to the chat input).",
+          "requirements": ["exists-reftarget"]
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Review the reply.\n\nAssistant may generate a query, open Explore, or summarize what it found. Use thumbs up or thumbs down when those controls appear. Feedback helps improve answer quality."
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "You should see a response in the chat.\n\nFor product details, refer to [Start your first conversation](https://grafana.com/docs/grafana-cloud/machine-learning/assistant/get-started/grafana-cloud/#start-your-first-conversation)."
+    },
+    {
+      "type": "conditional",
+      "conditions": ["renderer:pathfinder"],
+      "whenTrue": [
+        {
+          "type": "interactive",
+          "action": "popout",
+          "targetvalue": "sidebar",
+          "content": "Dock this guide back to the sidebar when you are ready for the next milestone."
+        }
+      ],
+      "whenFalse": []
+    },
+    {
+      "type": "markdown",
+      "content": "In the next milestone, you'll use an `@` mention so Assistant targets a specific data source."
+    }
+  ]
+}

--- a/get-started-grafana-assistant-lj/first-prompt/manifest.json
+++ b/get-started-grafana-assistant-lj/first-prompt/manifest.json
@@ -1,0 +1,17 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "get-started-grafana-assistant-first-prompt",
+  "type": "guide",
+  "description": "Open Grafana Assistant, send a starter prompt, and review the response.",
+  "category": "onboarding",
+  "author": {
+    "name": "bonnywelsford-source",
+    "team": "Grafana Documentation"
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": ["get-started-grafana-assistant-open-and-enable-plugin"],
+  "recommends": ["get-started-grafana-assistant-use-mentions"],
+  "suggests": []
+}

--- a/get-started-grafana-assistant-lj/first-prompt/website.yaml
+++ b/get-started-grafana-assistant-lj/first-prompt/website.yaml
@@ -1,0 +1,11 @@
+menuTitle: Send your first prompt
+weight: 400
+step: 4
+layout: single-journey
+cta:
+  type: continue
+keywords:
+  - Grafana Assistant
+  - prompt
+  - chat
+description: Open Grafana Assistant, send a starter prompt, and review the response.

--- a/get-started-grafana-assistant-lj/manifest.json
+++ b/get-started-grafana-assistant-lj/manifest.json
@@ -2,7 +2,7 @@
   "schemaVersion": "1.1.0",
   "id": "get-started-grafana-assistant-lj",
   "type": "path",
-  "description": "Enable Grafana Assistant in Grafana Cloud and complete your first conversation with @ mentions and Learn mode.",
+  "description": "Enable Grafana Assistant in Grafana Cloud, judge your first reply, decide when to use @ mentions, and choose Learn vs Assistant mode.",
   "category": "onboarding",
   "author": {
     "name": "bonnywelsford-source",

--- a/get-started-grafana-assistant-lj/manifest.json
+++ b/get-started-grafana-assistant-lj/manifest.json
@@ -1,0 +1,36 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "get-started-grafana-assistant-lj",
+  "type": "path",
+  "description": "Enable Grafana Assistant in Grafana Cloud and complete your first conversation with @ mentions and Learn mode.",
+  "category": "onboarding",
+  "author": {
+    "name": "bonnywelsford-source",
+    "team": "Grafana Documentation"
+  },
+  "startingLocation": "/plugins/grafana-assistant-app",
+  "targeting": {
+    "match": {
+      "and": [
+        {
+          "urlPrefix": "/plugins/grafana-assistant-app"
+        },
+        {
+          "targetPlatform": "cloud"
+        }
+      ]
+    }
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "milestones": [
+    "get-started-grafana-assistant-open-and-enable-plugin",
+    "get-started-grafana-assistant-first-prompt",
+    "get-started-grafana-assistant-use-mentions",
+    "get-started-grafana-assistant-try-learn-mode",
+    "get-started-grafana-assistant-end-journey"
+  ],
+  "recommends": [],
+  "suggests": []
+}

--- a/get-started-grafana-assistant-lj/open-and-enable-plugin/content.json
+++ b/get-started-grafana-assistant-lj/open-and-enable-plugin/content.json
@@ -1,0 +1,98 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "get-started-grafana-assistant-open-and-enable-plugin",
+  "title": "Open and enable the Assistant plugin",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "How you enable Assistant depends on your Grafana Cloud agreement. On some Free and Pro stacks, terms acceptance is handled automatically when a user first uses an Assistant feature. Stacks that require supplemental AI terms must be enabled from plugin settings by an administrator.\n\n**Already available?** Look for the sparkle icon in the top-right toolbar, or **Assistant** in the left navigation. If you see either one, Assistant is on for your stack. Skip the enable steps and continue."
+    },
+    {
+      "type": "markdown",
+      "content": "Open **Plugins**, search for Grafana Assistant, and open the plugin page."
+    },
+    {
+      "type": "section",
+      "id": "open-plugins-catalog",
+      "title": "Open the Plugins catalog",
+      "autoCollapse": true,
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "navigate",
+          "reftarget": "/plugins",
+          "content": "Go to **Plugins**.",
+          "verify": "on-page:/plugins"
+        },
+        {
+          "type": "interactive",
+          "action": "formfill",
+          "reftarget": "div[data-testid='input-wrapper'] input[placeholder='Search Grafana plugins']",
+          "targetvalue": "assistant",
+          "content": "Search for **Grafana Assistant**.",
+          "requirements": ["on-page:/plugins", "exists-reftarget"]
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "a[href^='/plugins/grafana-assistant-app']",
+          "content": "Open **Grafana Assistant**.",
+          "requirements": ["on-page:/plugins", "exists-reftarget"],
+          "objectives": ["on-page:/plugins/grafana-assistant-app"],
+          "hint": "Click the **Grafana Assistant** card in the search results (not Ask O11y)."
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "You should be on the Grafana Assistant plugin page."
+    },
+    {
+      "type": "markdown",
+      "content": "Check whether Assistant is already on: sparkle icon in the top-right toolbar, or **Assistant** in the left navigation. If you see either, skip this section.\n\nOnly continue if the plugin page shows an **Enable Assistant** (or **Assistant enabled**) checkbox."
+    },
+    {
+      "type": "section",
+      "id": "enable-assistant",
+      "title": "Enable Assistant (if required)",
+      "requirements": ["section-completed:open-plugins-catalog"],
+      "autoCollapse": true,
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "navigate",
+          "reftarget": "/plugins/grafana-assistant-app",
+          "content": "Open the **Grafana Assistant** plugin page if you are not already there.",
+          "verify": "on-page:/plugins/grafana-assistant-app",
+          "skippable": true
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "input[type='checkbox']",
+          "content": "If you see an **Assistant enabled** or **Enable Assistant** checkbox, select it. If there is no checkbox, skip. An installed plugin page without that control usually means Assistant is already available.",
+          "requirements": ["on-page:/plugins/grafana-assistant-app", "exists-reftarget"],
+          "skippable": true,
+          "hint": "No checkbox? Check the top-right sparkle icon or **Assistant** in the left nav. If either is present, skip this step."
+        },
+        {
+          "type": "interactive",
+          "action": "button",
+          "reftarget": "Save",
+          "content": "Click **Save** if you changed the enable setting.",
+          "requirements": ["on-page:/plugins/grafana-assistant-app"],
+          "skippable": true,
+          "hint": "Skip if you did not change a setting, or if there was no enable checkbox."
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "When Assistant is available, you should see the sparkle icon in the top-right toolbar and/or **Assistant** in the left navigation.\n\nFor full setup instructions, refer to [Set up Grafana Assistant in Grafana Cloud](https://grafana.com/docs/grafana-cloud/machine-learning/assistant/get-started/grafana-cloud/#enable-assistant-in-grafana-cloud)."
+    },
+    {
+      "type": "markdown",
+      "content": "In the next milestone, you'll open Assistant and send your first prompt."
+    }
+  ]
+}

--- a/get-started-grafana-assistant-lj/open-and-enable-plugin/manifest.json
+++ b/get-started-grafana-assistant-lj/open-and-enable-plugin/manifest.json
@@ -1,0 +1,18 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "get-started-grafana-assistant-open-and-enable-plugin",
+  "type": "guide",
+  "description": "Open the Grafana Assistant plugin and enable it for your Grafana Cloud stack when required.",
+  "category": "onboarding",
+  "author": {
+    "name": "bonnywelsford-source",
+    "team": "Grafana Documentation"
+  },
+  "startingLocation": "/plugins",
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": [],
+  "recommends": ["get-started-grafana-assistant-first-prompt"],
+  "suggests": []
+}

--- a/get-started-grafana-assistant-lj/open-and-enable-plugin/website.yaml
+++ b/get-started-grafana-assistant-lj/open-and-enable-plugin/website.yaml
@@ -1,0 +1,11 @@
+menuTitle: Open and enable the plugin
+weight: 300
+step: 3
+layout: single-journey
+cta:
+  type: continue
+keywords:
+  - Grafana Assistant
+  - plugins
+  - enable
+description: Open the Grafana Assistant plugin and enable it for your Grafana Cloud stack when required.

--- a/get-started-grafana-assistant-lj/try-learn-mode/content.json
+++ b/get-started-grafana-assistant-lj/try-learn-mode/content.json
@@ -5,7 +5,7 @@
   "blocks": [
     {
       "type": "markdown",
-      "content": "The mode menu switches how the chat behaves. Choose on purpose:\n\n- **Assistant:** Do work. Ask for queries, resources, or changes and move quickly.\n- **Learn:** Get step-by-step coaching. Lessons pause and ask before creating or changing anything.\n\nLearn suggests lessons from your role, the products you care about, and services in your environment. In this milestone you open Learn, optionally start a short lesson, then switch back. Completing a full lesson is optional."
+      "content": "The mode menu switches how the chat behaves. Choose on purpose:\n\n- **Assistant:** Do work. Ask for queries, resources, or changes and move quickly.\n- **Learn:** Get step-by-step coaching. In Learn mode, each step waits for your confirmation before creating or changing anything.\n\nLearn mode can show suggested lessons based on your role, the products you care about, and services in your environment. In this milestone you open Learn, optionally start a short lesson, then switch back. Completing a full lesson is optional."
     },
     {
       "type": "conditional",
@@ -51,7 +51,7 @@
           "action": "highlight",
           "reftarget": "[data-testid='grafana-assistant-chat'] [data-testid='prompt-input-body'] [role='textbox'][contenteditable='true']",
           "doIt": false,
-          "content": "Optionally paste or type a goal so Learn can suggest a lesson:\n\n> I'm new to Grafana. Show me a short lesson on finding dashboards.\n\nOr:\n\n> I'm an SRE. Teach me how to use metrics, logs, and traces to look into latency for a service in my stack.\n\nSkip this step if you only wanted to find where Learn mode lives.",
+          "content": "Optionally paste or type a goal so Learn mode can show a suggested lesson:\n\n> I'm new to Grafana. Show me a short lesson on finding dashboards.\n\nOr:\n\n> I'm an SRE. Teach me how to use metrics, logs, and traces to look into latency for a service in my stack.\n\nSkip this step if you only wanted to find where Learn mode lives.",
           "requirements": ["exists-reftarget"],
           "skippable": true
         },
@@ -66,7 +66,7 @@
         {
           "type": "interactive",
           "action": "noop",
-          "content": "If Learn suggests lessons, pick one and take a single step.\n\nNotice that Learn pauses and asks before it creates or changes anything. That is the cue to stay in Learn when you want coaching, and to switch back to **Assistant** when you want to do the work yourself. You do not need to finish the whole lesson for this path."
+          "content": "If lesson suggestions appear, pick one and take a single step.\n\nNotice that in Learn mode, the chat waits for confirmation before creating or changing anything. Stay in Learn when you want that coaching style. Switch back to **Assistant** when you want to work through prompts yourself. You don't need to finish the whole lesson for this path."
         },
         {
           "type": "interactive",
@@ -80,7 +80,7 @@
     },
     {
       "type": "markdown",
-      "content": "You can find Learn mode and choose when to use it versus Assistant: Learn for coaching that asks before changes; Assistant when you are ready to act.\n\nFor full details, refer to [Use Learn mode](https://grafana.com/docs/grafana-cloud/machine-learning/assistant/guides/learn-mode/)."
+      "content": "You can find Learn mode and choose when to use it versus Assistant: Learn for coaching with confirmation before changes; Assistant when you are ready to act.\n\nFor full details, refer to [Use Learn mode](https://grafana.com/docs/grafana-cloud/machine-learning/assistant/guides/learn-mode/)."
     },
     {
       "type": "conditional",

--- a/get-started-grafana-assistant-lj/try-learn-mode/content.json
+++ b/get-started-grafana-assistant-lj/try-learn-mode/content.json
@@ -5,7 +5,7 @@
   "blocks": [
     {
       "type": "markdown",
-      "content": "Learn mode turns Grafana Assistant into a guided coach. It suggests lessons based on your role, the products you want to use, and the services in your environment. Lessons teach one concept or action at a time and ask before creating or changing anything.\n\nIn this milestone you open Learn from the mode menu at the bottom of the chat, optionally start a short lesson, then switch back. Completing a full lesson is optional.\n\nIf this guide is docked, pop it out so Assistant stays visible."
+      "content": "Learn mode turns Grafana Assistant into a guided coach. It suggests lessons based on your role, the products you want to use, and the services in your environment. Lessons teach one concept or action at a time and ask before creating or changing anything.\n\nIn this milestone you open Learn from the mode menu at the bottom of the chat, optionally start a short lesson, then switch back. Completing a full lesson is optional."
     },
     {
       "type": "conditional",

--- a/get-started-grafana-assistant-lj/try-learn-mode/content.json
+++ b/get-started-grafana-assistant-lj/try-learn-mode/content.json
@@ -1,0 +1,103 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "get-started-grafana-assistant-try-learn-mode",
+  "title": "Find Learn mode",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "Learn mode turns Grafana Assistant into a guided coach. It suggests lessons based on your role, the products you want to use, and the services in your environment. Lessons teach one concept or action at a time and ask before creating or changing anything.\n\nIn this milestone you open Learn from the mode menu at the bottom of the chat, optionally start a short lesson, then switch back. Completing a full lesson is optional.\n\nIf this guide is docked, pop it out so Assistant stays visible."
+    },
+    {
+      "type": "conditional",
+      "conditions": ["renderer:pathfinder"],
+      "whenTrue": [
+        {
+          "type": "interactive",
+          "action": "popout",
+          "targetvalue": "floating",
+          "content": "If this guide is docked in the sidebar, pop it out into a floating window so it stays visible beside **Assistant**."
+        }
+      ],
+      "whenFalse": []
+    },
+    {
+      "type": "markdown",
+      "content": "To find Learn mode, complete the following steps:"
+    },
+    {
+      "type": "section",
+      "id": "switch-to-learn",
+      "title": "Switch to Learn",
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "div[data-testid='data-testid Nav toolbar'] button[data-testid='extension-toolbar-button-open']",
+          "content": "Open **Assistant** from the top toolbar (sparkle icon) if the panel is closed.",
+          "requirements": ["exists-reftarget"],
+          "skippable": true,
+          "hint": "Skip if Assistant is already open from the previous milestone."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='pde-lab-mode-selector-pill']",
+          "doIt": false,
+          "content": "At the bottom of the Assistant chat, click the mode button (it shows the current mode name, for example **Assistant**).\n\nIn the dropdown, select **Learn**. The mode button label should change to **Learn**.",
+          "requirements": ["exists-reftarget"]
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='grafana-assistant-chat'] [data-testid='prompt-input-body'] [role='textbox'][contenteditable='true']",
+          "doIt": false,
+          "content": "Optionally paste or type a goal so Learn can suggest a lesson:\n\n> I'm new to Grafana. Show me a short lesson on finding dashboards.\n\nOr:\n\n> I'm an SRE. Teach me how to use metrics, logs, and traces to look into latency for a service in my stack.\n\nSkip this step if you only wanted to find where Learn mode lives.",
+          "requirements": ["exists-reftarget"],
+          "skippable": true
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='grafana-assistant-chat'] button[aria-label='Send message']",
+          "content": "Click **Send** if you entered a goal.",
+          "requirements": ["exists-reftarget"],
+          "skippable": true
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "If Learn suggests lessons, pick one and take a single step.\n\nLearn mode pauses between steps and asks before it creates or changes anything. You do not need to finish the whole lesson for this path."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='pde-lab-mode-selector-pill']",
+          "doIt": false,
+          "content": "When you are done exploring, click the mode button again (it should say **Learn**).\n\nIn the dropdown, select **Assistant** (or another mode you use). You can return to Learn anytime the same way.",
+          "requirements": ["exists-reftarget"]
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "You found Learn mode and know how to start (and leave) a lesson.\n\nFor full details, refer to [Use Learn mode](https://grafana.com/docs/grafana-cloud/machine-learning/assistant/guides/learn-mode/)."
+    },
+    {
+      "type": "conditional",
+      "conditions": ["renderer:pathfinder"],
+      "whenTrue": [
+        {
+          "type": "interactive",
+          "action": "popout",
+          "targetvalue": "sidebar",
+          "content": "Dock this guide back to the sidebar when you are ready for the next milestone."
+        }
+      ],
+      "whenFalse": []
+    },
+    {
+      "type": "markdown",
+      "content": "In the next milestone, you'll wrap up this path and see where to go next."
+    }
+  ]
+}

--- a/get-started-grafana-assistant-lj/try-learn-mode/content.json
+++ b/get-started-grafana-assistant-lj/try-learn-mode/content.json
@@ -1,11 +1,11 @@
 {
   "schemaVersion": "1.1.0",
   "id": "get-started-grafana-assistant-try-learn-mode",
-  "title": "Find Learn mode",
+  "title": "Choose Learn mode",
   "blocks": [
     {
       "type": "markdown",
-      "content": "Learn mode turns Grafana Assistant into a guided coach. It suggests lessons based on your role, the products you want to use, and the services in your environment. Lessons teach one concept or action at a time and ask before creating or changing anything.\n\nIn this milestone you open Learn from the mode menu at the bottom of the chat, optionally start a short lesson, then switch back. Completing a full lesson is optional."
+      "content": "The mode menu switches how the chat behaves. Choose on purpose:\n\n- **Assistant:** Do work. Ask for queries, resources, or changes and move quickly.\n- **Learn:** Get step-by-step coaching. Lessons pause and ask before creating or changing anything.\n\nLearn suggests lessons from your role, the products you care about, and services in your environment. In this milestone you open Learn, optionally start a short lesson, then switch back. Completing a full lesson is optional."
     },
     {
       "type": "conditional",
@@ -66,21 +66,21 @@
         {
           "type": "interactive",
           "action": "noop",
-          "content": "If Learn suggests lessons, pick one and take a single step.\n\nLearn mode pauses between steps and asks before it creates or changes anything. You do not need to finish the whole lesson for this path."
+          "content": "If Learn suggests lessons, pick one and take a single step.\n\nNotice that Learn pauses and asks before it creates or changes anything. That is the cue to stay in Learn when you want coaching, and to switch back to **Assistant** when you want to do the work yourself. You do not need to finish the whole lesson for this path."
         },
         {
           "type": "interactive",
           "action": "highlight",
           "reftarget": "[data-testid='pde-lab-mode-selector-pill']",
           "doIt": false,
-          "content": "When you are done exploring, click the mode button again (it should say **Learn**).\n\nIn the dropdown, select **Assistant** (or another mode you use). You can return to Learn anytime the same way.",
+          "content": "When you are done exploring, click the mode button again (it should say **Learn**).\n\nIn the dropdown, select **Assistant** (or another mode you use). Return to Learn when you want guided lessons; stay in Assistant for day-to-day prompts.",
           "requirements": ["exists-reftarget"]
         }
       ]
     },
     {
       "type": "markdown",
-      "content": "You found Learn mode and know how to start (and leave) a lesson.\n\nFor full details, refer to [Use Learn mode](https://grafana.com/docs/grafana-cloud/machine-learning/assistant/guides/learn-mode/)."
+      "content": "You can find Learn mode and choose when to use it versus Assistant: Learn for coaching that asks before changes; Assistant when you are ready to act.\n\nFor full details, refer to [Use Learn mode](https://grafana.com/docs/grafana-cloud/machine-learning/assistant/guides/learn-mode/)."
     },
     {
       "type": "conditional",

--- a/get-started-grafana-assistant-lj/try-learn-mode/manifest.json
+++ b/get-started-grafana-assistant-lj/try-learn-mode/manifest.json
@@ -1,0 +1,17 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "get-started-grafana-assistant-try-learn-mode",
+  "type": "guide",
+  "description": "Open Learn from the mode menu, optionally start a short lesson, then switch back to Assistant.",
+  "category": "onboarding",
+  "author": {
+    "name": "bonnywelsford-source",
+    "team": "Grafana Documentation"
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": ["get-started-grafana-assistant-use-mentions"],
+  "recommends": ["get-started-grafana-assistant-end-journey"],
+  "suggests": []
+}

--- a/get-started-grafana-assistant-lj/try-learn-mode/manifest.json
+++ b/get-started-grafana-assistant-lj/try-learn-mode/manifest.json
@@ -2,7 +2,7 @@
   "schemaVersion": "1.1.0",
   "id": "get-started-grafana-assistant-try-learn-mode",
   "type": "guide",
-  "description": "Open Learn from the mode menu, optionally start a short lesson, then switch back to Assistant.",
+  "description": "Choose Learn for coaching or Assistant for day-to-day work; open Learn, optionally start a short lesson, then switch back.",
   "category": "onboarding",
   "author": {
     "name": "bonnywelsford-source",

--- a/get-started-grafana-assistant-lj/try-learn-mode/website.yaml
+++ b/get-started-grafana-assistant-lj/try-learn-mode/website.yaml
@@ -1,0 +1,10 @@
+menuTitle: Find Learn mode
+weight: 600
+step: 6
+layout: single-journey
+cta:
+  type: continue
+keywords:
+  - Grafana Assistant
+  - Learn mode
+description: Open Learn from the mode menu, optionally start a short lesson, then switch back to Assistant.

--- a/get-started-grafana-assistant-lj/try-learn-mode/website.yaml
+++ b/get-started-grafana-assistant-lj/try-learn-mode/website.yaml
@@ -1,4 +1,4 @@
-menuTitle: Find Learn mode
+menuTitle: Choose Learn mode
 weight: 600
 step: 6
 layout: single-journey
@@ -7,4 +7,4 @@ cta:
 keywords:
   - Grafana Assistant
   - Learn mode
-description: Open Learn from the mode menu, optionally start a short lesson, then switch back to Assistant.
+description: Choose Learn for coaching or Assistant for day-to-day work; open Learn from the mode menu, optionally start a short lesson, then switch back.

--- a/get-started-grafana-assistant-lj/use-mentions/content.json
+++ b/get-started-grafana-assistant-lj/use-mentions/content.json
@@ -5,7 +5,7 @@
   "blocks": [
     {
       "type": "markdown",
-      "content": "At-mentions tell Assistant which data source, dashboard, or panel to use. Without a mention, Assistant may pick a data source for you or ask for more detail. With a mention, you point it at the right place so answers are more accurate.\n\nHere you send a vague prompt first, then the same kind of request with an at-mention so Assistant targets a specific data source.\n\nIf this guide is docked, pop it out so the chat stays visible."
+      "content": "At-mentions tell Assistant which data source, dashboard, or panel to use. Without a mention, Assistant may pick a data source for you or ask for more detail. With a mention, you point it at the right place so answers are more accurate.\n\nHere you send a vague prompt first, then the same kind of request with an at-mention so Assistant targets a specific data source."
     },
     {
       "type": "conditional",

--- a/get-started-grafana-assistant-lj/use-mentions/content.json
+++ b/get-started-grafana-assistant-lj/use-mentions/content.json
@@ -5,7 +5,7 @@
   "blocks": [
     {
       "type": "markdown",
-      "content": "At-mentions tell Assistant which data source, dashboard, or panel to use. Without a mention, Assistant may pick a data source for you or ask for more detail. With a mention, you point it at the right place so answers are more accurate.\n\nUse this rule when you choose:\n\n- **Mention** when you already know which data source (or dashboard/panel) should answer the question.\n- **Omit** when you are exploring what is available and do not have a target yet.\n- **Retry with a mention** when a reply ignored the source you meant, or stayed too generic.\n\nHere you send a vague prompt first, then the same kind of request with an at-mention so you can compare focus."
+      "content": "At-mentions specify which data source, dashboard, or panel the request should use. Without a mention, the reply might use a different data source or request more detail. With a mention, you point the request at the right place so answers are more accurate.\n\nUse this rule when you choose:\n\n- **Mention** when you already know which data source (or dashboard/panel) should answer the question.\n- **Omit** when you are exploring what is available and don't have a target yet.\n- **Retry with a mention** when the reply doesn't use the source you meant, or stays too generic.\n\nHere you send a vague prompt first, then the same kind of request with an at-mention so you can compare focus."
     },
     {
       "type": "conditional",
@@ -22,7 +22,7 @@
     },
     {
       "type": "markdown",
-      "content": "To see why at-mentions help, complete the following steps:"
+      "content": "To compare a vague prompt with an at-mention, complete the following steps:"
     },
     {
       "type": "section",
@@ -79,7 +79,7 @@
         {
           "type": "interactive",
           "action": "noop",
-          "content": "Compare the two replies for focus, not perfection:\n\n- The **mentioned** reply should center on the data source you picked (name it, query it, or stay clearly scoped to it).\n- The **vague** reply may roam, pick a different source, or ask for more detail.\n\nIf the mentioned reply is clearer, keep using `@` when you know the target. If you only needed a tour of what exists, omitting `@` is fine."
+          "content": "Compare the two replies for focus, not perfection:\n\n- The **mentioned** reply should stay scoped to the data source you picked (name it, include a query for it, or otherwise stay clearly limited to it).\n- The **vague** reply might cover several sources, use a different source, or request more detail.\n\nIf the mentioned reply is clearer, keep using `@` when you know the target. If you only needed a tour of what exists, omitting `@` is fine."
         }
       ]
     },
@@ -102,7 +102,7 @@
     },
     {
       "type": "markdown",
-      "content": "In the next milestone, you'll find Learn mode in the Assistant panel."
+      "content": "In the next milestone, you'll choose Learn mode in the Assistant panel."
     }
   ]
 }

--- a/get-started-grafana-assistant-lj/use-mentions/content.json
+++ b/get-started-grafana-assistant-lj/use-mentions/content.json
@@ -1,0 +1,108 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "get-started-grafana-assistant-use-mentions",
+  "title": "Use @ mentions for better results",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "At-mentions tell Assistant which data source, dashboard, or panel to use. Without a mention, Assistant may pick a data source for you or ask for more detail. With a mention, you point it at the right place so answers are more accurate.\n\nHere you send a vague prompt first, then the same kind of request with an at-mention so Assistant targets a specific data source.\n\nIf this guide is docked, pop it out so the chat stays visible."
+    },
+    {
+      "type": "conditional",
+      "conditions": ["renderer:pathfinder"],
+      "whenTrue": [
+        {
+          "type": "interactive",
+          "action": "popout",
+          "targetvalue": "floating",
+          "content": "If this guide is docked in the sidebar, pop it out into a floating window so it stays visible beside **Assistant**."
+        }
+      ],
+      "whenFalse": []
+    },
+    {
+      "type": "markdown",
+      "content": "To see why at-mentions help, complete the following steps:"
+    },
+    {
+      "type": "section",
+      "id": "send-mention-prompt",
+      "title": "Compare vague vs at-mention",
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "div[data-testid='data-testid Nav toolbar'] button[data-testid='extension-toolbar-button-open']",
+          "content": "Open **Assistant** from the top toolbar (sparkle icon) if the panel is closed.",
+          "requirements": ["exists-reftarget"],
+          "skippable": true,
+          "hint": "Skip if Assistant is already open from the previous milestone."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='grafana-assistant-chat'] [data-testid='prompt-input-body'] [role='textbox'][contenteditable='true']",
+          "doIt": false,
+          "content": "In the chat input, paste or type a vague prompt (no at-mention):\n\n> Show me something useful from my stack\n\nOr try:\n\n> What can you tell me about my data sources?"
+          "requirements": ["exists-reftarget"]
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='grafana-assistant-chat'] button[aria-label='Send message']",
+          "content": "Click **Send**.",
+          "requirements": ["exists-reftarget"]
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='grafana-assistant-chat'] [data-testid='prompt-input-body'] [role='textbox'][contenteditable='true']",
+          "doIt": false,
+          "content": "In a new message, type the at symbol (@) in the chat input.\n\nPick a data source from the mention list (or type the name after the at symbol). Prefer one you already know from this path, for example a Prometheus or Loki source.",
+          "requirements": ["exists-reftarget"]
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='grafana-assistant-chat'] [data-testid='prompt-input-body'] [role='textbox'][contenteditable='true']",
+          "doIt": false,
+          "content": "Finish the prompt so it uses that mention.\n\nExample shapes (replace the mention with yours):\n\n> Summarize what I can query from @prometheus-ds\n\n> Show recent activity from @loki-logs\n\n> List metrics available in @grafanacloud-usage",
+          "requirements": ["exists-reftarget"]
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='grafana-assistant-chat'] button[aria-label='Send message']",
+          "content": "Click **Send**.",
+          "requirements": ["exists-reftarget"]
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Compare the two replies.\n\nYou are looking for a clearer focus on the data source you mentioned, not a perfect answer."
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "You practiced turning a vague request into a targeted one with an at-mention.\n\nFor more examples, refer to [Use mentions for better results](https://grafana.com/docs/grafana-cloud/machine-learning/assistant/get-started/grafana-cloud/#use-mentions-for-better-results)."
+    },
+    {
+      "type": "conditional",
+      "conditions": ["renderer:pathfinder"],
+      "whenTrue": [
+        {
+          "type": "interactive",
+          "action": "popout",
+          "targetvalue": "sidebar",
+          "content": "Dock this guide back to the sidebar when you are ready for the next milestone."
+        }
+      ],
+      "whenFalse": []
+    },
+    {
+      "type": "markdown",
+      "content": "In the next milestone, you'll find Learn mode in the Assistant panel."
+    }
+  ]
+}

--- a/get-started-grafana-assistant-lj/use-mentions/content.json
+++ b/get-started-grafana-assistant-lj/use-mentions/content.json
@@ -5,7 +5,7 @@
   "blocks": [
     {
       "type": "markdown",
-      "content": "At-mentions tell Assistant which data source, dashboard, or panel to use. Without a mention, Assistant may pick a data source for you or ask for more detail. With a mention, you point it at the right place so answers are more accurate.\n\nHere you send a vague prompt first, then the same kind of request with an at-mention so Assistant targets a specific data source."
+      "content": "At-mentions tell Assistant which data source, dashboard, or panel to use. Without a mention, Assistant may pick a data source for you or ask for more detail. With a mention, you point it at the right place so answers are more accurate.\n\nUse this rule when you choose:\n\n- **Mention** when you already know which data source (or dashboard/panel) should answer the question.\n- **Omit** when you are exploring what is available and do not have a target yet.\n- **Retry with a mention** when a reply ignored the source you meant, or stayed too generic.\n\nHere you send a vague prompt first, then the same kind of request with an at-mention so you can compare focus."
     },
     {
       "type": "conditional",
@@ -79,13 +79,13 @@
         {
           "type": "interactive",
           "action": "noop",
-          "content": "Compare the two replies.\n\nYou are looking for a clearer focus on the data source you mentioned, not a perfect answer."
+          "content": "Compare the two replies for focus, not perfection:\n\n- The **mentioned** reply should center on the data source you picked (name it, query it, or stay clearly scoped to it).\n- The **vague** reply may roam, pick a different source, or ask for more detail.\n\nIf the mentioned reply is clearer, keep using `@` when you know the target. If you only needed a tour of what exists, omitting `@` is fine."
         }
       ]
     },
     {
       "type": "markdown",
-      "content": "You practiced turning a vague request into a targeted one with an at-mention.\n\nFor more examples, refer to [Use mentions for better results](https://grafana.com/docs/grafana-cloud/machine-learning/assistant/get-started/grafana-cloud/#use-mentions-for-better-results)."
+      "content": "You practiced turning a vague request into a targeted one with an at-mention, and when to mention versus explore without one.\n\nFor more examples, refer to [Use mentions for better results](https://grafana.com/docs/grafana-cloud/machine-learning/assistant/get-started/grafana-cloud/#use-mentions-for-better-results)."
     },
     {
       "type": "conditional",

--- a/get-started-grafana-assistant-lj/use-mentions/content.json
+++ b/get-started-grafana-assistant-lj/use-mentions/content.json
@@ -43,7 +43,7 @@
           "action": "highlight",
           "reftarget": "[data-testid='grafana-assistant-chat'] [data-testid='prompt-input-body'] [role='textbox'][contenteditable='true']",
           "doIt": false,
-          "content": "In the chat input, paste or type a vague prompt (no at-mention):\n\n> Show me something useful from my stack\n\nOr try:\n\n> What can you tell me about my data sources?"
+          "content": "In the chat input, paste or type a vague prompt (no at-mention):\n\n> Show me something useful from my stack\n\nOr try:\n\n> What can you tell me about my data sources?",
           "requirements": ["exists-reftarget"]
         },
         {

--- a/get-started-grafana-assistant-lj/use-mentions/manifest.json
+++ b/get-started-grafana-assistant-lj/use-mentions/manifest.json
@@ -1,0 +1,17 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "get-started-grafana-assistant-use-mentions",
+  "type": "guide",
+  "description": "Practice @ mentions in Grafana Assistant so prompts target a specific data source.",
+  "category": "onboarding",
+  "author": {
+    "name": "bonnywelsford-source",
+    "team": "Grafana Documentation"
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": ["get-started-grafana-assistant-first-prompt"],
+  "recommends": ["get-started-grafana-assistant-try-learn-mode"],
+  "suggests": []
+}

--- a/get-started-grafana-assistant-lj/use-mentions/website.yaml
+++ b/get-started-grafana-assistant-lj/use-mentions/website.yaml
@@ -1,0 +1,11 @@
+menuTitle: Use @ mentions
+weight: 500
+step: 5
+layout: single-journey
+cta:
+  type: continue
+keywords:
+  - Grafana Assistant
+  - mentions
+  - data sources
+description: Practice @ mentions in Grafana Assistant so prompts target a specific data source.

--- a/get-started-grafana-assistant-lj/value-of-assistant/content.json
+++ b/get-started-grafana-assistant-lj/value-of-assistant/content.json
@@ -13,7 +13,7 @@
     },
     {
       "type": "markdown",
-      "content": "In this path you will:\n\n1. Open the Grafana Assistant plugin page\n2. Enable Assistant if your stack still shows the enable page\n3. Open Assistant and send a first prompt\n4. Use an `@` mention to target a data source\n5. Find Learn mode in the panel"
+      "content": "In this path you will:\n\n1. Open the Grafana Assistant plugin page\n2. Enable Assistant if your stack still shows the enable page\n3. Send a first prompt and judge whether the reply is specific enough\n4. Decide when to use an `@` mention versus exploring without one\n5. Choose Learn mode for coaching or Assistant for day-to-day work"
     },
     {
       "type": "markdown",

--- a/get-started-grafana-assistant-lj/value-of-assistant/content.json
+++ b/get-started-grafana-assistant-lj/value-of-assistant/content.json
@@ -1,0 +1,27 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "get-started-grafana-assistant-value-of-assistant",
+  "title": "Why Grafana Assistant",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "Grafana Assistant helps you work with Grafana through natural language. Instead of writing PromQL, LogQL, or TraceQL from scratch, you describe what you want and Assistant generates queries, finds dashboards, and helps you understand what your data shows."
+    },
+    {
+      "type": "markdown",
+      "content": "In Grafana Cloud, Assistant runs in your stack. After an administrator enables it (when your stack requires that step), the sparkle icon appears in the top-right corner for users with access.\n\nAssistant doesn't send data to any AI provider until someone actively uses an Assistant feature."
+    },
+    {
+      "type": "markdown",
+      "content": "In this path you will:\n\n1. Open the Grafana Assistant plugin page\n2. Enable Assistant if your stack still shows the enable page\n3. Open Assistant and send a first prompt\n4. Use an `@` mention to target a data source\n5. Find Learn mode in the panel"
+    },
+    {
+      "type": "markdown",
+      "content": "In the next milestone, you'll open the Grafana Assistant plugin and enable it if needed."
+    },
+    {
+      "type": "markdown",
+      "content": "---\n\n### More to explore (optional)\n\n- [What is Grafana Assistant?](https://grafana.com/docs/grafana-cloud/machine-learning/assistant/)\n- [Manage your data privacy and security](https://grafana.com/docs/grafana-cloud/machine-learning/assistant/privacy-and-security/)"
+    }
+  ]
+}

--- a/get-started-grafana-assistant-lj/value-of-assistant/manifest.json
+++ b/get-started-grafana-assistant-lj/value-of-assistant/manifest.json
@@ -1,0 +1,17 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "get-started-grafana-assistant-value-of-assistant",
+  "type": "guide",
+  "description": "Understand why Grafana Assistant helps you query, navigate, and build dashboards with natural language.",
+  "category": "onboarding",
+  "author": {
+    "name": "bonnywelsford-source",
+    "team": "Grafana Documentation"
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": [],
+  "recommends": ["get-started-grafana-assistant-open-and-enable-plugin"],
+  "suggests": []
+}

--- a/get-started-grafana-assistant-lj/value-of-assistant/website.yaml
+++ b/get-started-grafana-assistant-lj/value-of-assistant/website.yaml
@@ -1,0 +1,10 @@
+menuTitle: Why Grafana Assistant
+weight: 200
+step: 2
+layout: single-journey
+cta:
+  type: continue
+keywords:
+  - Grafana Assistant
+  - overview
+description: Understand why Grafana Assistant helps you query, navigate, and build dashboards with natural language.

--- a/get-started-grafana-assistant-lj/website.yaml
+++ b/get-started-grafana-assistant-lj/website.yaml
@@ -23,4 +23,4 @@ keywords:
   - AI
   - natural language
   - setup
-description: Enable Grafana Assistant in Grafana Cloud, start your first conversation, use @ mentions, and find Learn mode.
+description: Enable Grafana Assistant in Grafana Cloud, judge your first reply, decide when to use @ mentions, and choose Learn vs Assistant mode.

--- a/get-started-grafana-assistant-lj/website.yaml
+++ b/get-started-grafana-assistant-lj/website.yaml
@@ -1,0 +1,26 @@
+menuTitle: Get started with Grafana Assistant
+weight: 2150
+journey:
+  group: onboarding
+  skill: Beginner
+  source: Docs & blog posts
+  logo:
+    src: /static/img/menu/cloud.svg
+    background: '#FFFFFF'
+    width: 46
+    height: 55
+step: 1
+layout: single-journey
+cascade:
+  layout: single-journey
+cta:
+  type: start
+  title: Are you ready?
+  cta_text: Let's go!
+keywords:
+  - Grafana Assistant
+  - Grafana Cloud
+  - AI
+  - natural language
+  - setup
+description: Enable Grafana Assistant in Grafana Cloud, start your first conversation, use @ mentions, and find Learn mode.


### PR DESCRIPTION
## Summary
- Adds the `get-started-grafana-assistant-lj` Pathfinder learning path for Grafana Cloud: open/enable the Assistant plugin, send a first prompt, use `@` mentions, and find Learn mode.
- Registers CODEOWNERS for the new path package.

## Reviewer notes
- Assistant chat prompts are entered by the learner (`highlight` + `doIt: false`). Pathfinder `formfill` does not work on the TipTap chat input.
- Switching to Learn (and back) is one step: open the mode menu, then pick the mode. A separate step for the menu item fails because the item is not in the DOM until the menu is open.
- `value-of-assistant` stays in the package for the website Learning Path, but is omitted from Pathfinder `milestones` (framing). First hands-on is `open-and-enable-plugin` with `depends: []`.
- Enable checkbox / **Save** steps are skippable when Assistant is already enabled (for example on learn.grafana.net).

## Test plan
- [ ] Pathfinder CLI: `validate --packages get-started-grafana-assistant-lj`
- [ ] Block Editor smoke on learn.grafana.net: `open-and-enable-plugin`, `first-prompt`, `use-mentions`, `try-learn-mode`
- [ ] Confirm website framing step `value-of-assistant` is not required to start the in-app path
- [ ] Confirm enable steps skip cleanly when Assistant is already on


Made with [Cursor](https://cursor.com)