### PR TITLE
Add first-rule and query-language alerting learning paths

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -28,6 +28,8 @@
 /adaptive-metrics-lj/                                     @brendamuir
 /adaptive-metrics-recommendations/                        @brendamuir
 /alerting-101/                                            @tomglenn
+/alerting-first-rule-lj/                                  @JohnnyK-Grafana
+/alerting-query-language-lj/                              @JohnnyK-Grafana
 /alloy-configuration-basics-lj/                           @clayton-cornell 
 /billing-usage-lj/                                        @Eve832
 /categorize-collector-fleet-lj/                            @tiffany76

--- a/alerting-first-rule-lj/build-query/content.json
+++ b/alerting-first-rule-lj/build-query/content.json
@@ -1,0 +1,196 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "alerting-first-rule-build-query",
+  "title": "Build your query and set the condition",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "You'll build a query that watches QuickPizza for server errors, then confirm when the alert fires.\n\nUse **Builder** mode instead of writing PromQL. Keep the condition as **Is above** **0**."
+    },
+    {
+      "type": "section",
+      "id": "prepare-query-editor",
+      "title": "Prepare the query editor",
+      "requirements": [
+        "has-datasource:grafanacloud-play-prom"
+      ],
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "formfill",
+          "reftarget": "input[data-testid='data-testid Select a data source']",
+          "targetvalue": "grafanacloud-play-prom",
+          "content": "On the **New alert rule** page, choose the data source that holds the metric you want to alert on.\n\n**grafanacloud-play-prom** is filled in for you.",
+          "tooltip": "Prometheus data source from the QuickPizza tutorial data sources.",
+          "requirements": [
+            "on-page:/alerting/new/alerting",
+            "exists-reftarget"
+          ]
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='data-testid prometheus explain switch wrapper']",
+          "content": "Optionally, toggle **Explain** on. Grafana describes each part of your query in plain language.",
+          "requirements": [
+            "on-page:/alerting/new/alerting"
+          ],
+          "skippable": true,
+          "doIt": false
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "div[data-testid='data-testid QueryEditorModeToggle']",
+          "content": "Confirm **Builder** is selected so you can build the query without writing PromQL.",
+          "requirements": [
+            "on-page:/alerting/new/alerting"
+          ],
+          "skippable": true,
+          "doIt": false
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "You've prepared the query editor. Next, build the metric query."
+    },
+    {
+      "type": "section",
+      "id": "build-metric-query",
+      "title": "Build the metric query",
+      "requirements": [
+        "section-completed:prepare-query-editor"
+      ],
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='data-testid metric select']",
+          "content": "In the **Metric** drop-down, paste `quickpizza_server_http_requests_total`, then select it from the list.\n\nThis counter tracks HTTP requests for QuickPizza services and includes a response **status** label.",
+          "tooltip": "Paste the metric name, then pick it from the list.",
+          "doIt": false,
+          "requirements": [
+            "on-page:/alerting/new/alerting",
+            "exists-reftarget"
+          ]
+        },
+        {
+          "type": "interactive",
+          "action": "formfill",
+          "reftarget": "[data-testid='data-testid Select label']",
+          "targetvalue": "status",
+          "content": "In the **Label filters** row, open the **Label** drop-down and select **status**.",
+          "tooltip": "Pick status from the list.",
+          "requirements": [
+            "on-page:/alerting/new/alerting",
+            "exists-reftarget"
+          ]
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='data-testid Select match operator']",
+          "content": "Open the operator drop-down and change **=** to **=~** so one filter can match every 5xx status code.",
+          "tooltip": "=~ is regex match; = is exact match.",
+          "doIt": false,
+          "requirements": [
+            "on-page:/alerting/new/alerting",
+            "exists-reftarget"
+          ]
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='data-testid Select value']",
+          "content": "In the **Select value** box, enter `5..`, then press Enter.\n\nThat regex matches any three-digit status that starts with 5.",
+          "tooltip": "Enter 5.. and press Enter. Don't pick 500 from the list.",
+          "doIt": false,
+          "requirements": [
+            "on-page:/alerting/new/alerting",
+            "exists-reftarget"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "The metric is a counter that only increases. Add a range function to count new errors over the last 5 minutes. Optionally sum across services so the alert uses one total."
+    },
+    {
+      "type": "section",
+      "id": "add-operations-and-preview",
+      "title": "Add operations and run the query",
+      "requirements": [
+        "section-completed:build-metric-query"
+      ],
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "button",
+          "reftarget": "Operations",
+          "content": "Click **+ Operations**. In the **Operations** drop-down, select **Range functions / Increase**, then set the **Range** to **5m**.",
+          "requirements": [
+            "on-page:/alerting/new/alerting"
+          ]
+        },
+        {
+          "type": "interactive",
+          "action": "button",
+          "reftarget": "Operations",
+          "content": "Optionally, click **+ Operations** again and select **Aggregations / Sum**.",
+          "requirements": [
+            "on-page:/alerting/new/alerting"
+          ],
+          "skippable": true
+        },
+        {
+          "type": "interactive",
+          "action": "button",
+          "reftarget": "Run queries",
+          "content": "Click **Run queries**.",
+          "requirements": [
+            "on-page:/alerting/new/alerting"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "Check that your query matches `sum(increase(quickpizza_server_http_requests_total{status=~\"5..\"}[5m]))` and that **Run queries** succeeds.\n\nNext, confirm the alert condition."
+    },
+    {
+      "type": "section",
+      "id": "confirm-and-preview-condition",
+      "title": "Confirm and preview the condition",
+      "requirements": [
+        "section-completed:add-operations-and-preview"
+      ],
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "label:contains('WHEN QUERY')",
+          "content": "In the **Alert condition** section, confirm **Is above** is selected and the value is **0**.",
+          "doIt": false,
+          "requirements": [
+            "on-page:/alerting/new/alerting"
+          ]
+        },
+        {
+          "type": "interactive",
+          "action": "button",
+          "reftarget": "Preview alert rule condition",
+          "content": "Click **Preview alert rule condition** to evaluate the condition against your query.\n\nThe result may show **Normal** or **Firing**, depending on whether the query is above **0** right now.",
+          "requirements": [
+            "on-page:/alerting/new/alerting"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "Your query and alert condition are set. Next, you create a folder and add labels."
+    }
+  ]
+}

--- a/alerting-first-rule-lj/build-query/manifest.json
+++ b/alerting-first-rule-lj/build-query/manifest.json
@@ -1,0 +1,21 @@
+{
+  "id": "alerting-first-rule-build-query",
+  "type": "guide",
+  "description": "Build a Prometheus query and set the alert condition.",
+  "category": "take-action",
+  "author": {
+    "name": "JohnnyK-Grafana",
+    "team": "Grafana Documentation"
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": [
+    "alerting-first-rule-navigate-to-form"
+  ],
+  "recommends": [
+    "alerting-first-rule-configure-labels-evaluation"
+  ],
+  "suggests": [],
+  "provides": []
+}

--- a/alerting-first-rule-lj/build-query/website.yaml
+++ b/alerting-first-rule-lj/build-query/website.yaml
@@ -1,0 +1,12 @@
+menuTitle: Build query
+title: Build your query and set the condition
+description: Build a Prometheus query and set the alert condition.
+keywords:
+  - alerting
+  - query
+  - condition
+weight: 400
+step: 5
+layout: single-journey
+cta:
+  type: continue

--- a/alerting-first-rule-lj/business-value/content.json
+++ b/alerting-first-rule-lj/business-value/content.json
@@ -1,0 +1,19 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "alerting-first-rule-business-value",
+  "title": "Why build an alert rule?",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "An alert rule watches your data, fires when something looks wrong, and notifies the right people. You hear about problems before your users do."
+    },
+    {
+      "type": "markdown",
+      "content": "In this path, you build every part of an alert rule in order:\n\n- A query that picks what to watch\n- A condition that decides when to fire\n- A folder and labels that organize and route it\n- Evaluation settings that control how often it runs and how long it must be wrong before firing\n- A contact point and message that decide who hears about it and what they see"
+    },
+    {
+      "type": "markdown",
+      "content": "You'll use the QuickPizza tutorial data sources. The next milestone installs them, then the one after opens the new alert rule page so you can name your rule."
+    }
+  ]
+}

