### PR TITLE
Add Work with Grafana Assistant learning path

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -107,6 +107,7 @@
 /visualization-traces-lj/                                 @knylander-grafana
 /git-sync-dashboards-lj/                                  @bonnywelsford-source
 /interactive-dashboards-lj/                               @bonnywelsford-source
+/work-with-grafana-assistant-lj/                          @bonnywelsford-source
 /welcome-to-play/                                         @Jayclifford345 @mdcruz
 /windows-integration/                                     @chri2547
 /haproxy-load-balancer-lj/                                @tacole02

--- a/work-with-grafana-assistant-lj/assets/selector-notes.md
+++ b/work-with-grafana-assistant-lj/assets/selector-notes.md
@@ -1,0 +1,11 @@
+# Selector notes - work-with-grafana-assistant-lj
+
+Same Assistant chat patterns as `get-started-grafana-assistant-lj`.
+
+| Element | Selector | Notes |
+| --- | --- | --- |
+| Open Assistant toolbar | `div[data-testid='data-testid Nav toolbar'] button[data-testid='extension-toolbar-button-open']` | skippable when open |
+| Prompt input | `[data-testid='grafana-assistant-chat'] [data-testid='prompt-input-body'] [role='textbox'][contenteditable='true']` | TipTap; use `highlight` + `doIt: false` |
+| Send | `[data-testid='grafana-assistant-chat'] button[aria-label='Send message']` | |
+
+Avoid lone `` `@` `` in prose (Pathfinder layout break). Use "at-mention" / "at symbol (@)".

--- a/work-with-grafana-assistant-lj/content.json
+++ b/work-with-grafana-assistant-lj/content.json
@@ -1,0 +1,27 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "work-with-grafana-assistant-lj",
+  "title": "Work with Grafana Assistant",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "After Assistant is available in your Grafana Cloud stack, you can use natural language to find resources, write and explain queries, refine drafts, and create or edit dashboards."
+    },
+    {
+      "type": "markdown",
+      "content": "## Here's what to expect\n\nWhen you complete this path, you'll be able to:\n\n- Ask Assistant to find dashboards or list data sources\n- Generate a metrics or logs query with an at-mention\n- Paste a query and ask Assistant to explain it\n- Refine a query draft with a follow-up prompt\n- Create a small dashboard from a plain-language goal, or explain an existing panel"
+    },
+    {
+      "type": "markdown",
+      "content": "## Before you begin\n\n- Grafana Assistant enabled in your Grafana Cloud stack. Refer to [Get started with Grafana Assistant](https://grafana.com/docs/learning-paths/get-started-grafana-assistant/) if you still need to enable it.\n- At least one data source configured (Prometheus or Loki recommended).\n- Permission to view data sources and dashboards in your stack.\n\nTreat generated queries and dashboards as drafts you review before relying on them."
+    },
+    {
+      "type": "markdown",
+      "content": "## Troubleshooting\n\nIf you get stuck, we've got your back! Where appropriate, troubleshooting information is just a click away."
+    },
+    {
+      "type": "markdown",
+      "content": "## More to explore\n\nWe understand you might want to explore other capabilities not strictly on this path. We'll provide you opportunities where it makes sense."
+    }
+  ]
+}

