### PR TITLE
Remove parked Work with links from Get started Assistant end-journey

### DIFF
--- a/get-started-grafana-assistant-lj/end-journey/content.json
+++ b/get-started-grafana-assistant-lj/end-journey/content.json
@@ -9,7 +9,7 @@
     },
     {
       "type": "markdown",
-      "content": "---\n\n### More to explore (optional)\n\nContinue practicing Assistant workflows:\n\n- [Work with Grafana Assistant](https://grafana.com/docs/learning-paths/work-with-grafana-assistant/) to navigate resources, query data, and manage dashboards\n- [Navigate Grafana resources](https://grafana.com/docs/grafana-cloud/machine-learning/assistant/guides/navigation/)\n- [Query data](https://grafana.com/docs/grafana-cloud/machine-learning/assistant/guides/querying/)\n- [Manage dashboards](https://grafana.com/docs/grafana-cloud/machine-learning/assistant/guides/dashboarding/)\n- [Introduction to Grafana Assistant](https://grafana.com/docs/learning-hub/intro-to-grafana-assistant/) journey"
+      "content": "---\n\n### More to explore (optional)\n\nContinue practicing Assistant workflows:\n\n- [Introduction to Grafana Assistant](https://grafana.com/docs/learning-hub/intro-to-grafana-assistant/) journey\n- [Navigate Grafana resources](https://grafana.com/docs/grafana-cloud/machine-learning/assistant/guides/navigation/)\n- [Query data](https://grafana.com/docs/grafana-cloud/machine-learning/assistant/guides/querying/)\n- [Manage dashboards](https://grafana.com/docs/grafana-cloud/machine-learning/assistant/guides/dashboarding/)"
     }
   ]
 }

--- a/get-started-grafana-assistant-lj/end-journey/manifest.json
+++ b/get-started-grafana-assistant-lj/end-journey/manifest.json
@@ -13,5 +13,5 @@
   },
   "depends": ["get-started-grafana-assistant-try-learn-mode"],
   "recommends": [],
-  "suggests": ["work-with-grafana-assistant-lj"]
+  "suggests": []
 }

--- a/get-started-grafana-assistant-lj/end-journey/website.yaml
+++ b/get-started-grafana-assistant-lj/end-journey/website.yaml
@@ -12,8 +12,8 @@ side_journeys:
   title: More to explore (optional)
   heading: 'Continue practicing Assistant workflows:'
   items:
-    - title: Work with Grafana Assistant
-      link: /docs/learning-paths/work-with-grafana-assistant/
+    - title: Introduction to Grafana Assistant
+      link: /docs/learning-hub/intro-to-grafana-assistant/
     - title: Navigate Grafana resources
       link: /docs/grafana-cloud/machine-learning/assistant/guides/navigation/
     - title: Query data


### PR DESCRIPTION
## Summary
- Drop the unpublished Work with Grafana Assistant learning-path link from Get started end-journey (`content.json` and `website.yaml`).
- Point side journeys at the Introduction to Grafana Assistant Hub journey plus Navigate / Query / Manage dashboards docs.
- Clear `suggests: work-with-grafana-assistant-lj` from the end-journey manifest so Pathfinder does not recommend a parked package.

## Test plan
- [ ] Confirm end-journey “More to explore” lists Hub journey + three docs guides only
- [ ] Confirm no remaining `work-with-grafana-assistant` references under `get-started-grafana-assistant-lj/`
- [ ] After merge, spot-check Learning Hub destination side journeys when the path is live

(associated with https://github.com/grafana/website/pull/32909)
Made with [Cursor](https://cursor.com)