--- a/alerting-first-rule-lj/business-value/manifest.json
+++ b/alerting-first-rule-lj/business-value/manifest.json
@@ -1,0 +1,17 @@
+{
+  "id": "alerting-first-rule-business-value",
+  "type": "guide",
+  "description": "An alert rule turns telemetry into action so you find problems before your users do.",
+  "category": "take-action",
+  "author": {
+    "name": "JohnnyK-Grafana",
+    "team": "Grafana Documentation"
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": [],
+  "recommends": ["alerting-first-rule-install-datasources"],
+  "suggests": [],
+  "provides": []
+}

--- a/alerting-first-rule-lj/business-value/website.yaml
+++ b/alerting-first-rule-lj/business-value/website.yaml
@@ -1,0 +1,10 @@
+menuTitle: Why alerting
+title: Why build an alert rule?
+description: An alert rule turns telemetry into action so you find problems before your users do.
+keywords:
+  - alerting
+weight: 100
+step: 2
+layout: single-journey
+cta:
+  type: continue

--- a/alerting-first-rule-lj/configure-labels-evaluation/content.json
+++ b/alerting-first-rule-lj/configure-labels-evaluation/content.json
@@ -1,0 +1,63 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "alerting-first-rule-configure-labels-evaluation",
+  "title": "Create a folder and add labels",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "You'll organize your alert into a folder and add labels that control how notifications get routed.\n\nFolders organize alerts by team, service, or purpose, and control who can manage them.\n\nIn this milestone, you create a folder, then add rule-level labels."
+    },
+    {
+      "type": "section",
+      "id": "select-folder",
+      "title": "Create a folder",
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "button",
+          "reftarget": "New folder",
+          "content": "In the **Add folder and labels** section, click **New folder** to open the create dialog.",
+          "doIt": false,
+          "requirements": [
+            "on-page:/alerting/new/alerting"
+          ]
+        },
+        {
+          "type": "markdown",
+          "content": "Enter a folder name (for example, **Alerts**), then click **Create**. The folder is saved and selected for your rule."
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "You've created a folder for the rule. Next, add labels."
+    },
+    {
+      "type": "section",
+      "id": "add-labels",
+      "title": "Add labels",
+      "requirements": [
+        "section-completed:select-folder"
+      ],
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "button",
+          "reftarget": "Add labels",
+          "content": "Click **Add labels** to open the labels editor. Labels are key-value tags on the alert that control notification routing.",
+          "requirements": [
+            "on-page:/alerting/new/alerting"
+          ]
+        },
+        {
+          "type": "markdown",
+          "content": "Add a label with the key **severity** and the value **critical**, then click **Save**."
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "Your alert now has a folder and a label. Next, you set how often the rule evaluates and how long the condition must last before the alert fires."
+    }
+  ]
+}

--- a/alerting-first-rule-lj/configure-labels-evaluation/manifest.json
+++ b/alerting-first-rule-lj/configure-labels-evaluation/manifest.json
@@ -1,0 +1,21 @@
+{
+  "id": "alerting-first-rule-configure-labels-evaluation",
+  "type": "guide",
+  "description": "Create a folder and add labels that control routing.",
+  "category": "take-action",
+  "author": {
+    "name": "JohnnyK-Grafana",
+    "team": "Grafana Documentation"
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": [
+    "alerting-first-rule-build-query"
+  ],
+  "recommends": [
+    "alerting-first-rule-set-evaluation-behavior"
+  ],
+  "suggests": [],
+  "provides": []
+}

--- a/alerting-first-rule-lj/configure-labels-evaluation/website.yaml
+++ b/alerting-first-rule-lj/configure-labels-evaluation/website.yaml
@@ -1,0 +1,11 @@
+menuTitle: Folder and labels
+title: Create a folder and add labels
+description: Create a folder and add labels that control routing.
+keywords:
+  - alerting
+  - labels
+weight: 500
+step: 6
+layout: single-journey
+cta:
+  type: continue

--- a/alerting-first-rule-lj/configure-notification/content.json
+++ b/alerting-first-rule-lj/configure-notification/content.json
@@ -1,0 +1,55 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "alerting-first-rule-configure-notification",
+  "title": "Configure the notification message and save",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "When your alert fires, the notification includes a **Summary** and a **Description**. In this milestone, you complete both, then save the rule."
+    },
+    {
+      "type": "section",
+      "id": "add-summary-description-and-save",
+      "title": "Add the notification and save the rule",
+      "requirements": [
+        "on-page:/alerting/new/alerting"
+      ],
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "formfill",
+          "reftarget": "[data-testid='annotation-value-0']",
+          "targetvalue": "QuickPizza returned {{ $value }} server errors in the last 5 minutes",
+          "content": "In the **Summary** field, add this notification:\n\n`QuickPizza returned {{ $value }} server errors in the last 5 minutes`\n\nWhen the alert fires, {{ $value }} is replaced with the live query result.",
+          "requirements": [
+            "on-page:/alerting/new/alerting"
+          ]
+        },
+        {
+          "type": "interactive",
+          "action": "formfill",
+          "reftarget": "[data-testid='annotation-value-1']",
+          "targetvalue": "Fires when the 5-minute rate of QuickPizza HTTP 5xx responses stays above the threshold. Check the app dashboard and recent deploys first.",
+          "content": "In the **Description** field, add this text:\n\n`Fires when the 5-minute rate of QuickPizza HTTP 5xx responses stays above the threshold. Check the app dashboard and recent deploys first.`\n\nUse the description to explain what the alert watches and where to start looking.",
+          "requirements": [
+            "on-page:/alerting/new/alerting"
+          ]
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='save-rule']",
+          "content": "Click **Save** in the action bar at the bottom of the page to save and activate your alert rule.",
+          "doIt": false,
+          "requirements": [
+            "on-page:/alerting/new/alerting"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "Your alert rule is saved and running. When the condition holds past your pending period, the alert fires and notifications go to your contact point."
+    }
+  ]
+}

--- a/alerting-first-rule-lj/configure-notification/manifest.json
+++ b/alerting-first-rule-lj/configure-notification/manifest.json
@@ -1,0 +1,21 @@
+{
+  "id": "alerting-first-rule-configure-notification",
+  "type": "guide",
+  "description": "Add a Summary and Description, then save and activate the rule.",
+  "category": "take-action",
+  "author": {
+    "name": "JohnnyK-Grafana",
+    "team": "Grafana Documentation"
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": [
+    "alerting-first-rule-select-contact-point"
+  ],
+  "recommends": [
+    "alerting-first-rule-end-journey"
+  ],
+  "suggests": [],
+  "provides": []
+}

--- a/alerting-first-rule-lj/configure-notification/website.yaml
+++ b/alerting-first-rule-lj/configure-notification/website.yaml
@@ -1,0 +1,13 @@
+menuTitle: Notify and save
+title: Configure the notification message and save
+description: Add a Summary and Description, then save and activate the rule.
+keywords:
+  - alerting
+  - notifications
+  - annotations
+  - save
+weight: 800
+step: 9
+layout: single-journey
+cta:
+  type: success

--- a/alerting-first-rule-lj/content.json
+++ b/alerting-first-rule-lj/content.json
@@ -1,0 +1,27 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "alerting-first-rule-lj",
+  "title": "Create your first alert rule",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "Welcome to the hands-on learning path that walks you through building a complete Grafana alert rule from scratch, one piece at a time.\n\nIn this path, you open and name a rule, build a Prometheus query, set the condition, organize the rule with a folder and labels, configure evaluation behavior, choose how it handles missing data, select a contact point, and save the rule."
+    },
+    {
+      "type": "markdown",
+      "content": "## Here's what to expect\n\nWhen you complete this path, you'll be able to:\n\n- Open the new alert rule page and give your rule a clear name\n- Build a Prometheus query using the visual query builder\n- Set a comparison operator and threshold for the alert condition\n- Select a folder and add labels that control routing\n- Configure the evaluation interval and pending period\n- Configure no-data and error handling\n- Select a contact point\n- Add a summary and description to your notification\n- Save and activate your alert rule"
+    },
+    {
+      "type": "markdown",
+      "content": "## Before you begin\n\nBefore you build your alert rule, ensure you have:\n\n- A Grafana Cloud account. To create one, refer to [Grafana Cloud](https://grafana.com/signup/cloud/connect-account).\n- Permission to create and manage alert rules.\n\nThe path installs the QuickPizza tutorial data sources for you in the next milestone. This path uses `grafanacloud-play-prom`, and querying it does not count toward your Grafana Cloud usage."
+    },
+    {
+      "type": "markdown",
+      "content": "## Troubleshooting\n\nIf you get stuck, we've got your back! Where appropriate, troubleshooting information is just a click away."
+    },
+    {
+      "type": "markdown",
+      "content": "## More to explore\n\nAfter you save your first rule, explore silences to suppress notifications during planned maintenance, and learn how to configure contact points and notification policies in depth."
+    }
+  ]
+}

--- a/alerting-first-rule-lj/end-journey/content.json
+++ b/alerting-first-rule-lj/end-journey/content.json
@@ -1,0 +1,23 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "alerting-first-rule-end-journey",
+  "title": "Destination reached!",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "Congratulations on completing this path! Job well done!\n\nWe hope you've enjoyed traveling with us as you:\n\n- Opened and named your alert rule\n- Built a Prometheus query with the visual query builder\n- Set the alert condition and threshold\n- Selected a folder and added routing labels\n- Configured evaluation interval, pending period, and keep firing for\n- Configured no-data and error handling\n- Selected a contact point\n- Added a summary and description, then saved and activated your alert rule"
+    },
+    {
+      "type": "markdown",
+      "content": "You now have a working alert rule that monitors your data and notifies the right people when issues arise."
+    },
+    {
+      "type": "markdown",
+      "content": "---\n\n### More to explore (optional)\n\nRead more about how you can:\n\n- [Build alert queries and conditions](https://grafana.com/docs/grafana/latest/alerting/fundamentals/alert-rules/queries-conditions/)\n- [Configure contact points](https://grafana.com/docs/grafana/latest/alerting/configure-notifications/manage-contact-points/)\n- [Write effective alert annotations](https://grafana.com/docs/grafana/latest/alerting/fundamentals/alert-rules/annotation-label/)"
+    },
+    {
+      "type": "markdown",
+      "content": "---\n\n### Related paths\n\nConsider taking the following path next:\n\n- [Create an alert rule with query language](https://grafana.com/docs/learning-paths/alerting-query-language/)"
+    }
+  ]
+}