--- a/work-with-grafana-assistant-lj/content.json
+++ b/work-with-grafana-assistant-lj/content.json
@@ -9,7 +9,7 @@
     },
     {
       "type": "markdown",
-      "content": "## Here's what to expect\n\nWhen you complete this path, you'll be able to:\n\n- Ask Assistant to find dashboards or list data sources\n- Generate a metrics or logs query with an at-mention\n- Paste a query and ask Assistant to explain it\n- Refine a query draft with a follow-up prompt\n- Create a small dashboard from a plain-language goal, or explain an existing panel"
+      "content": "## Here's what to expect\n\nWhen you complete this path, you'll be able to:\n\n- Find dashboards or data sources and decide whether to open a result or narrow the ask\n- Generate a metrics or logs query with an at-mention and judge whether the draft is specific enough\n- Check a query explanation against selectors, functions, and range\n- Choose a refine prompt for a concrete problem and verify the new draft\n- Create a draft dashboard or explain an existing one, then review before you trust it"
     },
     {
       "type": "markdown",

--- a/work-with-grafana-assistant-lj/create-or-edit-dashboard/content.json
+++ b/work-with-grafana-assistant-lj/create-or-edit-dashboard/content.json
@@ -21,8 +21,7 @@
       "whenFalse": []
     },
     {
-      "type": "interactive",
-      "action": "noop",
+      "type": "markdown",
       "content": "Confirm your choice: **Option A** (create) or **Option B** (explain).\n\nIf you chose **Option B**, skip the whole Option A section that follows and continue at Option B."
     },
     {
@@ -94,7 +93,7 @@
           "action": "highlight",
           "reftarget": "[data-testid='grafana-assistant-chat'] [data-testid='prompt-input-body'] [role='textbox'][contenteditable='true']",
           "doIt": false,
-          "content": "In the chat input, paste or type:\n\n> Explain what this dashboard shows.\n\nOr use a panel menu Assistant action if available (**Explain**, **Troubleshoot**, and similar), then skip **Send**.",
+          "content": "In the chat input, paste or type:\n\n> Explain what this dashboard shows.\n\nOr use a panel menu Assistant action if available (**Explain in Assistant**, **Troubleshoot panel**, and similar), then skip **Send**.",
           "requirements": ["exists-reftarget"],
           "skippable": true,
           "hint": "Skip if you chose Option A, or if you already used a panel menu action."

--- a/work-with-grafana-assistant-lj/create-or-edit-dashboard/content.json
+++ b/work-with-grafana-assistant-lj/create-or-edit-dashboard/content.json
@@ -1,0 +1,142 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "work-with-grafana-assistant-create-or-edit-dashboard",
+  "title": "Create or explain a dashboard",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "Assistant can create panels from a plain-language goal and help you understand dashboards you already have.\n\nChoose one path now:\n\n- **Option A — Create a draft dashboard** if you have metrics data to work with.\n- **Option B — Explain an existing dashboard** if your stack has little data (open a dashboard you can view first).\n\nComplete only the section for your choice. Skip every step in the other section."
+    },
+    {
+      "type": "conditional",
+      "conditions": ["renderer:pathfinder"],
+      "whenTrue": [
+        {
+          "type": "interactive",
+          "action": "popout",
+          "targetvalue": "floating",
+          "content": "If this guide is docked in the sidebar, pop it out into a floating window so it stays visible beside **Assistant**."
+        }
+      ],
+      "whenFalse": []
+    },
+    {
+      "type": "interactive",
+      "action": "noop",
+      "content": "Confirm your choice: **Option A** (create) or **Option B** (explain).\n\nIf you chose **Option B**, skip the whole Option A section that follows and continue at Option B."
+    },
+    {
+      "type": "markdown",
+      "content": "To create a draft dashboard (**Option A**), complete the following steps:"
+    },
+    {
+      "type": "section",
+      "id": "option-a-create-dashboard",
+      "title": "Option A: Create a draft dashboard",
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "div[data-testid='data-testid Nav toolbar'] button[data-testid='extension-toolbar-button-open']",
+          "content": "If the Assistant panel is closed, open **Assistant** from the top toolbar.",
+          "requirements": ["exists-reftarget"],
+          "skippable": true,
+          "hint": "Skip this whole Option A section if you chose Option B, or skip this step if Assistant is already open."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='grafana-assistant-chat'] [data-testid='prompt-input-body'] [role='textbox'][contenteditable='true']",
+          "doIt": false,
+          "content": "In the chat input, paste or type:\n\n> Create a dashboard called 'Checkout Health' with panels for error rate, p95 latency, and request volume.\n\nMention data sources with the at symbol (@) when you can, for example a Prometheus source from the mention list.",
+          "requirements": ["exists-reftarget"],
+          "skippable": true,
+          "hint": "Skip if you chose Option B."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='grafana-assistant-chat'] button[aria-label='Send message']",
+          "content": "Click **Send**.",
+          "requirements": ["exists-reftarget"],
+          "skippable": true,
+          "hint": "Skip if you chose Option B."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Review the suggested panels before you save. Treat created dashboards as drafts.",
+          "skippable": true,
+          "hint": "Skip if you chose Option B."
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "If you finished **Option A**, you should have a draft dashboard to review. You can skip the Option B section below.\n\nIf you chose **Option B**, make sure a dashboard is open, then complete the following steps:"
+    },
+    {
+      "type": "section",
+      "id": "option-b-explain-dashboard",
+      "title": "Option B: Explain an existing dashboard",
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "div[data-testid='data-testid Nav toolbar'] button[data-testid='extension-toolbar-button-open']",
+          "content": "If the Assistant panel is closed, open **Assistant** from the top toolbar.",
+          "requirements": ["exists-reftarget"],
+          "skippable": true,
+          "hint": "Skip this whole Option B section if you chose Option A, or skip this step if Assistant is already open."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='grafana-assistant-chat'] [data-testid='prompt-input-body'] [role='textbox'][contenteditable='true']",
+          "doIt": false,
+          "content": "In the chat input, paste or type:\n\n> Explain what this dashboard shows.\n\nOr use a panel menu Assistant action if available (**Explain**, **Troubleshoot**, and similar), then skip **Send**.",
+          "requirements": ["exists-reftarget"],
+          "skippable": true,
+          "hint": "Skip if you chose Option A, or if you already used a panel menu action."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='grafana-assistant-chat'] button[aria-label='Send message']",
+          "content": "If you typed a prompt in chat, click **Send**.",
+          "requirements": ["exists-reftarget"],
+          "skippable": true,
+          "hint": "Skip if you chose Option A, or if you used a panel menu action instead."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Review the explanation.",
+          "skippable": true,
+          "hint": "Skip if you chose Option A."
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "You should have either a draft dashboard or a clear explanation of an existing dashboard or panel.\n\nFor more examples, refer to [Manage dashboards](https://grafana.com/docs/grafana-cloud/machine-learning/assistant/guides/dashboarding/)."
+    },
+    {
+      "type": "conditional",
+      "conditions": ["renderer:pathfinder"],
+      "whenTrue": [
+        {
+          "type": "interactive",
+          "action": "popout",
+          "targetvalue": "sidebar",
+          "content": "Dock this guide back to the sidebar when you are ready for the next milestone."
+        }
+      ],
+      "whenFalse": []
+    },
+    {
+      "type": "markdown",
+      "content": "In the next milestone, you'll wrap up this path and see where to go next."
+    }
+  ]
+}

