### PR TITLE
Clarify framing milestones are Pathfinder-only omissions

### DIFF
--- a/.cursor/skills/preflight-learning-path/SKILL.md
+++ b/.cursor/skills/preflight-learning-path/SKILL.md
@@ -222,7 +222,7 @@ If MCP is blocked, stop with the blocked shape in author-testing.md (`checkpoint
 
 1. Snapshot `pre_review_assets`; dispatch [audit-guide](../audit-guide/SKILL.md) per milestone (parallel OK).
 2. Walk shared [review reference-checks](../review-learning-path/reference-checks.md) + [learning-hub-standards.md](../review-learning-path/learning-hub-standards.md).
-3. **Always scan** for framing-in-milestones, [section intro markdown that may number as a step](../review-learning-path/reference-checks.md#section-intro-markdown-numbered-as-a-step), and [false noops](../review-learning-path/reference-checks.md#noop-and-non-interactive-steps).
+3. **Always scan** for framing-in-milestones ([Pathfinder-only omission](../review-learning-path/reference-checks.md#framing-milestones): keep packages for the website), [section intro markdown that may number as a step](../review-learning-path/reference-checks.md#section-intro-markdown-numbered-as-a-step), and [false noops](../review-learning-path/reference-checks.md#noop-and-non-interactive-steps).
 4. Run Pathfinder CLI `validate --packages {path_dir}` if available.
 5. Run the shared [claim-check](../review-learning-path/claim-check.md) pass (preflight pointer: [claim-check.md](claim-check.md)). Write `{slug}-claim-check.md`. Route Contradicted / Unsupported / Overstated as Fix before PR. Do not edit package JSON here.
 6. Tag findings with review [finding routing](../review-learning-path/reference-checks.md#finding-routing). Keep only review-level items for later author chat.

--- a/.cursor/skills/preflight-learning-path/reference-checks.md
+++ b/.cursor/skills/preflight-learning-path/reference-checks.md
@@ -35,6 +35,14 @@ When the list mixes both kinds, number everything, but in **Your turn** say whic
 
 Keep the identify + static work quiet when the path is known. Put the full numbered + fix-choice treatment in the **one results menu** after live (or after allowed static-only).
 
+### Framing finding wording
+
+When a framing ID is in path `milestones`, use wording like:
+
+> `{slug}` is framing (value / why). Omit it from Pathfinder path `milestones` so the in-app path stays action-oriented. Keep the package and `website.yaml` — the website Learning Path still shows it. First hands-on `depends` must be `[]`.
+
+Never say “remove this milestone” without the Pathfinder-only / website-kept distinction.
+
 ---
 
 ## Finding severity (author)
@@ -54,7 +62,7 @@ Do not invent an author-only softer bar. Do not surface "Polish / follow-up" lis
 Apply the same five-phase coach rules (cite shared reference-checks; do not soften):
 
 - Playwright / Block Editor runtime fail (when live failed or `walk-me` failed)
-- **Framing milestones** in path `milestones`, or first hands-on `depends` on a framing ID (must be `depends: []`)
+- **Framing milestones** listed in path `milestones`, or first hands-on `depends` on a framing ID (must be `depends: []`). When surfacing: say this is **Pathfinder-only** (omit from `milestones` so Pathfinder stays action-oriented); keep the framing package + `website.yaml` for the website Learning Path. Do not imply the milestone is removed from the website.
 - **Fake steps in sections:** missing bookends outside the section; in-section intro markdown that numbers as a step (e.g. first child "You'll …")
 - **False noops:** learner-action copy with `noop` and no `reftarget`
 - Missing / broken required `website.yaml` identity; Learning Hub structure the author must change
@@ -154,7 +162,7 @@ Include in `{slug}-readiness.md`:
 
 - [ ] Path `{path_dir}` validates with Pathfinder CLI (or CLI unavailable noted)
 - [ ] First hands-on milestone `depends: []`
-- [ ] No framing IDs in path `manifest.json` `milestones`
+- [ ] No framing IDs in path `manifest.json` `milestones` (Pathfinder-only omission; framing packages remain for the website)
 - [ ] `schemaVersion: "1.1.0"` or omitted on milestone `content.json`
 - [ ] Playwright DOM checked for scoped interactive milestones
 - [ ] Block Editor: already-tested notes, walk-me results, or skip noted for reviewer

--- a/.cursor/skills/review-learning-path/comment-style.md
+++ b/.cursor/skills/review-learning-path/comment-style.md
@@ -56,6 +56,10 @@ Voice and formatting for GitHub inline comments and the review summary. The agen
 
 > The first hands-on milestone depends on `business-value`, which isn't in the path milestones array. That will break the depends chain for learners. Should be `"depends": []`.
 
+**Good (framing in Pathfinder milestones only):**
+
+> `business-value` is framing for the website Learning Path. Drop it from Pathfinder path `milestones` so the in-app path stays action-oriented. Keep the package and `website.yaml` — the website still shows that intro.
+
 **Good (section intro numbered as a step, path-wide):**
 
 > The "You'll …" markdown inside the section shows as a numbered step in Pathfinder. Same pattern in create-custom, use-variables-queries, and chain-variables. Move those intros outside the section (or drop them if the section title is enough).

--- a/.cursor/skills/review-learning-path/learning-hub-standards.md
+++ b/.cursor/skills/review-learning-path/learning-hub-standards.md
@@ -120,12 +120,12 @@ Count path `manifest.json` `milestones` entries (hands-on only; exclude framing 
 
 ### Value milestone (framing)
 
-Every path should open with **why** before **how**. In packages this is usually a framing directory (`business-value`, `value-*`, `advantages-*`, `welcome`) with markdown-only `content.json` — **not** listed in path `milestones`. See [framing vs not framing](reference-checks.md#framing-vs-not-framing): `end-journey` stays in `milestones`; markdown-only alone does not mean framing.
+Every path should open with **why** before **how**. In packages this is usually a framing directory (`business-value`, `value-*`, `advantages-*`, `welcome`) with markdown-only `content.json`. The website Learning Path still shows that framing; Pathfinder omits it from path `milestones` so the in-app UI stays action-oriented. See [framing vs not framing](reference-checks.md#framing-vs-not-framing): `end-journey` stays in `milestones`; markdown-only alone does not mean framing.
 
 | Check | Notes |
 |---|---|
 | No framing milestone and first hands-on jumps straight to steps without intro context | Editorial |
-| Framing ID incorrectly listed in path `milestones` | See [framing milestones](reference-checks.md#framing-milestones) |
+| Framing ID incorrectly listed in path `milestones` | Pathfinder-only fix — see [framing milestones](reference-checks.md#framing-milestones); keep the package for the website |
 | Value milestone is generic / no clear problem statement | Editorial |
 | Ambiguous prose package (e.g. `understanding-*`) in `milestones` | Internal until reviewer confirms framing vs path step |
 

--- a/.cursor/skills/review-learning-path/reference-checks.md
+++ b/.cursor/skills/review-learning-path/reference-checks.md
@@ -124,9 +124,13 @@ Same scan applies to [false noops](#noop-and-non-interactive-steps) even when st
 
 ## Framing milestones
 
-Framing packages may live in the path directory for the website Learning Path, but must **not** appear in path `manifest.json` `milestones`. First hands-on `depends` must not reference framing IDs.
+Framing packages (value / why intros) stay in the path directory for the **website** Learning Path. Omit them only from Pathfinder path `manifest.json` `milestones` so the in-app Pathfinder UI stays action-oriented. Do **not** delete the framing package, its `content.json`, or its `website.yaml` when fixing this.
 
-Framing in path `milestones` or broken depends → **post inline**.
+- Keep the framing directory + `website.yaml` when the website needs that intro.
+- Remove framing IDs from path `milestones` (Pathfinder only).
+- First hands-on `depends` must be `[]` (must not reference framing IDs).
+
+Framing in path `milestones` or broken depends → **post inline**. When commenting or surfacing the finding, say explicitly that this is a **Pathfinder-only** omission and the website Learning Path still uses the framing package.
 
 ### Framing vs not framing
 
@@ -134,9 +138,9 @@ Framing is about **role**, not “markdown-only.”
 
 | Kind | Examples | In path `milestones`? |
 |---|---|---|
-| **Framing** (value / why intro) | `business-value`, `value-*`, `advantages-*`, `welcome` | No — keep the package + `website.yaml` if the website needs it; omit from Pathfinder `milestones` |
+| **Framing** (value / why intro) | `business-value`, `value-*`, `advantages-*`, `welcome` | No — Pathfinder drops these from `milestones` only; keep the package + `website.yaml` for the website Learning Path |
 | **Not framing** (path destination) | `end-journey`, `end-<topic>` | Yes |
-| **Case-by-case** | Prose conceptual packages such as `understanding-*` | Only if they are a Pathfinder path step learners must complete. If they are website-only conceptual framing, treat as framing (omit from `milestones`, first hands-on `depends: []`) |
+| **Case-by-case** | Prose conceptual packages such as `understanding-*` | Only if they are a Pathfinder path step learners must complete. If they are website-only conceptual framing, treat as framing (omit from Pathfinder `milestones`, keep the package for the website, first hands-on `depends: []`) |
 
 Do **not** auto-flag every markdown-only `milestones` entry. `end-journey` is normally prose-only and correctly listed.
 


### PR DESCRIPTION
## Summary
- Makes preflight/review framing guidance explicit: omit framing IDs from Pathfinder `milestones` only so the in-app UI stays action-oriented
- Clarifies that framing packages and `website.yaml` stay for the website Learning Path
- Adds author-facing and review comment wording so “remove from milestones” is not read as deleting the website milestone

Closes #497

## Test plan
- [ ] Skim preflight results-menu framing wording in `.cursor/skills/preflight-learning-path/reference-checks.md`
- [ ] Confirm shared framing section in `.cursor/skills/review-learning-path/reference-checks.md` states Pathfinder-only omission
- [ ] Optional: run `/preflight-learning-path` on a path with framing in `milestones` and confirm the finding text is unambiguous


Made with [Cursor](https://cursor.com)