--- a/alerting-first-rule-lj/end-journey/manifest.json
+++ b/alerting-first-rule-lj/end-journey/manifest.json
@@ -1,0 +1,19 @@
+{
+  "id": "alerting-first-rule-end-journey",
+  "type": "guide",
+  "description": "You created a complete alert rule from query to notification.",
+  "category": "take-action",
+  "author": {
+    "name": "JohnnyK-Grafana",
+    "team": "Grafana Documentation"
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": [
+    "alerting-first-rule-configure-notification"
+  ],
+  "recommends": [],
+  "suggests": [],
+  "provides": []
+}

--- a/alerting-first-rule-lj/end-journey/website.yaml
+++ b/alerting-first-rule-lj/end-journey/website.yaml
@@ -1,0 +1,20 @@
+menuTitle: Complete
+title: Destination reached!
+description: You created a complete alert rule from query to notification.
+keywords:
+  - alerting
+weight: 900
+step: 10
+layout: single-journey
+cta:
+  type: conclusion
+  image:
+    src: /media/docs/learning-journey/journey-conclusion-header-1.svg
+    width: 735
+    height: 175
+related_journeys:
+  title: Related paths
+  heading: Consider taking the following paths after you complete this journey.
+  items:
+    - title: Create an alert rule with query language
+      link: /docs/learning-paths/alerting-query-language/

--- a/alerting-first-rule-lj/install-datasources/content.json
+++ b/alerting-first-rule-lj/install-datasources/content.json
@@ -1,0 +1,55 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "alerting-first-rule-install-datasources",
+  "title": "Install the QuickPizza demo",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "This path uses the QuickPizza tutorial data sources, which include a Prometheus data source named **grafanacloud-play-prom** that carries real metrics from a running demo service. Querying these data sources does not count toward your Grafana Cloud usage.\n\nThe install runs from the **Demo Data Dashboards** app in the left nav. After the install finishes, Grafana refreshes the page and the alerting flow picks up in the next milestone."
+    },
+    {
+      "type": "section",
+      "id": "install-tutorial-datasources",
+      "title": "Install QuickPizza",
+      "objectives": [
+        "has-datasource:grafanacloud-play-prom"
+      ],
+      "blocks": [
+        {
+          "type": "multistep",
+          "content": "Expand **More apps** in the main menu, then open **Demo Data Dashboards**.",
+          "requirements": [
+            "navmenu-open"
+          ],
+          "steps": [
+            {
+              "action": "highlight",
+              "reftarget": "button[aria-label*='section: More apps']"
+            },
+            {
+              "action": "highlight",
+              "reftarget": "a[data-testid='data-testid Nav menu item'][href='/a/grafana-demodashboards-app']"
+            }
+          ]
+        },
+        {
+          "type": "guided",
+          "content": "Click **Install the Quick Pizza SRE demo**. This deploys the tutorial data sources and refreshes the page.",
+          "completeEarly": true,
+          "steps": [
+            {
+              "action": "highlight",
+              "reftarget": "button[data-testid='install-quickpizza']",
+              "lazyRender": true,
+              "description": "Click **Install the Quick Pizza SRE demo**."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "Install opens the QuickPizza dashboards folder. Those dashboards use the tutorial Prometheus data source **grafanacloud-play-prom**. Next, you'll open the new alert rule page and build a query on that same data."
+    }
+  ]
+}

--- a/alerting-first-rule-lj/install-datasources/manifest.json
+++ b/alerting-first-rule-lj/install-datasources/manifest.json
@@ -1,0 +1,19 @@
+{
+  "id": "alerting-first-rule-install-datasources",
+  "type": "guide",
+  "description": "Install the QuickPizza demo so the alert rule has real data to query.",
+  "category": "take-action",
+  "author": {
+    "name": "JohnnyK-Grafana",
+    "team": "Grafana Documentation"
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": [],
+  "recommends": [
+    "alerting-first-rule-navigate-to-form"
+  ],
+  "suggests": [],
+  "provides": []
+}

--- a/alerting-first-rule-lj/install-datasources/website.yaml
+++ b/alerting-first-rule-lj/install-datasources/website.yaml
@@ -1,0 +1,12 @@
+menuTitle: Install QuickPizza
+title: Install the QuickPizza demo
+description: Install the QuickPizza demo so the alert rule has real data to query.
+keywords:
+  - alerting
+  - datasource
+  - quickpizza
+weight: 200
+step: 3
+layout: single-journey
+cta:
+  type: continue

--- a/alerting-first-rule-lj/manifest.json
+++ b/alerting-first-rule-lj/manifest.json
@@ -1,0 +1,40 @@
+{
+  "id": "alerting-first-rule-lj",
+  "type": "path",
+  "description": "Step-by-step guide: open and name an alert rule, build a query, set the condition, add a folder and labels, configure evaluation and handling, select a contact point, and save.",
+  "category": "take-action",
+  "author": {
+    "name": "JohnnyK-Grafana",
+    "team": "Grafana Documentation"
+  },
+  "startingLocation": "/alerting",
+  "targeting": {
+    "match": {
+      "and": [
+        {
+          "urlPrefix": "/alerting"
+        },
+        {
+          "targetPlatform": "cloud"
+        }
+      ]
+    }
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "milestones": [
+    "alerting-first-rule-install-datasources",
+    "alerting-first-rule-navigate-to-form",
+    "alerting-first-rule-build-query",
+    "alerting-first-rule-configure-labels-evaluation",
+    "alerting-first-rule-set-evaluation-behavior",
+    "alerting-first-rule-select-contact-point",
+    "alerting-first-rule-configure-notification",
+    "alerting-first-rule-end-journey"
+  ],
+  "depends": [],
+  "recommends": [],
+  "suggests": ["alerting-query-language-lj"],
+  "provides": []
+}

--- a/alerting-first-rule-lj/navigate-to-form/content.json
+++ b/alerting-first-rule-lj/navigate-to-form/content.json
@@ -1,0 +1,51 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "alerting-first-rule-navigate-to-form",
+  "title": "Open the New alert rule page",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "A clear, descriptive name is the first thing responders see when an alert fires. A good name tells them immediately what's wrong without opening the alert details.\n\nIn this milestone, you'll open the **New alert rule** page and name your rule."
+    },
+    {
+      "type": "section",
+      "id": "open-and-name-alert-rule",
+      "title": "Open and name your alert rule",
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "navigate",
+          "reftarget": "/alerting/list",
+          "content": "In the left navigation menu, click **Alerting** > **Alert rules**.",
+          "verify": "on-page:/alerting/list"
+        },
+        {
+          "type": "interactive",
+          "action": "navigate",
+          "reftarget": "/alerting/new/alerting",
+          "content": "On the **Alert rules** page, click **+ New alert rule**.",
+          "requirements": [
+            "on-page:/alerting/list"
+          ],
+          "verify": "on-page:/alerting/new/alerting"
+        },
+        {
+          "type": "interactive",
+          "action": "formfill",
+          "reftarget": "input[placeholder='Give your alert rule a name']",
+          "targetvalue": "QuickPizza server errors",
+          "content": "On the **New alert rule** page, in the **Name** field, enter a clear name that helps responders triage alerts quickly.\n\n**QuickPizza server errors** is filled in for you.",
+          "tooltip": "Responders see this name first when the alert fires.",
+          "requirements": [
+            "on-page:/alerting/new/alerting",
+            "exists-reftarget"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "Your rule has a clear name. In the next milestone, you build the query that defines what the alert monitors."
+    }
+  ]
+}

--- a/alerting-first-rule-lj/navigate-to-form/manifest.json
+++ b/alerting-first-rule-lj/navigate-to-form/manifest.json
@@ -1,0 +1,21 @@
+{
+  "id": "alerting-first-rule-navigate-to-form",
+  "type": "guide",
+  "description": "Open the New alert rule page and give your rule a clear name.",
+  "category": "take-action",
+  "author": {
+    "name": "JohnnyK-Grafana",
+    "team": "Grafana Documentation"
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": [
+    "alerting-first-rule-install-datasources"
+  ],
+  "recommends": [
+    "alerting-first-rule-build-query"
+  ],
+  "suggests": [],
+  "provides": []
+}

--- a/alerting-first-rule-lj/navigate-to-form/website.yaml
+++ b/alerting-first-rule-lj/navigate-to-form/website.yaml
@@ -1,0 +1,11 @@
+menuTitle: Name your rule
+title: Open the New alert rule page
+description: Open the New alert rule page and give your rule a clear name.
+keywords:
+  - alerting
+  - alert rule
+weight: 300
+step: 4
+layout: single-journey
+cta:
+  type: continue

--- a/alerting-first-rule-lj/select-contact-point/content.json
+++ b/alerting-first-rule-lj/select-contact-point/content.json
@@ -1,0 +1,46 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "alerting-first-rule-select-contact-point",
+  "title": "Configure handling and select a contact point",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "In this milestone, you keep the default no-data and error handling, then choose where notifications go when the alert fires."
+    },
+    {
+      "type": "section",
+      "id": "configure-handling-and-contact-point",
+      "title": "Configure handling and select a contact point",
+      "requirements": [
+        "on-page:/alerting/new/alerting"
+      ],
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "button",
+          "reftarget": "Configure no data and error handling",
+          "content": "In the **Set evaluation behavior** section, click **Configure no data and error handling** to expand the options.\n\nLeave both drop-downs at their defaults: **No Data** for no data or all null values, and **Error** for execution error or timeout.",
+          "doIt": true,
+          "requirements": [
+            "on-page:/alerting/new/alerting"
+          ]
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='data-testid alert-rule contact-point-picker']",
+          "content": "In the **Configure notifications** section, open the **Contact point** picker and choose a contact point available on your stack.",
+          "doIt": false,
+          "requirements": [
+            "on-page:/alerting/new/alerting",
+            "exists-reftarget"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "Your rule has handling defaults and a contact point. Next, you write the notification message and save the rule."
+    }
+  ]
+}