--- a/work-with-grafana-assistant-lj/create-or-edit-dashboard/content.json
+++ b/work-with-grafana-assistant-lj/create-or-edit-dashboard/content.json
@@ -5,7 +5,7 @@
   "blocks": [
     {
       "type": "markdown",
-      "content": "Assistant can create panels from a plain-language goal and help you understand dashboards you already have.\n\nChoose one path now:\n\n- **Option A — Create a draft dashboard** if you have metrics data to work with.\n- **Option B — Explain an existing dashboard** if your stack has little data (open a dashboard you can view first).\n\nComplete only the section for your choice. Skip every step in the other section."
+      "content": "You can create panels from a plain-language goal, or ask for an explanation of a dashboard you already have.\n\nChoose one path now:\n\n- **Option A: Create a draft dashboard** if you have metrics data to work with.\n- **Option B: Explain an existing dashboard** if your stack has little data (open a dashboard you can view first).\n\nComplete only the section for your choice. Skip every step in the other section."
     },
     {
       "type": "conditional",
@@ -65,7 +65,7 @@
         {
           "type": "interactive",
           "action": "noop",
-          "content": "Review the suggested panels before you save. Treat created dashboards as drafts.",
+          "content": "Judge the draft before you save:\n\n- **Useful draft:** The panels match the goal you asked for (for example error rate, latency, and volume), and data sources look right when `@` mentions were used.\n- **Needs another pass:** Panels are missing, titles don't match the goal, or the draft isn't something you'd keep even as a starting point.\n\nDon't treat an unsaved or unreviewed draft as production. Save only after a quick review, or send a follow-up to adjust panels first.",
           "skippable": true,
           "hint": "Skip if you chose Option B."
         }
@@ -111,7 +111,7 @@
         {
           "type": "interactive",
           "action": "noop",
-          "content": "Review the explanation.",
+          "content": "Judge whether the explanation maps to the open dashboard:\n\n- **Useful:** It names panels or signals you can see on the dashboard, and the summary matches the layout in front of you.\n- **Needs a follow-up:** It stays generic, or it doesn't match the panels on screen.\n\nIf it needs a follow-up, point at a specific panel title in your next prompt.",
           "skippable": true,
           "hint": "Skip if you chose Option A."
         }
@@ -119,7 +119,7 @@
     },
     {
       "type": "markdown",
-      "content": "You should have either a draft dashboard or a clear explanation of an existing dashboard or panel.\n\nFor more examples, refer to [Manage dashboards](https://grafana.com/docs/grafana-cloud/machine-learning/assistant/guides/dashboarding/)."
+      "content": "You should have either a reviewed draft dashboard or an explanation you checked against the open dashboard.\n\nFor more examples, refer to [Manage dashboards](https://grafana.com/docs/grafana-cloud/machine-learning/assistant/guides/dashboarding/)."
     },
     {
       "type": "conditional",

--- a/work-with-grafana-assistant-lj/create-or-edit-dashboard/manifest.json
+++ b/work-with-grafana-assistant-lj/create-or-edit-dashboard/manifest.json
@@ -1,0 +1,17 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "work-with-grafana-assistant-create-or-edit-dashboard",
+  "type": "guide",
+  "description": "Create a small dashboard from a plain-language goal or explain an existing panel with Grafana Assistant.",
+  "category": "query-and-visualize",
+  "author": {
+    "name": "bonnywelsford-source",
+    "team": "Grafana Documentation"
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": ["work-with-grafana-assistant-refine-a-query"],
+  "recommends": ["work-with-grafana-assistant-end-journey"],
+  "suggests": []
+}

--- a/work-with-grafana-assistant-lj/create-or-edit-dashboard/website.yaml
+++ b/work-with-grafana-assistant-lj/create-or-edit-dashboard/website.yaml
@@ -1,0 +1,11 @@
+menuTitle: Create or explain a dashboard
+weight: 600
+step: 6
+layout: single-journey
+cta:
+  type: continue
+keywords:
+  - Grafana Assistant
+  - dashboards
+  - panels
+description: Create a small dashboard from a plain-language goal or explain an existing panel with Grafana Assistant.

--- a/work-with-grafana-assistant-lj/end-journey/content.json
+++ b/work-with-grafana-assistant-lj/end-journey/content.json
@@ -5,7 +5,7 @@
   "blocks": [
     {
       "type": "markdown",
-      "content": "Congratulations on completing this path! You practiced:\n\n- Finding dashboards or data sources with natural language\n- Generating queries with at-mentions\n- Explaining an existing PromQL query\n- Refining a query draft with a follow-up prompt\n- Creating a draft dashboard or explaining an existing panel"
+      "content": "Congratulations on completing this path! You practiced:\n\n- Finding resources and deciding when to open a result versus narrow the ask\n- Generating query drafts with at-mentions and checking data source, selectors, and time window\n- Reading query explanations against selectors, functions, and range\n- Refining a draft for a concrete problem and verifying the change\n- Creating a draft dashboard or explaining an existing one, then reviewing before you trust it"
     },
     {
       "type": "markdown",

--- a/work-with-grafana-assistant-lj/end-journey/content.json
+++ b/work-with-grafana-assistant-lj/end-journey/content.json
@@ -1,0 +1,15 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "work-with-grafana-assistant-end-journey",
+  "title": "Destination reached!",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "Congratulations on completing this path! You practiced:\n\n- Finding dashboards or data sources with natural language\n- Generating queries with at-mentions\n- Explaining an existing PromQL query\n- Refining a query draft with a follow-up prompt\n- Creating a draft dashboard or explaining an existing panel"
+    },
+    {
+      "type": "markdown",
+      "content": "---\n\n### More to explore (optional)\n\n- [Introduction to Grafana Assistant](https://grafana.com/docs/learning-hub/intro-to-grafana-assistant/) journey\n- [Use Learn mode](https://grafana.com/docs/grafana-cloud/machine-learning/assistant/guides/learn-mode/)\n- [Alerting with Assistant](https://grafana.com/docs/grafana-cloud/machine-learning/assistant/guides/alerting/)\n- [Infrastructure memory](https://grafana.com/docs/grafana-cloud/machine-learning/assistant/guides/infrastructure-memory/)\n- [Get started with Grafana Assistant](https://grafana.com/docs/learning-paths/get-started-grafana-assistant/) if teammates still need setup help"
+    }
+  ]
+}

--- a/work-with-grafana-assistant-lj/end-journey/manifest.json
+++ b/work-with-grafana-assistant-lj/end-journey/manifest.json
@@ -1,0 +1,17 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "work-with-grafana-assistant-end-journey",
+  "type": "guide",
+  "description": "Wrap up the Work with Grafana Assistant path and explore next steps.",
+  "category": "query-and-visualize",
+  "author": {
+    "name": "bonnywelsford-source",
+    "team": "Grafana Documentation"
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": ["work-with-grafana-assistant-create-or-edit-dashboard"],
+  "recommends": [],
+  "suggests": []
+}

--- a/work-with-grafana-assistant-lj/end-journey/website.yaml
+++ b/work-with-grafana-assistant-lj/end-journey/website.yaml
@@ -1,0 +1,21 @@
+menuTitle: Destination reached!
+weight: 700
+step: 7
+layout: single-journey
+cta:
+  type: conclusion
+keywords:
+  - Grafana Assistant
+  - completion
+  - next steps
+side_journeys:
+  title: More to explore (optional)
+  heading: 'Keep building with Assistant:'
+  items:
+    - title: Introduction to Grafana Assistant journey
+      link: /docs/learning-hub/intro-to-grafana-assistant/
+    - title: Use Learn mode
+      link: /docs/grafana-cloud/machine-learning/assistant/guides/learn-mode/
+    - title: Alerting with Assistant
+      link: /docs/grafana-cloud/machine-learning/assistant/guides/alerting/
+description: Wrap up the Work with Grafana Assistant path and explore next steps.

--- a/work-with-grafana-assistant-lj/explain-a-query/content.json
+++ b/work-with-grafana-assistant-lj/explain-a-query/content.json
@@ -5,7 +5,7 @@
   "blocks": [
     {
       "type": "markdown",
-      "content": "If you already have a query and want to understand it, paste it into Assistant and ask for an explanation. You can also ask for help optimizing a slow or overly broad query."
+      "content": "If you already have a query and want to understand it, paste it into chat and ask for an explanation. You can also ask how to tighten a slow or overly broad query.\n\nA useful explanation covers the main parts of the query, not only a one-line summary."
     },
     {
       "type": "conditional",
@@ -55,13 +55,13 @@
         {
           "type": "interactive",
           "action": "noop",
-          "content": "Read the explanation and check that it matches your understanding of the selectors and functions."
+          "content": "Judge whether the explanation is complete enough:\n\n- **Useful:** It covers the selectors (labels or filters), the functions or operations, and the range or window.\n- **Needs a follow-up:** It stays at a one-line summary, skips a part of the query, or conflicts with what you meant.\n\nIf it needs a follow-up, paste your intent (for example, \"I expected this to filter only production\") and ask for a corrected reading. You can refine the query itself in the next milestone."
         }
       ]
     },
     {
       "type": "markdown",
-      "content": "You should see a plain-language explanation of the query parts (rate, labels, and range).\n\nFor more examples, refer to [Query data](https://grafana.com/docs/grafana-cloud/machine-learning/assistant/guides/querying/)."
+      "content": "You practiced reading an explanation against a checklist (selectors, functions, and range), not only skimming the reply.\n\nFor more examples, refer to [Query data](https://grafana.com/docs/grafana-cloud/machine-learning/assistant/guides/querying/)."
     },
     {
       "type": "conditional",

--- a/work-with-grafana-assistant-lj/explain-a-query/content.json
+++ b/work-with-grafana-assistant-lj/explain-a-query/content.json
@@ -1,0 +1,84 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "work-with-grafana-assistant-explain-a-query",
+  "title": "Explain a query",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "If you already have a query and want to understand it, paste it into Assistant and ask for an explanation. You can also ask for help optimizing a slow or overly broad query."
+    },
+    {
+      "type": "conditional",
+      "conditions": ["renderer:pathfinder"],
+      "whenTrue": [
+        {
+          "type": "interactive",
+          "action": "popout",
+          "targetvalue": "floating",
+          "content": "If this guide is docked in the sidebar, pop it out into a floating window so it stays visible beside **Assistant**."
+        }
+      ],
+      "whenFalse": []
+    },
+    {
+      "type": "markdown",
+      "content": "To ask Assistant to explain a query, complete the following steps:"
+    },
+    {
+      "type": "section",
+      "id": "explain-promql",
+      "title": "Ask Assistant to explain PromQL",
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "div[data-testid='data-testid Nav toolbar'] button[data-testid='extension-toolbar-button-open']",
+          "content": "If the Assistant panel is closed, open **Assistant** from the top toolbar.",
+          "requirements": ["exists-reftarget"],
+          "skippable": true
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='grafana-assistant-chat'] [data-testid='prompt-input-body'] [role='textbox'][contenteditable='true']",
+          "doIt": false,
+          "content": "In the chat input, paste this prompt (or substitute a query from your own stack):\n\n> Explain what this PromQL query does: `rate(http_requests_total{job=\"api\"}[5m])`",
+          "requirements": ["exists-reftarget"]
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='grafana-assistant-chat'] button[aria-label='Send message']",
+          "content": "Click **Send**.",
+          "requirements": ["exists-reftarget"]
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Read the explanation and check that it matches your understanding of the selectors and functions."
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "You should see a plain-language explanation of the query parts (rate, labels, and range).\n\nFor more examples, refer to [Query data](https://grafana.com/docs/grafana-cloud/machine-learning/assistant/guides/querying/)."
+    },
+    {
+      "type": "conditional",
+      "conditions": ["renderer:pathfinder"],
+      "whenTrue": [
+        {
+          "type": "interactive",
+          "action": "popout",
+          "targetvalue": "sidebar",
+          "content": "Dock this guide back to the sidebar when you are ready for the next milestone."
+        }
+      ],
+      "whenFalse": []
+    },
+    {
+      "type": "markdown",
+      "content": "In the next milestone, you'll refine a query draft with a follow-up prompt."
+    }
+  ]
+}

