### PR TITLE
Fixes broken selector in Play NZ Geonet Guide

### DIFF
--- a/play-nz-geonet-tour/content.json
+++ b/play-nz-geonet-tour/content.json
@@ -243,8 +243,8 @@
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "div[data-testid=\"query-editor-row\"] > :first-child",
-          "content": "The data source here is set to **Dashboard**, pointing at the Recent Earthquakes panel. No second API call is made — this panel simply reuses the table that Infinity + JQ already produced, applying its own colour rules on top.",
+          "reftarget": "input[data-testid='data-testid Select a data source']",
+          "content": "The data source here is set to **-- Dashboard --**, and the query below points at the Recent Earthquakes panel. No second API call is made — this panel simply reuses the table that Infinity + JQ already produced, applying its own colour rules on top.",
           "doIt": false,
           "lazyRender": true
         },


### PR DESCRIPTION
This fixes a broken selector in the Play NZ Geonet dashboard guide, where it was trying to show that the data source for a query was "Dashboard".  I also had Claude run through the whole guide with the current guidelines.  I've tested this as an anonymous user on playdev, which is how users accessing this guide will reach it in production on Play.

Can be tested with dashboard at https://playdev.grafana.net/d/simgmgk/new-zealand-geonet