--- a/alerting-first-rule-lj/select-contact-point/manifest.json
+++ b/alerting-first-rule-lj/select-contact-point/manifest.json
@@ -1,0 +1,21 @@
+{
+  "id": "alerting-first-rule-select-contact-point",
+  "type": "guide",
+  "description": "Keep default no-data and error handling, then select a contact point.",
+  "category": "take-action",
+  "author": {
+    "name": "JohnnyK-Grafana",
+    "team": "Grafana Documentation"
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": [
+    "alerting-first-rule-set-evaluation-behavior"
+  ],
+  "recommends": [
+    "alerting-first-rule-configure-notification"
+  ],
+  "suggests": [],
+  "provides": []
+}

--- a/alerting-first-rule-lj/select-contact-point/website.yaml
+++ b/alerting-first-rule-lj/select-contact-point/website.yaml
@@ -1,0 +1,12 @@
+menuTitle: Handling and contact point
+title: Configure handling and select a contact point
+description: Keep default no-data and error handling, then select a contact point.
+keywords:
+  - alerting
+  - notifications
+  - handling
+weight: 700
+step: 8
+layout: single-journey
+cta:
+  type: continue

--- a/alerting-first-rule-lj/set-evaluation-behavior/content.json
+++ b/alerting-first-rule-lj/set-evaluation-behavior/content.json
@@ -1,0 +1,63 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "alerting-first-rule-set-evaluation-behavior",
+  "title": "Set evaluation behavior",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "Evaluation behavior sets how often the query runs, how long a problem must last before the alert fires, and how long the alert keeps firing after the condition resolves.\n\nIn this milestone, create an evaluation group, then set the pending period and keep firing for."
+    },
+    {
+      "type": "section",
+      "id": "set-evaluation-behavior",
+      "title": "Set evaluation behavior",
+      "requirements": [
+        "on-page:/alerting/new/alerting"
+      ],
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "button",
+          "reftarget": "New evaluation group",
+          "content": "In the **Set evaluation behavior** section, click **New evaluation group** to open the dialog.",
+          "doIt": false,
+          "requirements": [
+            "on-page:/alerting/new/alerting",
+            "exists-reftarget"
+          ]
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Give the group a name, such as **Alerts group**, set the **Evaluation interval** to **1m**, then click **Create**."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "#eval-for-input",
+          "content": "In the **Pending period** field, enter **1m**. This is how long the condition must stay true before the alert fires.",
+          "doIt": false,
+          "requirements": [
+            "on-page:/alerting/new/alerting",
+            "exists-reftarget"
+          ]
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "#keep-firing-for-input",
+          "content": "In the **Keep firing for** field, select **None**. This is how long the alert keeps firing after the condition resolves.",
+          "doIt": false,
+          "requirements": [
+            "on-page:/alerting/new/alerting",
+            "exists-reftarget"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "Your evaluation schedule is set. Next, you configure no-data and error handling and choose a contact point."
+    }
+  ]
+}

--- a/alerting-first-rule-lj/set-evaluation-behavior/manifest.json
+++ b/alerting-first-rule-lj/set-evaluation-behavior/manifest.json
@@ -1,0 +1,21 @@
+{
+  "id": "alerting-first-rule-set-evaluation-behavior",
+  "type": "guide",
+  "description": "Create an evaluation group, then set the pending period and keep firing for.",
+  "category": "take-action",
+  "author": {
+    "name": "JohnnyK-Grafana",
+    "team": "Grafana Documentation"
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": [
+    "alerting-first-rule-configure-labels-evaluation"
+  ],
+  "recommends": [
+    "alerting-first-rule-select-contact-point"
+  ],
+  "suggests": [],
+  "provides": []
+}

--- a/alerting-first-rule-lj/set-evaluation-behavior/website.yaml
+++ b/alerting-first-rule-lj/set-evaluation-behavior/website.yaml
@@ -1,0 +1,11 @@
+menuTitle: Evaluation behavior
+title: Set evaluation behavior
+description: Create an evaluation group, then set the pending period and keep firing for.
+keywords:
+  - alerting
+  - evaluation
+weight: 600
+step: 7
+layout: single-journey
+cta:
+  type: continue

--- a/alerting-first-rule-lj/website.yaml
+++ b/alerting-first-rule-lj/website.yaml
@@ -1,0 +1,35 @@
+menuTitle: First alert rule
+title: Create your first alert rule
+description: Build a complete Grafana alert rule from scratch — write a query, set a condition, add labels, configure evaluation and notifications, and save.
+weight: 700
+journey:
+  group: take-action
+  skill: Beginner
+  source: Docs & blog posts
+  logo:
+    src: /static/img/menu/grafana2.svg
+    background: '#0068FF'
+    width: 46
+    height: 55
+step: 1
+layout: single-journey
+cascade:
+  layout: single-journey
+cta:
+  type: start
+  title: Are you ready?
+  cta_text: Let's go!
+keywords:
+  - alerting
+  - alert rule
+  - query
+  - notifications
+  - save
+related_journeys:
+  title: Related paths
+  heading: Consider taking the following paths before you start this path.
+  items: []
+source_docs:
+  - /docs/grafana/latest/alerting/fundamentals/alert-rules/
+  - /docs/grafana/latest/alerting/fundamentals/alert-rules/queries-conditions/
+  - /docs/grafana/latest/alerting/fundamentals/notifications/contact-points/

--- a/alerting-query-language-lj/build-query/content.json
+++ b/alerting-query-language-lj/build-query/content.json
@@ -1,0 +1,68 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "alerting-query-language-build-query",
+  "title": "Write your query in Code mode",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "Your alert watches how often QuickPizza's server fails. You want it to fire when more than 5 in every 100 requests fail.\n\nYou switch to **Code** and write PromQL so the full ratio is one clear expression.\n\nWhat the query does:\n\n- `quickpizza_server_http_requests_total` counts every request.\n- `rate(...[5m])` converts that count to a per-second rate over 5 minutes.\n- `{status=~\"5..\"}` keeps only 5xx failures.\n- Dividing failed by all requests, then multiplying by 100, gives a percentage."
+    },
+    {
+      "type": "section",
+      "id": "build-code-query",
+      "title": "Build the Code mode query",
+      "requirements": [
+        "has-datasource:grafanacloud-play-prom"
+      ],
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "formfill",
+          "reftarget": "input[data-testid='data-testid Select a data source']",
+          "targetvalue": "grafanacloud-play-prom",
+          "content": "Choose **grafanacloud-play-prom** as the data source.",
+          "tooltip": "QuickPizza's Prometheus data source.",
+          "requirements": [
+            "on-page:/alerting/new/alerting",
+            "exists-reftarget"
+          ]
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "div[data-testid='data-testid QueryEditorModeToggle']",
+          "content": "Click **Code** on the mode toggle.",
+          "tooltip": "Switches the query editor from Builder to Code.",
+          "doIt": false,
+          "requirements": [
+            "on-page:/alerting/new/alerting"
+          ]
+        },
+        {
+          "type": "code-block",
+          "reftarget": "div[data-testid='data-testid Query field']",
+          "language": "promql",
+          "code": "100 * sum(rate(quickpizza_server_http_requests_total{status=~\"5..\"}[5m])) / sum(rate(quickpizza_server_http_requests_total[5m]))",
+          "content": "Click **Insert** to add this query to the editor.",
+          "requirements": [
+            "on-page:/alerting/new/alerting"
+          ]
+        },
+        {
+          "type": "interactive",
+          "action": "button",
+          "reftarget": "Run queries",
+          "content": "Click **Run queries**.",
+          "requirements": [
+            "on-page:/alerting/new/alerting",
+            "exists-reftarget"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "The query reports QuickPizza's error rate as a percentage. Next, you set the threshold and recovery while you're still in this section."
+    }
+  ]
+}

--- a/alerting-query-language-lj/build-query/manifest.json
+++ b/alerting-query-language-lj/build-query/manifest.json
@@ -1,0 +1,21 @@
+{
+  "id": "alerting-query-language-build-query",
+  "type": "guide",
+  "description": "Switch to Code mode and write a PromQL error-rate query for QuickPizza.",
+  "category": "take-action",
+  "author": {
+    "name": "JohnnyK-Grafana",
+    "team": "Grafana Documentation"
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": [
+    "alerting-query-language-navigate-to-form"
+  ],
+  "recommends": [
+    "alerting-query-language-set-condition"
+  ],
+  "suggests": [],
+  "provides": []
+}

--- a/alerting-query-language-lj/build-query/website.yaml
+++ b/alerting-query-language-lj/build-query/website.yaml
@@ -1,0 +1,12 @@
+menuTitle: Build query
+title: Write your query in Code mode
+description: Switch to Code mode and write a PromQL error-rate query for QuickPizza.
+keywords:
+  - alerting
+  - query
+  - PromQL
+weight: 400
+step: 5
+layout: single-journey
+cta:
+  type: continue