--- a/work-with-grafana-assistant-lj/explain-a-query/manifest.json
+++ b/work-with-grafana-assistant-lj/explain-a-query/manifest.json
@@ -1,0 +1,17 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "work-with-grafana-assistant-explain-a-query",
+  "type": "guide",
+  "description": "Paste a PromQL query into Grafana Assistant and ask for a plain-language explanation.",
+  "category": "query-and-visualize",
+  "author": {
+    "name": "bonnywelsford-source",
+    "team": "Grafana Documentation"
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": ["work-with-grafana-assistant-query-natural-language"],
+  "recommends": ["work-with-grafana-assistant-refine-a-query"],
+  "suggests": []
+}

--- a/work-with-grafana-assistant-lj/explain-a-query/website.yaml
+++ b/work-with-grafana-assistant-lj/explain-a-query/website.yaml
@@ -1,0 +1,11 @@
+menuTitle: Explain a query
+weight: 400
+step: 4
+layout: single-journey
+cta:
+  type: continue
+keywords:
+  - Grafana Assistant
+  - PromQL
+  - explain
+description: Paste a PromQL query into Grafana Assistant and ask for a plain-language explanation.

--- a/work-with-grafana-assistant-lj/find-a-resource/content.json
+++ b/work-with-grafana-assistant-lj/find-a-resource/content.json
@@ -5,7 +5,7 @@
   "blocks": [
     {
       "type": "markdown",
-      "content": "Instead of browsing folders, describe what you need in plain language. You can ask for dashboards, a list of data sources, or an Explore view with a query already loaded.\n\nStay in **Assistant** mode for this path (switch back from Learn or other modes if needed). This path assumes you already know how to open Assistant and use `@` mentions from [Get started with Grafana Assistant](https://grafana.com/docs/learning-paths/get-started-grafana-assistant/)."
+      "content": "Instead of browsing folders, describe what you need in plain language. You can ask for dashboards, a list of data sources, or an Explore view with a query already loaded.\n\nStay out of **Learn** and other specialized modes for this path (for example **Dashboarding** or **Investigation**). This path assumes you already know how to open Assistant and use `@` mentions from [Get started with Grafana Assistant](https://grafana.com/docs/learning-paths/get-started-grafana-assistant/)."
     },
     {
       "type": "conditional",

--- a/work-with-grafana-assistant-lj/find-a-resource/content.json
+++ b/work-with-grafana-assistant-lj/find-a-resource/content.json
@@ -1,0 +1,85 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "work-with-grafana-assistant-find-a-resource",
+  "title": "Find a Grafana resource",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "Instead of browsing folders, describe what you need in plain language. Assistant can find dashboards, list data sources, and open Explore with a query already loaded.\n\nStay in **Assistant** mode for this path (switch back from Learn or other modes if needed)."
+    },
+    {
+      "type": "conditional",
+      "conditions": ["renderer:pathfinder"],
+      "whenTrue": [
+        {
+          "type": "interactive",
+          "action": "popout",
+          "targetvalue": "floating",
+          "content": "If this guide is docked in the sidebar, pop it out into a floating window so it stays visible when **Assistant** opens."
+        }
+      ],
+      "whenFalse": []
+    },
+    {
+      "type": "markdown",
+      "content": "To find a resource with Assistant, complete the following steps:"
+    },
+    {
+      "type": "section",
+      "id": "ask-to-find-resource",
+      "title": "Ask Assistant to find something",
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "div[data-testid='data-testid Nav toolbar'] button[data-testid='extension-toolbar-button-open']",
+          "content": "Open **Assistant** from the top toolbar (sparkle icon). You can also select **Assistant** from the left navigation.",
+          "requirements": ["exists-reftarget"],
+          "skippable": true,
+          "hint": "Skip if the Assistant panel is already open."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='grafana-assistant-chat'] [data-testid='prompt-input-body'] [role='textbox'][contenteditable='true']",
+          "doIt": false,
+          "content": "In the chat input, paste or type a prompt that matches your environment:\n\n> List Prometheus data sources available to me.\n\n> Find dashboards tagged \"production\" that include checkout metrics.\n\n> List data sources available to me.",
+          "requirements": ["exists-reftarget"]
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='grafana-assistant-chat'] button[aria-label='Send message']",
+          "content": "Click **Send** (the arrow next to the chat input).",
+          "requirements": ["exists-reftarget"]
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Review the reply.\n\nCheck that the resources or links match what you asked for. When a dashboard opens from the reply, the current time range stays the same."
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "You should see matching resources or a link you can open. Results depend on what exists in your stack.\n\nFor more prompts, refer to [Navigate Grafana resources](https://grafana.com/docs/grafana-cloud/machine-learning/assistant/guides/navigation/)."
+    },
+    {
+      "type": "conditional",
+      "conditions": ["renderer:pathfinder"],
+      "whenTrue": [
+        {
+          "type": "interactive",
+          "action": "popout",
+          "targetvalue": "sidebar",
+          "content": "Dock this guide back to the sidebar when you are ready for the next milestone."
+        }
+      ],
+      "whenFalse": []
+    },
+    {
+      "type": "markdown",
+      "content": "In the next milestone, you'll ask Assistant to write a query using natural language."
+    }
+  ]
+}