--- a/alerting-query-language-lj/business-value/content.json
+++ b/alerting-query-language-lj/business-value/content.json
@@ -1,0 +1,23 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "alerting-query-language-business-value",
+  "title": "Why write your alert in query language?",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "**Builder mode** lets you build a query by picking metrics and filters from menus. **Code mode** lets you type PromQL yourself, which is often clearer for multi-step math like ratios.\n\nIn this path, you use Code mode to alert on QuickPizza's **error rate**: the percentage of requests that fail. That query divides failed requests by all requests, then scales the result to a percentage. You can write that pattern directly in Code mode."
+    },
+    {
+      "type": "markdown",
+      "content": "## When to reach for Code mode\n\nCode mode is worth it when your alert needs:\n\n- **A percentage or ratio.** For example, failed requests as a share of all requests, written as one PromQL expression.\n- **Custom or multi-step math.** Patterns that are awkward to assemble from menus alone.\n- **To compare two metrics.** For example, current usage against a capacity limit on a different series.\n- **A query you already trust.** Paste one in from a dashboard or a teammate."
+    },
+    {
+      "type": "markdown",
+      "content": "## What you'll build\n\nStep by step, you build every part of the rule:\n\n- The PromQL query that measures error rate\n- The threshold that decides when to fire\n- A folder and labels so the alert is easy to find and organize\n- How often Grafana checks the rule, and how long the problem must last before firing\n- Rules for handling missing data\n- The contact point and message that tell someone what's wrong"
+    },
+    {
+      "type": "markdown",
+      "content": "You'll use **QuickPizza**, a demo pizza shop you install in Grafana Cloud. The next milestone walks through that install."
+    }
+  ]
+}

--- a/alerting-query-language-lj/business-value/manifest.json
+++ b/alerting-query-language-lj/business-value/manifest.json
@@ -1,0 +1,19 @@
+{
+  "id": "alerting-query-language-business-value",
+  "type": "guide",
+  "description": "See why Code mode and PromQL give you more control when building an alert rule.",
+  "category": "take-action",
+  "author": {
+    "name": "JohnnyK-Grafana",
+    "team": "Grafana Documentation"
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": [],
+  "recommends": [
+    "alerting-query-language-install-datasources"
+  ],
+  "suggests": [],
+  "provides": []
+}

--- a/alerting-query-language-lj/business-value/website.yaml
+++ b/alerting-query-language-lj/business-value/website.yaml
@@ -1,0 +1,10 @@
+menuTitle: Why query language
+title: Why write your alert in query language?
+description: See why Code mode and PromQL give you more control when building an alert rule.
+keywords:
+  - alerting
+weight: 100
+step: 2
+layout: single-journey
+cta:
+  type: continue

--- a/alerting-query-language-lj/configure-handling/content.json
+++ b/alerting-query-language-lj/configure-handling/content.json
@@ -1,0 +1,58 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "alerting-query-language-configure-handling",
+  "title": "Configure no-data and error handling",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "No-data and error handling controls what your rule does when a query returns no data or fails.\n\nIn this milestone, you open those settings and confirm the defaults."
+    },
+    {
+      "type": "section",
+      "id": "configure-handling",
+      "title": "Confirm no-data and error handling",
+      "requirements": [
+        "on-page:/alerting/new/alerting"
+      ],
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "button",
+          "reftarget": "Configure no data and error handling",
+          "content": "In the **Set evaluation behavior** section, click **Configure no data and error handling** to expand the options.",
+          "doIt": true,
+          "requirements": [
+            "on-page:/alerting/new/alerting",
+            "exists-reftarget"
+          ]
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "#no-data-state-input",
+          "content": "Confirm **Alert state if no data or all values are null** is set to **No Data**. Don't change it.",
+          "doIt": false,
+          "requirements": [
+            "on-page:/alerting/new/alerting",
+            "exists-reftarget"
+          ]
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "#exec-err-state-input",
+          "content": "Confirm **Alert state if execution error or timeout** is set to **Error**. Don't change it.",
+          "doIt": false,
+          "requirements": [
+            "on-page:/alerting/new/alerting",
+            "exists-reftarget"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "Your rule keeps the default handling for empty results and query errors. Next, you choose the contact point that receives the notification."
+    }
+  ]
+}

--- a/alerting-query-language-lj/configure-handling/manifest.json
+++ b/alerting-query-language-lj/configure-handling/manifest.json
@@ -1,0 +1,21 @@
+{
+  "id": "alerting-query-language-configure-handling",
+  "type": "guide",
+  "description": "Confirm how your rule handles missing data and query errors.",
+  "category": "take-action",
+  "author": {
+    "name": "JohnnyK-Grafana",
+    "team": "Grafana Documentation"
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": [
+    "alerting-query-language-set-evaluation-behavior"
+  ],
+  "recommends": [
+    "alerting-query-language-configure-notification"
+  ],
+  "suggests": [],
+  "provides": []
+}

--- a/alerting-query-language-lj/configure-handling/website.yaml
+++ b/alerting-query-language-lj/configure-handling/website.yaml
@@ -1,0 +1,11 @@
+menuTitle: Handling
+title: Configure no-data and error handling
+description: Confirm how your rule handles missing data and query errors.
+keywords:
+  - alerting
+  - handling
+weight: 800
+step: 9
+layout: single-journey
+cta:
+  type: continue

--- a/alerting-query-language-lj/configure-labels-evaluation/content.json
+++ b/alerting-query-language-lj/configure-labels-evaluation/content.json
@@ -1,0 +1,66 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "alerting-query-language-configure-labels-evaluation",
+  "title": "Create a folder and add labels",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "You'll organize your alert into a folder and add labels so the rule is easy to find and filter later. Labels can also feed notification policies when you set those up.\n\nFolders organize alerts by team, service, or purpose, and control who can manage them.\n\nIn this milestone, you create a folder, then add a rule-level label."
+    },
+    {
+      "type": "section",
+      "id": "select-folder",
+      "title": "Create a folder",
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "button",
+          "reftarget": "New folder",
+          "content": "In the **Add folder and labels** section, click **New folder** to open the create dialog.",
+          "doIt": false,
+          "requirements": [
+            "on-page:/alerting/new/alerting",
+            "exists-reftarget"
+          ]
+        },
+        {
+          "type": "markdown",
+          "content": "Enter a folder name (for example, **Alerts**), then click **Create**. The folder is saved and selected for your rule."
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "You've created a folder for the rule. Next, add labels."
+    },
+    {
+      "type": "section",
+      "id": "add-labels",
+      "title": "Add labels",
+      "requirements": [
+        "section-completed:select-folder"
+      ],
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "button",
+          "reftarget": "Add labels",
+          "content": "Click **Add labels** to open the labels editor. Labels are key-value tags that help you find and filter this alert. A sustained 5% error rate deserves the key **severity** and the value **critical**.",
+          "doIt": false,
+          "requirements": [
+            "on-page:/alerting/new/alerting",
+            "exists-reftarget"
+          ]
+        },
+        {
+          "type": "markdown",
+          "content": "Add a label with the key **severity** and the value **critical**, then click **Save**."
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "Your alert now has a folder and a label. Next, you set how often the rule evaluates and how long the condition must last before the alert fires."
+    }
+  ]
+}

--- a/alerting-query-language-lj/configure-labels-evaluation/manifest.json
+++ b/alerting-query-language-lj/configure-labels-evaluation/manifest.json
@@ -1,0 +1,21 @@
+{
+  "id": "alerting-query-language-configure-labels-evaluation",
+  "type": "guide",
+  "description": "Select a folder to organize your rule, then add a severity label.",
+  "category": "take-action",
+  "author": {
+    "name": "JohnnyK-Grafana",
+    "team": "Grafana Documentation"
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": [
+    "alerting-query-language-set-condition"
+  ],
+  "recommends": [
+    "alerting-query-language-set-evaluation-behavior"
+  ],
+  "suggests": [],
+  "provides": []
+}

--- a/alerting-query-language-lj/configure-labels-evaluation/website.yaml
+++ b/alerting-query-language-lj/configure-labels-evaluation/website.yaml
@@ -1,0 +1,11 @@
+menuTitle: Folder and labels
+title: Create a folder and add labels
+description: Select a folder to organize your rule, then add a severity label.
+keywords:
+  - alerting
+  - labels
+weight: 600
+step: 7
+layout: single-journey
+cta:
+  type: continue