--- a/work-with-grafana-assistant-lj/find-a-resource/content.json
+++ b/work-with-grafana-assistant-lj/find-a-resource/content.json
@@ -5,7 +5,7 @@
   "blocks": [
     {
       "type": "markdown",
-      "content": "Instead of browsing folders, describe what you need in plain language. Assistant can find dashboards, list data sources, and open Explore with a query already loaded.\n\nStay in **Assistant** mode for this path (switch back from Learn or other modes if needed)."
+      "content": "Instead of browsing folders, describe what you need in plain language. You can ask for dashboards, a list of data sources, or an Explore view with a query already loaded.\n\nStay in **Assistant** mode for this path (switch back from Learn or other modes if needed). This path assumes you already know how to open Assistant and use `@` mentions from [Get started with Grafana Assistant](https://grafana.com/docs/learning-paths/get-started-grafana-assistant/)."
     },
     {
       "type": "conditional",
@@ -56,13 +56,13 @@
         {
           "type": "interactive",
           "action": "noop",
-          "content": "Review the reply.\n\nCheck that the resources or links match what you asked for. When a dashboard opens from the reply, the current time range stays the same."
+          "content": "Judge whether the reply is useful enough to act on:\n\n- **Useful:** It names resources or includes openable links that match what you asked for.\n- **Needs narrowing:** It's empty, off-target, or too broad for your stack.\n\nIf it's useful, open a result you care about. If it needs narrowing, send a follow-up with a tag, folder name, or `@` mention. When a dashboard opens from the reply, the current time range stays the same."
         }
       ]
     },
     {
       "type": "markdown",
-      "content": "You should see matching resources or a link you can open. Results depend on what exists in your stack.\n\nFor more prompts, refer to [Navigate Grafana resources](https://grafana.com/docs/grafana-cloud/machine-learning/assistant/guides/navigation/)."
+      "content": "You practiced finding a resource and deciding whether to open a result or narrow the ask. Results depend on what exists in your stack.\n\nFor more prompts, refer to [Navigate Grafana resources](https://grafana.com/docs/grafana-cloud/machine-learning/assistant/guides/navigation/)."
     },
     {
       "type": "conditional",
@@ -79,7 +79,7 @@
     },
     {
       "type": "markdown",
-      "content": "In the next milestone, you'll ask Assistant to write a query using natural language."
+      "content": "In the next milestone, you'll generate a query draft with natural language and an `@` mention."
     }
   ]
 }