--- a/alerting-query-language-lj/configure-notification/content.json
+++ b/alerting-query-language-lj/configure-notification/content.json
@@ -1,0 +1,68 @@
+{
+  "id": "alerting-query-language-configure-notification",
+  "title": "Configure the notification and save",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "When your alert fires, Grafana sends a notification to a contact point. The message includes a **Summary** and a **Description**.\n\nThis alert reports a **percentage**, so the Summary uses `printf \"%.1f\"` to format `$value` as a one-decimal number, and the Description names the ratio so the on-call reader knows what 5% means.\n\nIn this milestone, you choose the contact point, write the message, and save the rule."
+    },
+    {
+      "type": "section",
+      "id": "notify-and-save",
+      "title": "Choose contact point, write the message, and save",
+      "requirements": [
+        "on-page:/alerting/new/alerting"
+      ],
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='data-testid alert-rule contact-point-picker']",
+          "content": "In the **Configure notifications** section, open the **Contact point** picker and choose a contact point available on your stack.",
+          "requirements": [
+            "on-page:/alerting/new/alerting",
+            "exists-reftarget"
+          ],
+          "doIt": false
+        },
+        {
+          "type": "interactive",
+          "action": "formfill",
+          "reftarget": "[data-testid='annotation-value-0']",
+          "targetvalue": "QuickPizza error rate at {{ $value | printf \"%.1f\" }}% over the last 5 minutes",
+          "content": "In the **Summary** field (under **Configure notification message**), add:\n\n`QuickPizza error rate at {{ $value | printf \"%.1f\" }}% over the last 5 minutes`\n\nWhen the alert fires, `{{ $value }}` is replaced with the live percentage.",
+          "requirements": [
+            "on-page:/alerting/new/alerting",
+            "exists-reftarget"
+          ]
+        },
+        {
+          "type": "interactive",
+          "action": "formfill",
+          "reftarget": "[data-testid='annotation-value-1']",
+          "targetvalue": "Fires when the ratio of QuickPizza 5xx responses to total requests exceeds 5% over 5 minutes. Check recent deploys and the app dashboard first.",
+          "content": "In the **Description** field, add:\n\n`Fires when the ratio of QuickPizza 5xx responses to total requests exceeds 5% over 5 minutes. Check recent deploys and the app dashboard first.`",
+          "requirements": [
+            "on-page:/alerting/new/alerting",
+            "exists-reftarget"
+          ]
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='save-rule']",
+          "content": "Click **Save** in the action bar at the bottom of the page to save and activate your alert rule.",
+          "requirements": [
+            "on-page:/alerting/new/alerting",
+            "exists-reftarget"
+          ],
+          "doIt": false
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "Your alert rule is saved and running. When the error rate holds above 5% past the pending period, the alert fires and notifications go to your contact point."
+    }
+  ]
+}

--- a/alerting-query-language-lj/configure-notification/manifest.json
+++ b/alerting-query-language-lj/configure-notification/manifest.json
@@ -1,0 +1,21 @@
+{
+  "id": "alerting-query-language-configure-notification",
+  "type": "guide",
+  "description": "Choose a contact point, add a Summary and Description, and save the alert rule.",
+  "category": "take-action",
+  "author": {
+    "name": "JohnnyK-Grafana",
+    "team": "Grafana Documentation"
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": [
+    "alerting-query-language-configure-handling"
+  ],
+  "recommends": [
+    "alerting-query-language-create-silence"
+  ],
+  "suggests": [],
+  "provides": []
+}

--- a/alerting-query-language-lj/configure-notification/website.yaml
+++ b/alerting-query-language-lj/configure-notification/website.yaml
@@ -1,0 +1,12 @@
+menuTitle: Notify and save
+title: Configure the notification and save
+description: Choose a contact point, add a Summary and Description, and save the alert rule.
+keywords:
+  - alerting
+  - notifications
+  - annotations
+weight: 1000
+step: 11
+layout: single-journey
+cta:
+  type: continue

--- a/alerting-query-language-lj/content.json
+++ b/alerting-query-language-lj/content.json
@@ -1,0 +1,27 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "alerting-query-language-lj",
+  "title": "Create an alert rule with query language",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "Welcome! In this learning path, you build a Grafana alert rule by writing the query yourself in **Code mode**, instead of picking it from menus.\n\nYou'll open a new alert rule, write a PromQL query that measures QuickPizza's error rate, set a threshold, add labels and a folder, choose a contact point, and save."
+    },
+    {
+      "type": "markdown",
+      "content": "## What you'll learn\n\nBy the end of this path, you can:\n\n- Tell when Code mode is a better fit than Builder mode\n- Write a PromQL query that calculates a percentage\n- Set a threshold that decides when the alert fires\n- Organize an alert with a folder and labels for later filtering\n- Control how often Grafana checks the rule\n- Handle no-data and error cases so the alert stays useful\n- Send the alert to a contact point with a helpful message"
+    },
+    {
+      "type": "markdown",
+      "content": "## Before you begin\n\nYou need:\n\n- A Grafana Cloud account. To sign up, refer to [Grafana Cloud](https://grafana.com/signup/cloud/connect-account).\n- Permission to create alert rules.\n- Some familiarity with PromQL. If PromQL is new to you, try [Create your first alert rule](https://grafana.com/docs/learning-paths/alerting-first-rule/) first. It uses Builder mode, so you don't need to write any query.\n\nThe next milestone installs **QuickPizza**, a demo pizza shop that generates real metrics. Querying it doesn't count toward your Grafana Cloud usage."
+    },
+    {
+      "type": "markdown",
+      "content": "## Troubleshooting\n\nIf you get stuck, we've got your back! Where appropriate, troubleshooting information is just a click away."
+    },
+    {
+      "type": "markdown",
+      "content": "## More to explore\n\nAfter you save your first rule, explore silences to suppress notifications during planned maintenance, and learn how to configure contact points and notification policies in depth."
+    }
+  ]
+}

--- a/alerting-query-language-lj/create-silence/content.json
+++ b/alerting-query-language-lj/create-silence/content.json
@@ -1,0 +1,149 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "alerting-query-language-create-silence",
+  "title": "Create a silence",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "You'll create a silence that suppresses notifications for alerts with the label **severity=critical**.\n\nUse the defaults for the time window. Enter the label matcher values this path provides."
+    },
+    {
+      "type": "section",
+      "id": "open-silence-form",
+      "title": "Start a new silence",
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "navigate",
+          "reftarget": "/alerting/silences",
+          "content": "In the main menu, click **Alerting > Silences**.",
+          "verify": "on-page:/alerting/silences"
+        },
+        {
+          "type": "interactive",
+          "action": "navigate",
+          "reftarget": "/alerting/silence/new",
+          "content": "Click **Create silence**.",
+          "requirements": [
+            "on-page:/alerting/silences"
+          ],
+          "verify": "on-page:/alerting/silence/new"
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "You've opened the new silence form. Next, leave the default time window."
+    },
+    {
+      "type": "section",
+      "id": "set-time-window",
+      "title": "Set the silence time window",
+      "requirements": [
+        "section-completed:open-silence-form"
+      ],
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "label:contains('Silence start and end')",
+          "content": "Leave the default **Silence start and end** times for now.",
+          "doIt": false,
+          "requirements": [
+            "on-page:/alerting/silence/new"
+          ]
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "#duration",
+          "content": "Leave **Duration** set to **2h**.",
+          "doIt": false,
+          "requirements": [
+            "on-page:/alerting/silence/new"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "You've kept the default two-hour window. Next, add a label matcher."
+    },
+    {
+      "type": "section",
+      "id": "add-matchers",
+      "title": "Add label matchers",
+      "requirements": [
+        "section-completed:set-time-window"
+      ],
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "formfill",
+          "reftarget": "#matcher-0-label",
+          "targetvalue": "severity",
+          "content": "In the **Label** field, enter `severity`.",
+          "tooltip": "Paste the label name from the label you added earlier.",
+          "doIt": true,
+          "requirements": [
+            "on-page:/alerting/silence/new",
+            "exists-reftarget"
+          ]
+        },
+        {
+          "type": "interactive",
+          "action": "formfill",
+          "reftarget": "#matcher-0-value",
+          "targetvalue": "critical",
+          "content": "In the **Value** field, enter `critical`.",
+          "tooltip": "Paste the label value from the label you added earlier.",
+          "doIt": true,
+          "requirements": [
+            "on-page:/alerting/silence/new",
+            "exists-reftarget"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "Your matcher is **severity=critical**. Optionally check **Affected alert instances** below the matchers (an empty list is fine), then add a comment and save."
+    },
+    {
+      "type": "section",
+      "id": "verify-and-submit",
+      "title": "Add a comment and save",
+      "requirements": [
+        "section-completed:add-matchers"
+      ],
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "formfill",
+          "reftarget": "#comment",
+          "targetvalue": "Maintenance window",
+          "content": "In the **Comment** field, replace the text with `Maintenance window`.",
+          "doIt": true,
+          "requirements": [
+            "on-page:/alerting/silence/new",
+            "exists-reftarget"
+          ]
+        },
+        {
+          "type": "interactive",
+          "action": "button",
+          "reftarget": "Save silence",
+          "content": "Click **Save silence**.",
+          "requirements": [
+            "on-page:/alerting/silence/new",
+            "exists-reftarget"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "Your silence is active. Matching alerts won't notify anyone until the window ends."
+    }
+  ]
+}

--- a/alerting-query-language-lj/create-silence/manifest.json
+++ b/alerting-query-language-lj/create-silence/manifest.json
@@ -1,0 +1,21 @@
+{
+  "id": "alerting-query-language-create-silence",
+  "type": "guide",
+  "description": "Set a time window, add label matchers, verify affected instances, and submit the silence.",
+  "category": "take-action",
+  "author": {
+    "name": "JohnnyK-Grafana",
+    "team": "Grafana Documentation"
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": [
+    "alerting-query-language-configure-notification"
+  ],
+  "recommends": [
+    "alerting-query-language-end-journey"
+  ],
+  "suggests": [],
+  "provides": []
+}

--- a/alerting-query-language-lj/create-silence/website.yaml
+++ b/alerting-query-language-lj/create-silence/website.yaml
@@ -1,0 +1,11 @@
+menuTitle: Create silence
+title: Create a silence
+description: Set a time window, add label matchers, verify affected instances, and submit.
+keywords:
+  - alerting
+  - silence
+weight: 1100
+step: 12
+layout: single-journey
+cta:
+  type: continue

--- a/alerting-query-language-lj/end-journey/content.json
+++ b/alerting-query-language-lj/end-journey/content.json
@@ -1,0 +1,19 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "alerting-query-language-end-journey",
+  "title": "Destination reached!",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "Congratulations on completing this path! Job well done!\n\nWe hope you've enjoyed traveling with us as you:\n\n- Opened and named your alert rule\n- Switched the query editor to Code mode\n- Wrote a PromQL error-rate query using two `rate()` calls and a ratio\n- Set the alert condition, threshold, and recovery threshold\n- Created a folder and added a severity label\n- Configured the evaluation interval and pending period\n- Confirmed no-data and error handling\n- Chose a contact point, wrote the notification message, and saved the rule\n- Suppressed notifications during maintenance with a silence"
+    },
+    {
+      "type": "markdown",
+      "content": "You now have a working alert rule whose error-rate query is written as clear PromQL in Code mode. That's a pattern you'll reuse whenever the query needs multi-step math."
+    },
+    {
+      "type": "markdown",
+      "content": "---\n\n### More to explore (optional)\n\nRead more about how you can:\n\n- [Build alert queries and conditions](https://grafana.com/docs/grafana/latest/alerting/fundamentals/alert-rules/queries-conditions/)\n- [Write PromQL expressions](https://grafana.com/docs/grafana/latest/fundamentals/intro-to-promql/)\n- [Configure contact points](https://grafana.com/docs/grafana/latest/alerting/configure-notifications/manage-contact-points/)\n- [Write effective alert annotations](https://grafana.com/docs/grafana/latest/alerting/fundamentals/alert-rules/annotation-label/)"
+    }
+  ]
+}