--- a/work-with-grafana-assistant-lj/find-a-resource/manifest.json
+++ b/work-with-grafana-assistant-lj/find-a-resource/manifest.json
@@ -1,0 +1,17 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "work-with-grafana-assistant-find-a-resource",
+  "type": "guide",
+  "description": "Use Grafana Assistant to find dashboards or list data sources with natural language.",
+  "category": "query-and-visualize",
+  "author": {
+    "name": "bonnywelsford-source",
+    "team": "Grafana Documentation"
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": [],
+  "recommends": ["work-with-grafana-assistant-query-natural-language"],
+  "suggests": []
+}

--- a/work-with-grafana-assistant-lj/find-a-resource/website.yaml
+++ b/work-with-grafana-assistant-lj/find-a-resource/website.yaml
@@ -1,0 +1,12 @@
+menuTitle: Find a Grafana resource
+weight: 200
+step: 2
+layout: single-journey
+cta:
+  type: continue
+keywords:
+  - Grafana Assistant
+  - navigation
+  - dashboards
+  - data sources
+description: Use Grafana Assistant to find dashboards or list data sources with natural language.

--- a/work-with-grafana-assistant-lj/manifest.json
+++ b/work-with-grafana-assistant-lj/manifest.json
@@ -2,7 +2,7 @@
   "schemaVersion": "1.1.0",
   "id": "work-with-grafana-assistant-lj",
   "type": "path",
-  "description": "Practice Grafana Assistant workflows: find resources, query with natural language, explain and refine queries, and manage dashboards.",
+  "description": "Practice Grafana Assistant workflows and judge drafts: find resources, generate and refine queries, explain queries, and create or explain dashboards.",
   "category": "query-and-visualize",
   "author": {
     "name": "bonnywelsford-source",

--- a/work-with-grafana-assistant-lj/manifest.json
+++ b/work-with-grafana-assistant-lj/manifest.json
@@ -1,0 +1,37 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "work-with-grafana-assistant-lj",
+  "type": "path",
+  "description": "Practice Grafana Assistant workflows: find resources, query with natural language, explain and refine queries, and manage dashboards.",
+  "category": "query-and-visualize",
+  "author": {
+    "name": "bonnywelsford-source",
+    "team": "Grafana Documentation"
+  },
+  "startingLocation": "/",
+  "targeting": {
+    "match": {
+      "and": [
+        {
+          "urlRegex": "^/(d/|dashboards|explore|a/grafana-assistant-app|plugins/grafana-assistant-app)"
+        },
+        {
+          "targetPlatform": "cloud"
+        }
+      ]
+    }
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "milestones": [
+    "work-with-grafana-assistant-find-a-resource",
+    "work-with-grafana-assistant-query-natural-language",
+    "work-with-grafana-assistant-explain-a-query",
+    "work-with-grafana-assistant-refine-a-query",
+    "work-with-grafana-assistant-create-or-edit-dashboard",
+    "work-with-grafana-assistant-end-journey"
+  ],
+  "recommends": ["get-started-grafana-assistant-lj"],
+  "suggests": []
+}

--- a/work-with-grafana-assistant-lj/query-natural-language/content.json
+++ b/work-with-grafana-assistant-lj/query-natural-language/content.json
@@ -1,0 +1,84 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "work-with-grafana-assistant-query-natural-language",
+  "title": "Query with natural language",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "Assistant can write queries across your observability stack. Describe what you want and use an at-mention to point Assistant at a specific data source."
+    },
+    {
+      "type": "conditional",
+      "conditions": ["renderer:pathfinder"],
+      "whenTrue": [
+        {
+          "type": "interactive",
+          "action": "popout",
+          "targetvalue": "floating",
+          "content": "If this guide is docked in the sidebar, pop it out into a floating window so it stays visible beside **Assistant**."
+        }
+      ],
+      "whenFalse": []
+    },
+    {
+      "type": "markdown",
+      "content": "To generate a query from a prompt, complete the following steps:"
+    },
+    {
+      "type": "section",
+      "id": "run-natural-language-query",
+      "title": "Generate a query from a prompt",
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "div[data-testid='data-testid Nav toolbar'] button[data-testid='extension-toolbar-button-open']",
+          "content": "If the Assistant panel is closed, open **Assistant** from the top toolbar.",
+          "requirements": ["exists-reftarget"],
+          "skippable": true
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='grafana-assistant-chat'] [data-testid='prompt-input-body'] [role='textbox'][contenteditable='true']",
+          "doIt": false,
+          "content": "In the chat input, type the at symbol (@) and pick a data source from the mention list, then ask for a query.\n\nFor metrics:\n\n> Create a PromQL query in @prometheus-ds that shows p95 latency for checkout_service over the last hour.\n\nFor logs:\n\n> Find logs from @loki-logs where job=\"checkout\" and level=\"error\" in the last 15 minutes.\n\nReplace those example names with data sources in your stack.",
+          "requirements": ["exists-reftarget"]
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='grafana-assistant-chat'] button[aria-label='Send message']",
+          "content": "Click **Send**.",
+          "requirements": ["exists-reftarget"]
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Review the generated query and, when data is available, any visualization or Explore view Assistant opens.\n\nTreat the result as a draft. You refine it in a later milestone."
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "You practiced turning a natural-language request into a query draft.\n\nFor supported sources and more examples, refer to [Query data](https://grafana.com/docs/grafana-cloud/machine-learning/assistant/guides/querying/)."
+    },
+    {
+      "type": "conditional",
+      "conditions": ["renderer:pathfinder"],
+      "whenTrue": [
+        {
+          "type": "interactive",
+          "action": "popout",
+          "targetvalue": "sidebar",
+          "content": "Dock this guide back to the sidebar when you are ready for the next milestone."
+        }
+      ],
+      "whenFalse": []
+    },
+    {
+      "type": "markdown",
+      "content": "In the next milestone, you'll paste an existing query and ask Assistant to explain it."
+    }
+  ]
+}

--- a/work-with-grafana-assistant-lj/query-natural-language/content.json
+++ b/work-with-grafana-assistant-lj/query-natural-language/content.json
@@ -5,7 +5,7 @@
   "blocks": [
     {
       "type": "markdown",
-      "content": "Assistant can write queries across your observability stack. Describe what you want and use an at-mention to point Assistant at a specific data source."
+      "content": "You can generate queries across your observability stack from a plain-language ask. Describe what you want and use an at-mention so the request targets a specific data source.\n\nBefore you reuse a draft, check that the data source, selectors, and time window look right. You refine weak drafts in a later milestone."
     },
     {
       "type": "conditional",
@@ -55,13 +55,13 @@
         {
           "type": "interactive",
           "action": "noop",
-          "content": "Review the generated query and, when data is available, any visualization or Explore view Assistant opens.\n\nTreat the result as a draft. You refine it in a later milestone."
+          "content": "Judge the draft before you trust it:\n\n- **Ready to refine or try:** It uses the data source you mentioned, includes plausible metric or log selectors, and states a time window (in the query or in the reply).\n- **Needs another pass:** The source is wrong or missing, selectors look invented for your stack, or there is no time scope.\n\nTreat the result as a draft either way. When Explore or a visualization opens, use it as a check, not as a final answer. You tighten weak drafts in the refine milestone."
         }
       ]
     },
     {
       "type": "markdown",
-      "content": "You practiced turning a natural-language request into a query draft.\n\nFor supported sources and more examples, refer to [Query data](https://grafana.com/docs/grafana-cloud/machine-learning/assistant/guides/querying/)."
+      "content": "You practiced turning a natural-language request into a query draft and checking whether that draft is specific enough to continue.\n\nFor supported sources and more examples, refer to [Query data](https://grafana.com/docs/grafana-cloud/machine-learning/assistant/guides/querying/)."
     },
     {
       "type": "conditional",

--- a/work-with-grafana-assistant-lj/query-natural-language/manifest.json
+++ b/work-with-grafana-assistant-lj/query-natural-language/manifest.json
@@ -1,0 +1,17 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "work-with-grafana-assistant-query-natural-language",
+  "type": "guide",
+  "description": "Generate a metrics or logs query in Grafana Assistant using natural language and @ mentions.",
+  "category": "query-and-visualize",
+  "author": {
+    "name": "bonnywelsford-source",
+    "team": "Grafana Documentation"
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": ["work-with-grafana-assistant-find-a-resource"],
+  "recommends": ["work-with-grafana-assistant-explain-a-query"],
+  "suggests": []
+}

--- a/work-with-grafana-assistant-lj/query-natural-language/website.yaml
+++ b/work-with-grafana-assistant-lj/query-natural-language/website.yaml
@@ -1,0 +1,12 @@
+menuTitle: Query with natural language
+weight: 300
+step: 3
+layout: single-journey
+cta:
+  type: continue
+keywords:
+  - Grafana Assistant
+  - PromQL
+  - LogQL
+  - querying
+description: Generate a metrics or logs query in Grafana Assistant using natural language and @ mentions.

--- a/work-with-grafana-assistant-lj/refine-a-query/content.json
+++ b/work-with-grafana-assistant-lj/refine-a-query/content.json
@@ -1,0 +1,84 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "work-with-grafana-assistant-refine-a-query",
+  "title": "Refine a query",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "A first draft is rarely final. Ask Assistant to tighten filters, group results, or reduce how much data a query returns. Keep the conversation in the same chat so Assistant has the prior query as context."
+    },
+    {
+      "type": "conditional",
+      "conditions": ["renderer:pathfinder"],
+      "whenTrue": [
+        {
+          "type": "interactive",
+          "action": "popout",
+          "targetvalue": "floating",
+          "content": "If this guide is docked in the sidebar, pop it out into a floating window so it stays visible beside **Assistant**."
+        }
+      ],
+      "whenFalse": []
+    },
+    {
+      "type": "markdown",
+      "content": "To refine a query draft, complete the following steps:"
+    },
+    {
+      "type": "section",
+      "id": "refine-query-draft",
+      "title": "Ask for a tighter query",
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "div[data-testid='data-testid Nav toolbar'] button[data-testid='extension-toolbar-button-open']",
+          "content": "If the Assistant panel is closed, open **Assistant** from the top toolbar.",
+          "requirements": ["exists-reftarget"],
+          "skippable": true
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='grafana-assistant-chat'] [data-testid='prompt-input-body'] [role='textbox'][contenteditable='true']",
+          "doIt": false,
+          "content": "In the same conversation (or after pasting a query you care about), ask for a refinement.\n\nExamples:\n\n> Group by region and sort by highest error rate.\n\n> This query is returning too much data. Help me filter it to only the production namespace.\n\n> Narrow this to the last 15 minutes and keep only the top 5 series.",
+          "requirements": ["exists-reftarget"]
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='grafana-assistant-chat'] button[aria-label='Send message']",
+          "content": "Click **Send**.",
+          "requirements": ["exists-reftarget"]
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Compare the refined query to the earlier draft.\n\nCheck that filters, groupings, or time ranges match what you asked for before you reuse the query elsewhere."
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "You practiced improving a query with a follow-up prompt.\n\nFor more examples, refer to [Query data](https://grafana.com/docs/grafana-cloud/machine-learning/assistant/guides/querying/)."
+    },
+    {
+      "type": "conditional",
+      "conditions": ["renderer:pathfinder"],
+      "whenTrue": [
+        {
+          "type": "interactive",
+          "action": "popout",
+          "targetvalue": "sidebar",
+          "content": "Dock this guide back to the sidebar when you are ready for the next milestone."
+        }
+      ],
+      "whenFalse": []
+    },
+    {
+      "type": "markdown",
+      "content": "In the next milestone, you'll create a small dashboard from a description, or explain an existing panel if that fits your stack better."
+    }
+  ]
+}