--- a/alerting-query-language-lj/end-journey/manifest.json
+++ b/alerting-query-language-lj/end-journey/manifest.json
@@ -1,0 +1,19 @@
+{
+  "id": "alerting-query-language-end-journey",
+  "type": "guide",
+  "description": "You created a complete alert rule in Code mode from query to notification.",
+  "category": "take-action",
+  "author": {
+    "name": "JohnnyK-Grafana",
+    "team": "Grafana Documentation"
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": [
+    "alerting-query-language-create-silence"
+  ],
+  "recommends": [],
+  "suggests": [],
+  "provides": []
+}

--- a/alerting-query-language-lj/end-journey/website.yaml
+++ b/alerting-query-language-lj/end-journey/website.yaml
@@ -1,0 +1,14 @@
+menuTitle: Complete
+title: Destination reached!
+description: You created a complete alert rule in Code mode from query to notification.
+keywords:
+  - alerting
+weight: 1200
+step: 13
+layout: single-journey
+cta:
+  type: conclusion
+  image:
+    src: /media/docs/learning-journey/journey-conclusion-header-1.svg
+    width: 735
+    height: 175

--- a/alerting-query-language-lj/install-datasources/content.json
+++ b/alerting-query-language-lj/install-datasources/content.json
@@ -1,0 +1,55 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "alerting-query-language-install-datasources",
+  "title": "Install the QuickPizza demo",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "This path uses the QuickPizza tutorial data sources, which include a Prometheus data source named **grafanacloud-play-prom** that carries real metrics from a running demo service. Querying these data sources does not count toward your Grafana Cloud usage.\n\nThe install runs from the **Demo Data Dashboards** app in the left nav. After the install finishes, Grafana refreshes the page and the alerting flow picks up in the next milestone."
+    },
+    {
+      "type": "section",
+      "id": "install-tutorial-datasources",
+      "title": "Install QuickPizza",
+      "objectives": [
+        "has-datasource:grafanacloud-play-prom"
+      ],
+      "blocks": [
+        {
+          "type": "multistep",
+          "content": "Expand **More apps** in the main menu, then open **Demo Data Dashboards**.",
+          "requirements": [
+            "navmenu-open"
+          ],
+          "steps": [
+            {
+              "action": "highlight",
+              "reftarget": "button[aria-label*='section: More apps']"
+            },
+            {
+              "action": "highlight",
+              "reftarget": "a[data-testid='data-testid Nav menu item'][href='/a/grafana-demodashboards-app']"
+            }
+          ]
+        },
+        {
+          "type": "guided",
+          "content": "Click **Install the Quick Pizza SRE demo**. This deploys the tutorial data sources and refreshes the page.",
+          "completeEarly": true,
+          "steps": [
+            {
+              "action": "highlight",
+              "reftarget": "button[data-testid='install-quickpizza']",
+              "lazyRender": true,
+              "description": "Click **Install the Quick Pizza SRE demo**."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "Install opens the QuickPizza dashboards folder. Those dashboards use the tutorial Prometheus data source **grafanacloud-play-prom**. Next, you'll open the new alert rule page and build a query on that same data."
+    }
+  ]
+}

--- a/alerting-query-language-lj/install-datasources/manifest.json
+++ b/alerting-query-language-lj/install-datasources/manifest.json
@@ -1,0 +1,19 @@
+{
+  "id": "alerting-query-language-install-datasources",
+  "type": "guide",
+  "description": "Install the QuickPizza tutorial data sources so the alert rule has real data to query.",
+  "category": "take-action",
+  "author": {
+    "name": "JohnnyK-Grafana",
+    "team": "Grafana Documentation"
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": [],
+  "recommends": [
+    "alerting-query-language-navigate-to-form"
+  ],
+  "suggests": [],
+  "provides": []
+}

--- a/alerting-query-language-lj/install-datasources/website.yaml
+++ b/alerting-query-language-lj/install-datasources/website.yaml
@@ -1,0 +1,12 @@
+menuTitle: Install QuickPizza
+title: Install the QuickPizza demo
+description: Install the QuickPizza tutorial data sources so the alert rule has real data to query.
+keywords:
+  - alerting
+  - datasource
+  - quickpizza
+weight: 200
+step: 3
+layout: single-journey
+cta:
+  type: continue

--- a/alerting-query-language-lj/manifest.json
+++ b/alerting-query-language-lj/manifest.json
@@ -1,0 +1,26 @@
+{
+  "id": "alerting-query-language-lj",
+  "type": "path",
+  "description": "Step-by-step guide: open and name an alert rule, switch to Code mode and write a PromQL error-rate query, set the condition and recovery, add a folder and labels, configure evaluation and handling, choose a contact point, write the notification, and save.",
+  "category": "take-action",
+  "author": { "name": "JohnnyK-Grafana", "team": "Grafana Documentation" },
+  "startingLocation": "/alerting",
+  "targeting": { "match": { "and": [ { "urlPrefix": "/alerting" }, { "targetPlatform": "cloud" } ] } },
+  "testEnvironment": { "tier": "cloud" },
+  "milestones": [
+    "alerting-query-language-install-datasources",
+    "alerting-query-language-navigate-to-form",
+    "alerting-query-language-build-query",
+    "alerting-query-language-set-condition",
+    "alerting-query-language-configure-labels-evaluation",
+    "alerting-query-language-set-evaluation-behavior",
+    "alerting-query-language-configure-handling",
+    "alerting-query-language-configure-notification",
+    "alerting-query-language-create-silence",
+    "alerting-query-language-end-journey"
+  ],
+  "depends": [],
+  "recommends": [],
+  "suggests": [],
+  "provides": []
+}

--- a/alerting-query-language-lj/navigate-to-form/content.json
+++ b/alerting-query-language-lj/navigate-to-form/content.json
@@ -1,0 +1,51 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "alerting-query-language-navigate-to-form",
+  "title": "Open the New alert rule page",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "A clear, descriptive name is the first thing responders see when an alert fires. A good name tells them immediately what's wrong without opening the alert details.\n\nIn this milestone, you'll open the **New alert rule** page and name your rule."
+    },
+    {
+      "type": "section",
+      "id": "open-and-name-alert-rule",
+      "title": "Open and name your alert rule",
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "navigate",
+          "reftarget": "/alerting/list",
+          "content": "In the main menu, click **Alerting > Alert rules**.",
+          "verify": "on-page:/alerting/list"
+        },
+        {
+          "type": "interactive",
+          "action": "navigate",
+          "reftarget": "/alerting/new/alerting",
+          "content": "Click **+ New alert rule**.",
+          "requirements": [
+            "on-page:/alerting/list"
+          ],
+          "verify": "on-page:/alerting/new/alerting"
+        },
+        {
+          "type": "interactive",
+          "action": "formfill",
+          "reftarget": "input[placeholder='Give your alert rule a name']",
+          "targetvalue": "QuickPizza high error rate",
+          "content": "In the **Name** field, enter `QuickPizza high error rate`.",
+          "tooltip": "Responders see this name first when the alert fires.",
+          "requirements": [
+            "on-page:/alerting/new/alerting",
+            "exists-reftarget"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "Your rule has a clear name. Next, you write the query in Code mode."
+    }
+  ]
+}

--- a/alerting-query-language-lj/navigate-to-form/manifest.json
+++ b/alerting-query-language-lj/navigate-to-form/manifest.json
@@ -1,0 +1,21 @@
+{
+  "id": "alerting-query-language-navigate-to-form",
+  "type": "guide",
+  "description": "Open the new alert rule page and give your rule a clear name.",
+  "category": "take-action",
+  "author": {
+    "name": "JohnnyK-Grafana",
+    "team": "Grafana Documentation"
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": [
+    "alerting-query-language-install-datasources"
+  ],
+  "recommends": [
+    "alerting-query-language-build-query"
+  ],
+  "suggests": [],
+  "provides": []
+}

--- a/alerting-query-language-lj/navigate-to-form/website.yaml
+++ b/alerting-query-language-lj/navigate-to-form/website.yaml
@@ -1,0 +1,11 @@
+menuTitle: Name your rule
+title: Open the new alert rule page
+description: Open the new alert rule page and give your rule a clear name.
+keywords:
+  - alerting
+  - alert rule
+weight: 300
+step: 4
+layout: single-journey
+cta:
+  type: continue

--- a/alerting-query-language-lj/set-condition/content.json
+++ b/alerting-query-language-lj/set-condition/content.json
@@ -1,0 +1,69 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "alerting-query-language-set-condition",
+  "title": "Set the alert condition and recovery",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "Your query returns a percentage. Tell Grafana when that percentage is too high, then add a recovery threshold so the alert doesn't flap near the trigger point.\n\nSet the threshold to **5** so the alert fires when the error rate goes above 5%. Then set recovery to **3** so it returns to normal only after the rate drops below 3%."
+    },
+    {
+      "type": "section",
+      "id": "set-preview-and-recovery",
+      "title": "Set the condition and recovery threshold",
+      "requirements": [
+        "has-datasource:grafanacloud-play-prom"
+      ],
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "label:contains('WHEN QUERY')",
+          "content": "In the **Alert condition** section, leave **Is above** selected.",
+          "doIt": false,
+          "requirements": [
+            "on-page:/alerting/new/alerting"
+          ]
+        },
+        {
+          "type": "interactive",
+          "action": "formfill",
+          "reftarget": "[data-testid='data-testid alert-rule step-2'] input[type='number']",
+          "targetvalue": "5",
+          "content": "Set the threshold to `5`.",
+          "tooltip": "The query returns a percentage, so 5 means 5%.",
+          "requirements": [
+            "on-page:/alerting/new/alerting",
+            "exists-reftarget"
+          ]
+        },
+        {
+          "type": "interactive",
+          "action": "button",
+          "reftarget": "Preview alert rule condition",
+          "content": "Click **Preview alert rule condition** to evaluate the threshold against your query.\n\nLook for a result row above the button (for example **Series 1** with a value). It may show **Normal** or **Firing**. With a threshold of **5**, **Normal** is expected when the error rate is under 5% right now.",
+          "requirements": [
+            "on-page:/alerting/new/alerting",
+            "exists-reftarget"
+          ]
+        },
+        {
+          "type": "markdown",
+          "content": "Still in **Define query and alert condition**, turn on **Advanced options** at the top of that section."
+        },
+        {
+          "type": "markdown",
+          "content": "Scroll down to the **Expressions** area and open the **C Threshold** block. Under **IS ABOVE**, turn on **Custom recovery threshold**."
+        },
+        {
+          "type": "markdown",
+          "content": "Still in **C Threshold**, in **Stop alerting (or pending state) when below**, set the value to **3**."
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "The condition and recovery threshold are set. Next, you pick a folder and add labels so the alert is easy to find and organize."
+    }
+  ]
+}