--- a/work-with-grafana-assistant-lj/refine-a-query/content.json
+++ b/work-with-grafana-assistant-lj/refine-a-query/content.json
@@ -5,7 +5,7 @@
   "blocks": [
     {
       "type": "markdown",
-      "content": "A first draft is rarely final. Ask Assistant to tighten filters, group results, or reduce how much data a query returns. Keep the conversation in the same chat so Assistant has the prior query as context."
+      "content": "A first draft is rarely final. Send a follow-up to tighten filters, group results, or reduce how much data a query returns.\n\nRefine when the draft is too broad, uses the wrong grouping, uses the wrong time window, or returns too many series. Keep the conversation in the same chat so the prior query stays in context."
     },
     {
       "type": "conditional",
@@ -55,13 +55,13 @@
         {
           "type": "interactive",
           "action": "noop",
-          "content": "Compare the refined query to the earlier draft.\n\nCheck that filters, groupings, or time ranges match what you asked for before you reuse the query elsewhere."
+          "content": "Compare the refined query to the earlier draft against what you asked for:\n\n- **Success:** The new draft shows the filter, grouping, time window, or series limit you requested.\n- **Try again:** The change is missing, or the draft still looks too broad for reuse.\n\nOnly reuse the query elsewhere after the change you asked for appears in the draft."
         }
       ]
     },
     {
       "type": "markdown",
-      "content": "You practiced improving a query with a follow-up prompt.\n\nFor more examples, refer to [Query data](https://grafana.com/docs/grafana-cloud/machine-learning/assistant/guides/querying/)."
+      "content": "You practiced choosing a refine prompt for a concrete problem and checking that the new draft reflects that change.\n\nFor more examples, refer to [Query data](https://grafana.com/docs/grafana-cloud/machine-learning/assistant/guides/querying/)."
     },
     {
       "type": "conditional",

--- a/work-with-grafana-assistant-lj/refine-a-query/manifest.json
+++ b/work-with-grafana-assistant-lj/refine-a-query/manifest.json
@@ -1,0 +1,17 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "work-with-grafana-assistant-refine-a-query",
+  "type": "guide",
+  "description": "Refine a query draft in Grafana Assistant with a follow-up prompt.",
+  "category": "query-and-visualize",
+  "author": {
+    "name": "bonnywelsford-source",
+    "team": "Grafana Documentation"
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": ["work-with-grafana-assistant-explain-a-query"],
+  "recommends": ["work-with-grafana-assistant-create-or-edit-dashboard"],
+  "suggests": []
+}

--- a/work-with-grafana-assistant-lj/refine-a-query/website.yaml
+++ b/work-with-grafana-assistant-lj/refine-a-query/website.yaml
@@ -1,0 +1,12 @@
+menuTitle: Refine a query
+weight: 500
+step: 5
+layout: single-journey
+cta:
+  type: continue
+keywords:
+  - Grafana Assistant
+  - query
+  - refine
+  - optimize
+description: Refine a query draft in Grafana Assistant with a follow-up prompt.

--- a/work-with-grafana-assistant-lj/website.yaml
+++ b/work-with-grafana-assistant-lj/website.yaml
@@ -1,0 +1,32 @@
+menuTitle: Work with Grafana Assistant
+weight: 2160
+journey:
+  group: query-and-visualize
+  skill: Beginner
+  source: Docs & blog posts
+  logo:
+    src: /static/img/menu/cloud.svg
+    background: '#FFFFFF'
+    width: 46
+    height: 55
+step: 1
+layout: single-journey
+cascade:
+  layout: single-journey
+cta:
+  type: start
+  title: Are you ready?
+  cta_text: Let's go!
+keywords:
+  - Grafana Assistant
+  - query
+  - dashboards
+  - navigation
+  - natural language
+description: Practice Grafana Assistant workflows for finding resources, querying data, explaining and refining queries, and managing dashboards.
+related_journeys:
+  title: Related paths
+  heading: 'Complete setup first if you have not enabled Assistant yet:'
+  items:
+    - title: Get started with Grafana Assistant
+      link: /docs/learning-paths/get-started-grafana-assistant/

--- a/work-with-grafana-assistant-lj/website.yaml
+++ b/work-with-grafana-assistant-lj/website.yaml
@@ -26,7 +26,7 @@ keywords:
 description: Practice Grafana Assistant workflows and judge drafts for finding resources, querying data, explaining and refining queries, and managing dashboards.
 related_journeys:
   title: Related paths
-  heading: 'Complete setup first if you have not enabled Assistant yet:'
+  heading: 'If Assistant is not enabled yet, consider this setup guide:'
   items:
     - title: Get started with Grafana Assistant
       link: /docs/learning-paths/get-started-grafana-assistant/

--- a/work-with-grafana-assistant-lj/website.yaml
+++ b/work-with-grafana-assistant-lj/website.yaml
@@ -23,7 +23,7 @@ keywords:
   - dashboards
   - navigation
   - natural language
-description: Practice Grafana Assistant workflows for finding resources, querying data, explaining and refining queries, and managing dashboards.
+description: Practice Grafana Assistant workflows and judge drafts for finding resources, querying data, explaining and refining queries, and managing dashboards.
 related_journeys:
   title: Related paths
   heading: 'Complete setup first if you have not enabled Assistant yet:'


### PR DESCRIPTION
## Summary
- Adds the `work-with-grafana-assistant-lj` Pathfinder learning path: find resources, query with natural language, explain and refine queries, and create or explain a dashboard.
- Companion to Get started ([PR #495](https://github.com/grafana/interactive-tutorials/pull/495)); related-journey links point at that path once published.

## Test plan
- [ ] Pathfinder CLI `validate --packages work-with-grafana-assistant-lj` passes
- [ ] Block Editor smoke on learn.grafana.net for each interactive milestone (TipTap paste + Send; create/explain dashboard options)
- [ ] Confirm Assistant toolbar / chat selectors still match
- [ ] After Get started publishes, related-journey and Before you begin links resolve


Made with [Cursor](https://cursor.com)