--- a/alerting-query-language-lj/set-condition/manifest.json
+++ b/alerting-query-language-lj/set-condition/manifest.json
@@ -1,0 +1,21 @@
+{
+  "id": "alerting-query-language-set-condition",
+  "type": "guide",
+  "description": "Set a threshold, preview the result, then add a recovery threshold.",
+  "category": "take-action",
+  "author": {
+    "name": "JohnnyK-Grafana",
+    "team": "Grafana Documentation"
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": [
+    "alerting-query-language-build-query"
+  ],
+  "recommends": [
+    "alerting-query-language-configure-labels-evaluation"
+  ],
+  "suggests": [],
+  "provides": []
+}

--- a/alerting-query-language-lj/set-condition/website.yaml
+++ b/alerting-query-language-lj/set-condition/website.yaml
@@ -1,0 +1,11 @@
+menuTitle: Set condition
+title: Set the alert condition and recovery
+description: Set a threshold, preview the result, then add a recovery threshold.
+keywords:
+  - alerting
+  - condition
+weight: 500
+step: 6
+layout: single-journey
+cta:
+  type: continue

--- a/alerting-query-language-lj/set-evaluation-behavior/content.json
+++ b/alerting-query-language-lj/set-evaluation-behavior/content.json
@@ -1,0 +1,63 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "alerting-query-language-set-evaluation-behavior",
+  "title": "Set evaluation behavior",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "Evaluation behavior sets how often Grafana runs your query, how long a problem must last before the alert fires, and how long the alert keeps firing after the condition resolves.\n\nIn this milestone, create an evaluation group, then set the pending period and keep firing for."
+    },
+    {
+      "type": "section",
+      "id": "set-evaluation-behavior",
+      "title": "Set evaluation behavior",
+      "requirements": [
+        "on-page:/alerting/new/alerting"
+      ],
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "button",
+          "reftarget": "New evaluation group",
+          "content": "In the **Set evaluation behavior** section, click **New evaluation group** to open the dialog.",
+          "doIt": false,
+          "requirements": [
+            "on-page:/alerting/new/alerting",
+            "exists-reftarget"
+          ]
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Give the group a name, such as **Alerts group**, set the **Evaluation interval** to **1m**, then click **Create**."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "#eval-for-input",
+          "content": "In the **Pending period** field, enter **1m**. Brief spikes get filtered out, but a real problem fires quickly.",
+          "doIt": false,
+          "requirements": [
+            "on-page:/alerting/new/alerting",
+            "exists-reftarget"
+          ]
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "#keep-firing-for-input",
+          "content": "In the **Keep firing for** field, leave **None**. This is how long the alert keeps firing after the condition resolves.",
+          "doIt": false,
+          "requirements": [
+            "on-page:/alerting/new/alerting",
+            "exists-reftarget"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "Your evaluation schedule is set. Next, you confirm no-data and error handling."
+    }
+  ]
+}

--- a/alerting-query-language-lj/set-evaluation-behavior/manifest.json
+++ b/alerting-query-language-lj/set-evaluation-behavior/manifest.json
@@ -1,0 +1,21 @@
+{
+  "id": "alerting-query-language-set-evaluation-behavior",
+  "type": "guide",
+  "description": "Create an evaluation group, then set the pending period and keep firing for.",
+  "category": "take-action",
+  "author": {
+    "name": "JohnnyK-Grafana",
+    "team": "Grafana Documentation"
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": [
+    "alerting-query-language-configure-labels-evaluation"
+  ],
+  "recommends": [
+    "alerting-query-language-configure-handling"
+  ],
+  "suggests": [],
+  "provides": []
+}

--- a/alerting-query-language-lj/set-evaluation-behavior/website.yaml
+++ b/alerting-query-language-lj/set-evaluation-behavior/website.yaml
@@ -1,0 +1,11 @@
+menuTitle: Evaluation behavior
+title: Set evaluation behavior
+description: Create an evaluation group, then set the pending period and keep firing for.
+keywords:
+  - alerting
+  - evaluation
+weight: 700
+step: 8
+layout: single-journey
+cta:
+  type: continue

--- a/alerting-query-language-lj/website.yaml
+++ b/alerting-query-language-lj/website.yaml
@@ -1,0 +1,40 @@
+menuTitle: First alert rule with query language
+title: Create an alert rule with query language
+description: Build a Grafana alert rule in Code mode — write a PromQL error-rate query, set a condition, add labels, configure evaluation and notifications, and save.
+weight: 750
+journey:
+  group: take-action
+  skill: Intermediate
+  source: Docs & blog posts
+  logo:
+    src: /static/img/menu/grafana2.svg
+    background: '#0068FF'
+    width: 46
+    height: 55
+step: 1
+layout: single-journey
+cascade:
+  layout: single-journey
+cta:
+  type: start
+  title: Are you ready?
+  cta_text: Let's go!
+keywords:
+  - alerting
+  - alert rule
+  - PromQL
+  - code mode
+  - query language
+  - notifications
+  - save
+related_journeys:
+  title: Related paths
+  heading: Consider taking the following paths before you start this path.
+  items:
+    - title: Create your first alert rule
+      url: /docs/learning-paths/alerting-first-rule/
+      description: Companion Builder-mode path on the same PR. Recommended before this path if you're new to PromQL.
+source_docs:
+  - /docs/grafana/latest/alerting/fundamentals/alert-rules/
+  - /docs/grafana/latest/alerting/fundamentals/alert-rules/queries-conditions/
+  - /docs/grafana/latest/alerting/fundamentals/notifications/contact-points/


### PR DESCRIPTION
Replacement for #377 — same content, rebased onto current `main` as a single signed commit so the branch can pass the org signed-commits ruleset.

## Summary
- Adds `alerting-first-rule-lj` (Builder-mode first alert rule path)
- Adds `alerting-query-language-lj` (Code-mode path, including silence)
- Contact-point selectors match the live UI (`data-testid alert-rule contact-point-picker`)
- CODEOWNERS entries for both packages

## Why replace #377
#377 is 376 commits behind `main` and cannot be updated/rebased in place: merging or force-pushing would introduce unsigned commits already on `main`, which the signed-commits ruleset rejects on that branch. This PR is `main` + one signed commit.

Closes #377

Made with [Cursor](https://cursor.com)