### PR TITLE
asCode - Moving learning paths

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -110,6 +110,7 @@
 /visualization-metrics-lj/                                @knylander-grafana
 /visualization-traces-lj/                                 @knylander-grafana
 /git-sync-dashboards-lj/                                  @bonnywelsford-source
+/git-sync-use-lj/                                         @urbiz-grafana
 /get-started-grafana-assistant-lj/                        @bonnywelsford-source
 /interactive-dashboards-lj/                               @bonnywelsford-source
 /welcome-to-play/                                         @Jayclifford345 @mdcruz

--- a/git-sync-use-lj/business-value/content.json
+++ b/git-sync-use-lj/business-value/content.json
@@ -1,0 +1,19 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "git-sync-use-business-value",
+  "title": "The value of Git Sync",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "Managing dashboards at scale presents challenges for teams that need to collaborate, track changes, and maintain consistency across environments. Traditional dashboard management lacks version control, making it difficult to understand who changed what, when changes occurred, and how to revert problematic updates.\n\nGit Sync solves these challenges by treating dashboards as code with full Git workflow benefits. This approach brings proven software development practices to observability infrastructure management."
+    },
+    {
+      "type": "markdown",
+      "content": "Git Sync provides the following advantages for dashboard management:\n\n- Treat dashboards as code with Git version control and change history\n- Enable collaboration through pull requests and code reviews\n- Track all changes with detailed commit history and author information\n- Roll back to previous versions when issues occur\n- Integrate dashboard changes into CI/CD workflows and automation\n- Maintain consistency across development, staging, and production environments\n- Enforce quality standards through branch protection and approval processes"
+    },
+    {
+      "type": "markdown",
+      "content": "In the next milestone, you'll learn how Git Sync works and understand the different sync states."
+    }
+  ]
+}

--- a/git-sync-use-lj/business-value/manifest.json
+++ b/git-sync-use-lj/business-value/manifest.json
@@ -1,0 +1,18 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "git-sync-use-business-value",
+  "type": "guide",
+  "description": "Learn about the advantages of managing dashboards with Git Sync and version control.",
+  "category": "take-action",
+  "author": {
+    "team": "Grafana Documentation"
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": [],
+  "recommends": [
+    "git-sync-use-how-git-sync-works"
+  ],
+  "suggests": []
+}

--- a/git-sync-use-lj/business-value/website.yaml
+++ b/git-sync-use-lj/business-value/website.yaml
@@ -1,0 +1,13 @@
+menuTitle: Value of Git Sync
+title: The value of Git Sync
+description: Learn about the advantages of managing dashboards with Git Sync and version control.
+weight: 100
+step: 2
+layout: single-journey
+cta:
+  type: continue
+keywords:
+  - Git Sync
+  - version control
+  - collaboration
+  - dashboards

--- a/git-sync-use-lj/content.json
+++ b/git-sync-use-lj/content.json
@@ -1,0 +1,23 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "git-sync-use-lj",
+  "title": "Use Git Sync to manage resources",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "Welcome to the learning path that shows you how to use Git Sync, a feature that provides bidirectional synchronization between your Grafana dashboards and Git repositories. With Git Sync, you can manage dashboards as code through pull requests, track version history, and maintain consistency across environments using the same workflows your development teams already use for application code."
+    },
+    {
+      "type": "markdown",
+      "content": "## Here's what to expect\n\nWhen you complete this journey, you'll be able to:\n\n- Understand the value of managing dashboards with Git version control\n- Learn how Git Sync works and the different sync states\n- Review prerequisites and known limitations\n- Navigate to the Git Sync interface\n- View synced dashboards and their status\n- Manage dashboard synchronization between Grafana and Git"
+    },
+    {
+      "type": "markdown",
+      "content": "## Troubleshooting\n\nIf you get stuck, we've got your back! Where appropriate, troubleshooting information is just a click away.\n\n## More to explore\n\nWe understand you might want to explore other capabilities not strictly on this path. We'll provide you opportunities where it makes sense."
+    },
+    {
+      "type": "markdown",
+      "content": "---\n\n### Related paths\n\nConsider taking the following journey after you complete this journey:\n\n- [Work with dashboards using Git Sync](https://grafana.com/docs/learning-paths/git-sync-dashboards/)"
+    }
+  ]
+}

--- a/git-sync-use-lj/end-journey/content.json
+++ b/git-sync-use-lj/end-journey/content.json
@@ -1,0 +1,19 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "git-sync-use-end-journey",
+  "title": "Destination reached!",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "Congratulations on completing this journey! Job well done!"
+    },
+    {
+      "type": "markdown",
+      "content": "We hope you've enjoyed traveling with us as you:\n\n- Understood the value of managing dashboards with Git Sync and version control\n- Learned how Git Sync works and the different sync states\n- Reviewed prerequisites and known limitations\n- Navigated to the Git Sync interface in Grafana Cloud\n- Viewed synced dashboards and their sync status\n- Managed dashboard synchronization between Grafana and Git"
+    },
+    {
+      "type": "markdown",
+      "content": "---\n\n### Related paths\n\nConsider taking the following journey after you complete this journey:\n\n- [Work with dashboards using Git Sync](https://grafana.com/docs/learning-paths/git-sync-dashboards/)"
+    }
+  ]
+}

--- a/git-sync-use-lj/end-journey/manifest.json
+++ b/git-sync-use-lj/end-journey/manifest.json
@@ -1,0 +1,20 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "git-sync-use-end-journey",
+  "type": "guide",
+  "description": "Congratulations on completing the Git Sync learning path.",
+  "category": "take-action",
+  "author": {
+    "team": "Grafana Documentation"
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": [
+    "git-sync-use-manage-dashboard-sync"
+  ],
+  "recommends": [],
+  "suggests": [
+    "git-sync-dashboards-lj"
+  ]
+}

--- a/git-sync-use-lj/end-journey/website.yaml
+++ b/git-sync-use-lj/end-journey/website.yaml
@@ -1,0 +1,21 @@
+menuTitle: Destination reached!
+title: Destination reached!
+description: Congratulations on completing the Git Sync learning path.
+weight: 800
+step: 9
+layout: single-journey
+cta:
+  type: conclusion
+  image:
+    src: /media/docs/learning-journey/journey-conclusion-header-1.svg
+    width: 735
+    height: 175
+keywords:
+  - Git Sync
+  - completion
+related_journeys:
+  title: Related paths
+  heading: Consider taking the following journey after you complete this journey.
+  items:
+    - title: Work with dashboards using Git Sync
+      link: /docs/learning-paths/git-sync-dashboards/

--- a/git-sync-use-lj/how-git-sync-works/content.json
+++ b/git-sync-use-lj/how-git-sync-works/content.json
@@ -1,0 +1,27 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "git-sync-use-how-git-sync-works",
+  "title": "How Git Sync works",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "Git Sync provides bidirectional synchronization between your Grafana Cloud instance and Git repositories. When you enable Git Sync, dashboards are stored as JSON files in your repository, allowing you to manage them using standard Git workflows including commits, branches, pull requests, and merges."
+    },
+    {
+      "type": "markdown",
+      "content": "The synchronization mechanism monitors both Grafana and your Git repository for changes. When you modify a dashboard in Grafana, Git Sync can push those changes to your repository. When changes occur in your repository, Git Sync can pull those updates into Grafana. This bidirectional flow ensures your dashboards stay synchronized across both systems."
+    },
+    {
+      "type": "markdown",
+      "content": "## Sync states\n\nGit Sync uses the following sync states to track dashboard status:\n\n| State | Description |\n| --- | --- |\n| **Synced** | Dashboard matches the version in Git with no differences |\n| **Modified** | Dashboard has local changes in Grafana not yet committed to Git |\n| **Out of sync** | Git repository has a newer version than the dashboard in Grafana |\n| **Conflict** | Both Grafana and Git have conflicting changes that require manual resolution |"
+    },
+    {
+      "type": "markdown",
+      "content": "Understanding these states helps you identify which dashboards need attention and what actions to take. The sync state appears next to each dashboard in the Git Sync interface."
+    },
+    {
+      "type": "markdown",
+      "content": "In the next milestone, you'll review the prerequisites for using Git Sync."
+    }
+  ]
+}

--- a/git-sync-use-lj/how-git-sync-works/manifest.json
+++ b/git-sync-use-lj/how-git-sync-works/manifest.json
@@ -1,0 +1,18 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "git-sync-use-how-git-sync-works",
+  "type": "guide",
+  "description": "Understand the bidirectional synchronization between Grafana and Git repositories and learn about sync states.",
+  "category": "take-action",
+  "author": {
+    "team": "Grafana Documentation"
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": [],
+  "recommends": [
+    "git-sync-use-prerequisites"
+  ],
+  "suggests": []
+}

--- a/git-sync-use-lj/how-git-sync-works/website.yaml
+++ b/git-sync-use-lj/how-git-sync-works/website.yaml
@@ -1,0 +1,13 @@
+menuTitle: How Git Sync works
+title: How Git Sync works
+description: Understand the bidirectional synchronization between Grafana and Git repositories and learn about sync states.
+weight: 200
+step: 3
+layout: single-journey
+cta:
+  type: continue
+keywords:
+  - Git Sync
+  - synchronization
+  - sync states
+  - dashboards

--- a/git-sync-use-lj/known-limitations/content.json
+++ b/git-sync-use-lj/known-limitations/content.json
@@ -1,0 +1,27 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "git-sync-use-known-limitations",
+  "title": "Known limitations",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "Git Sync has certain limitations you should be aware of when planning your dashboard management workflow. Understanding these constraints helps you design effective processes and avoid unexpected behavior."
+    },
+    {
+      "type": "markdown",
+      "content": "## Current limitations\n\nBe aware of the following limitations when using Git Sync.\n\n**Synced resources**\n\n- You can only sync dashboards and folders. Refer to [Supported resources](https://grafana.com/docs/grafana/latest/as-code/observability-as-code/git-sync/#resource-support-and-compatibility) for more information.\n- If you're using Git Sync in Grafana OSS and Grafana Enterprise, some resources might be in an incompatible data format and won't be synced.\n- Full-instance sync is not available in Grafana Cloud and is experimental in Grafana OSS and Grafana Enterprise.\n- If you want to manage existing resources with Git Sync, you need to save them as JSON files and commit them to the synced repository. Use `grafanactl` or open a PR to import, copy, move, or save a dashboard. Refer to [Export non-provisioned resources from Grafana](https://grafana.com/docs/grafana/latest/as-code/observability-as-code/git-sync/export-resources) for more details.\n- Restoring resources from the UI is currently not possible. As an alternative, you can restore dashboards directly in your GitHub repository by raising a PR, and they will be updated in Grafana.\n- You cannot modify the permissions of a provisioned folder after you've synced it."
+    },
+    {
+      "type": "markdown",
+      "content": "For detailed information about usage limits and quotas, refer to the [Git Sync usage limitations](https://grafana.com/docs/grafana/latest/as-code/observability-as-code/git-sync/usage-limits) documentation."
+    },
+    {
+      "type": "markdown",
+      "content": "In the next milestone, you'll navigate to the Git Sync interface in Grafana Cloud."
+    },
+    {
+      "type": "markdown",
+      "content": "---\n\n### More to explore (optional)\n\nAt this point in your journey, you can explore the following paths:\n\n- [Git Sync usage limitations](https://grafana.com/docs/grafana-cloud/account-management/billing-and-usage/git-sync-usage/)"
+    }
+  ]
+}

--- a/git-sync-use-lj/known-limitations/manifest.json
+++ b/git-sync-use-lj/known-limitations/manifest.json
@@ -1,0 +1,20 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "git-sync-use-known-limitations",
+  "type": "guide",
+  "description": "Understand the current limitations and constraints of Git Sync.",
+  "category": "take-action",
+  "author": {
+    "team": "Grafana Documentation"
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": [
+    "git-sync-use-prerequisites"
+  ],
+  "recommends": [
+    "git-sync-use-navigate-to-git-sync"
+  ],
+  "suggests": []
+}

--- a/git-sync-use-lj/known-limitations/website.yaml
+++ b/git-sync-use-lj/known-limitations/website.yaml
@@ -1,0 +1,18 @@
+menuTitle: Known limitations
+title: Known limitations
+description: Understand the current limitations and constraints of Git Sync.
+weight: 400
+step: 5
+layout: single-journey
+cta:
+  type: continue
+keywords:
+  - Git Sync
+  - limitations
+  - constraints
+side_journeys:
+  title: More to explore (optional)
+  heading: 'At this point in your journey, you can explore the following paths:'
+  items:
+    - title: Git Sync usage limitations
+      link: /docs/grafana-cloud/account-management/billing-and-usage/git-sync-usage/

--- a/git-sync-use-lj/manage-dashboard-sync/content.json
+++ b/git-sync-use-lj/manage-dashboard-sync/content.json
@@ -1,0 +1,66 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "git-sync-use-manage-dashboard-sync",
+  "title": "Manage dashboard sync",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "Managing dashboard synchronization involves handling different sync states and resolving conflicts between Grafana and Git versions. Git Sync provides actions to push local changes to Git, pull remote changes to Grafana, or resolve conflicts when both locations have modifications."
+    },
+    {
+      "type": "markdown",
+      "content": "Select a dashboard with a sync state that needs attention, such as **Modified** or **Out of sync**, then review the available actions based on that sync state. For modified dashboards, you can push changes to Git. For out-of-sync dashboards, you can pull changes from Git. For conflicts, you must resolve differences before syncing."
+    },
+    {
+      "type": "markdown",
+      "content": "Choose the appropriate sync action for the dashboard's current state and confirm it when prompted. For example, click **Push to Git** to commit local changes to your repository, or click **Pull from Git** to update the Grafana dashboard with repository changes. Git Sync performs the synchronization and updates the dashboard's sync state."
+    },
+    {
+      "type": "markdown",
+      "content": "To manage dashboard synchronization, complete the following steps:"
+    },
+    {
+      "type": "section",
+      "autoCollapse": false,
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "a[data-testid='data-testid Tab Resources']",
+          "content": "On the repository page, open the **Resources** tab and find a dashboard with a sync state that needs attention, such as **Modified** or **Out of sync**.",
+          "tooltip": "Each row shows a resource's title, type, current sync status, and commit hash.",
+          "requirements": ["exists-reftarget"]
+        },
+        {
+          "type": "interactive",
+          "action": "button",
+          "reftarget": "Pull",
+          "content": "Click **Pull** to synchronize from the remote repository and bring out-of-sync dashboards up to date in Grafana.",
+          "tooltip": "Use this to sync immediately instead of waiting for the next scheduled run.",
+          "requirements": ["exists-reftarget"]
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "div[data-testid='data-testid Card heading']:contains('Pull status')",
+          "content": "Check the **Pull status** card to confirm the sync succeeded and review the most recent commit reference.",
+          "tooltip": "This card reports the result of the last sync and when it completed.",
+          "requirements": ["exists-reftarget"],
+          "doIt": false
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "The dashboard sync state updates to show successful synchronization. The dashboard now matches the version in Git, and the sync state indicator shows **Synced**."
+    },
+    {
+      "type": "markdown",
+      "content": "Changes flow in the other direction too. When you save a dashboard that lives in a provisioned folder, Git Sync commits the change to your repository, so a **Modified** dashboard becomes **Synced** once the commit is pushed."
+    },
+    {
+      "type": "markdown",
+      "content": "In the next milestone, you'll complete this learning path."
+    }
+  ]
+}

--- a/git-sync-use-lj/manage-dashboard-sync/manifest.json
+++ b/git-sync-use-lj/manage-dashboard-sync/manifest.json
@@ -1,0 +1,21 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "git-sync-use-manage-dashboard-sync",
+  "type": "guide",
+  "description": "Handle different sync states and synchronize dashboards between Grafana and Git.",
+  "category": "take-action",
+  "author": {
+    "team": "Grafana Documentation"
+  },
+  "startingLocation": "/admin/provisioning",
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": [
+    "git-sync-use-view-synced-dashboards"
+  ],
+  "recommends": [
+    "git-sync-use-end-journey"
+  ],
+  "suggests": []
+}

--- a/git-sync-use-lj/manage-dashboard-sync/website.yaml
+++ b/git-sync-use-lj/manage-dashboard-sync/website.yaml
@@ -1,0 +1,12 @@
+menuTitle: Manage dashboard sync
+title: Manage dashboard sync
+description: Handle different sync states and synchronize dashboards between Grafana and Git.
+weight: 700
+step: 8
+layout: single-journey
+cta:
+  type: continue
+keywords:
+  - Git Sync
+  - synchronization
+  - manage dashboards

--- a/git-sync-use-lj/manifest.json
+++ b/git-sync-use-lj/manifest.json
@@ -1,0 +1,57 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "git-sync-use-lj",
+  "type": "path",
+  "description": "Use Git Sync to manage Grafana resources with version control, from sync states to synchronizing dashboards.",
+  "category": "take-action",
+  "author": {
+    "team": "Grafana Documentation"
+  },
+  "startingLocation": "/admin/provisioning",
+  "targeting": {
+    "match": {
+      "or": [
+        {
+          "and": [
+            {
+              "urlPrefix": "/admin/provisioning"
+            },
+            {
+              "targetPlatform": "cloud"
+            }
+          ]
+        },
+        {
+          "and": [
+            {
+              "urlPrefix": "/dashboards"
+            },
+            {
+              "targetPlatform": "cloud"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "milestones": [
+    "git-sync-use-how-git-sync-works",
+    "git-sync-use-prerequisites",
+    "git-sync-use-known-limitations",
+    "git-sync-use-navigate-to-git-sync",
+    "git-sync-use-view-synced-dashboards",
+    "git-sync-use-manage-dashboard-sync",
+    "git-sync-use-end-journey"
+  ],
+  "depends": [],
+  "recommends": [
+    "git-sync-setup"
+  ],
+  "suggests": [
+    "git-sync-dashboards-lj",
+    "git-sync-guide"
+  ]
+}

--- a/git-sync-use-lj/navigate-to-git-sync/content.json
+++ b/git-sync-use-lj/navigate-to-git-sync/content.json
@@ -1,0 +1,50 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "git-sync-use-navigate-to-git-sync",
+  "title": "Navigate to Git Sync",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "The Git Sync interface in Grafana Cloud provides a centralized location to view and manage your synced repositories and dashboards. This interface displays the sync status for all connected repositories and allows you to perform synchronization actions."
+    },
+    {
+      "type": "markdown",
+      "content": "Before you start, log in to Grafana with an account that has the Grafana Admin flag set. Provisioning settings are only available to administrators."
+    },
+    {
+      "type": "markdown",
+      "content": "To navigate to Git Sync, complete the following steps:"
+    },
+    {
+      "type": "section",
+      "autoCollapse": false,
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "navigate",
+          "reftarget": "/admin/provisioning",
+          "content": "Select **Administration > General > Provisioning** in the left-side menu to open the Git Sync configuration screen.",
+          "tooltip": "Provisioning manages external sources of Grafana resources, such as Git repositories.",
+          "verify": "on-page:/admin/provisioning"
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "a[href^='/admin/provisioning/repository-']",
+          "content": "Review the list of connected repositories. Each entry shows the number of synced dashboards and indicates whether any resources need attention.",
+          "tooltip": "Each connected repository has its own page with sync status, managed resources, and recent jobs.",
+          "requirements": ["on-page:/admin/provisioning", "exists-reftarget"],
+          "doIt": false
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "The Git Sync page displays with a list of connected repositories and their current sync status. Each repository shows the number of synced dashboards and indicates if any dashboards require attention due to modifications or conflicts."
+    },
+    {
+      "type": "markdown",
+      "content": "In the next milestone, you'll learn how to view synced dashboards in a repository."
+    }
+  ]
+}

--- a/git-sync-use-lj/navigate-to-git-sync/manifest.json
+++ b/git-sync-use-lj/navigate-to-git-sync/manifest.json
@@ -1,0 +1,21 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "git-sync-use-navigate-to-git-sync",
+  "type": "guide",
+  "description": "Learn how to access the Git Sync interface in Grafana Cloud.",
+  "category": "take-action",
+  "author": {
+    "team": "Grafana Documentation"
+  },
+  "startingLocation": "/admin/provisioning",
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": [
+    "git-sync-use-known-limitations"
+  ],
+  "recommends": [
+    "git-sync-use-view-synced-dashboards"
+  ],
+  "suggests": []
+}

--- a/git-sync-use-lj/navigate-to-git-sync/website.yaml
+++ b/git-sync-use-lj/navigate-to-git-sync/website.yaml
@@ -1,0 +1,12 @@
+menuTitle: Navigate to Git Sync
+title: Navigate to Git Sync
+description: Learn how to access the Git Sync interface in Grafana Cloud.
+weight: 500
+step: 6
+layout: single-journey
+cta:
+  type: continue
+keywords:
+  - Git Sync
+  - navigation
+  - interface

--- a/git-sync-use-lj/prerequisites/content.json
+++ b/git-sync-use-lj/prerequisites/content.json
@@ -1,0 +1,23 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "git-sync-use-prerequisites",
+  "title": "Before you begin",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "Git Sync requires a specific setup in both Grafana and your Git repository to function correctly."
+    },
+    {
+      "type": "markdown",
+      "content": "Before you use Git Sync to manage your dashboards, ensure you have the necessary access and permissions configured:\n\n- A Grafana account\n- Appropriate permissions to manage dashboards in Grafana\n- A Git repository\n- Appropriate repository permissions to push and pull changes\n- Git Sync configured and connected to your repository\n- Basic familiarity with Git concepts including commits, branches, and pull requests"
+    },
+    {
+      "type": "markdown",
+      "content": "Git Sync works with existing Grafana dashboards. If you don't have dashboards to sync, you can create them in Grafana or import existing dashboard JSON files into your repository."
+    },
+    {
+      "type": "markdown",
+      "content": "In the next milestone, you'll learn about known limitations of Git Sync."
+    }
+  ]
+}

--- a/git-sync-use-lj/prerequisites/manifest.json
+++ b/git-sync-use-lj/prerequisites/manifest.json
@@ -1,0 +1,20 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "git-sync-use-prerequisites",
+  "type": "guide",
+  "description": "Review the prerequisites required to use Git Sync effectively.",
+  "category": "take-action",
+  "author": {
+    "team": "Grafana Documentation"
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": [
+    "git-sync-use-how-git-sync-works"
+  ],
+  "recommends": [
+    "git-sync-use-known-limitations"
+  ],
+  "suggests": []
+}

--- a/git-sync-use-lj/prerequisites/website.yaml
+++ b/git-sync-use-lj/prerequisites/website.yaml
@@ -1,0 +1,12 @@
+menuTitle: Prerequisites
+title: Before you begin
+description: Review the prerequisites required to use Git Sync effectively.
+weight: 300
+step: 4
+layout: single-journey
+cta:
+  type: continue
+keywords:
+  - Git Sync
+  - prerequisites
+  - requirements

--- a/git-sync-use-lj/view-synced-dashboards/content.json
+++ b/git-sync-use-lj/view-synced-dashboards/content.json
@@ -1,0 +1,76 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "git-sync-use-view-synced-dashboards",
+  "title": "View synced dashboards",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "After navigating to Git Sync, you can explore the dashboards synced from your Git repository. The repository page summarizes the connection and lists each synced resource with its current sync state, helping you identify which dashboards are synchronized and which require action."
+    },
+    {
+      "type": "markdown",
+      "content": "To view synced dashboards in a repository, complete the following steps:"
+    },
+    {
+      "type": "section",
+      "autoCollapse": false,
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "a[href^='/admin/provisioning/repository-']",
+          "content": "Click **View** on a repository to open it.",
+          "tooltip": "Opening a repository shows its sync status, managed resources, and recent jobs.",
+          "requirements": ["on-page:/admin/provisioning", "exists-reftarget"]
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "div[data-testid='data-testid Card heading']:contains('Resources')",
+          "content": "Review the **Resources** card. It lists the types and counts of Grafana resources managed by this repository, such as folders and dashboards.",
+          "tooltip": "This summary updates as you add or remove resources from the synced folder.",
+          "requirements": ["exists-reftarget"],
+          "doIt": false
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "div[data-testid='data-testid Card heading']:contains('Health')",
+          "content": "Check the **Health** card. It reports whether Grafana can reach and authenticate with the remote repository.",
+          "tooltip": "A healthy status confirms the Git connection and credentials are working.",
+          "requirements": ["exists-reftarget"],
+          "doIt": false
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "div[data-testid='data-testid Card heading']:contains('Pull status')",
+          "content": "Check the **Pull status** card. It shows the result of the last sync, the most recent commit reference, and when the last successful pull occurred.",
+          "tooltip": "Grafana pulls changes from the repository on a schedule or when a webhook fires.",
+          "requirements": ["exists-reftarget"],
+          "doIt": false
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "a[data-testid='data-testid Tab Resources']",
+          "content": "Switch to the **Resources** tab to see every individual resource managed by this repository. Review the list of synced dashboards and their sync state indicators.",
+          "tooltip": "Each row shows a resource's title, type, current sync status, and commit hash.",
+          "requirements": ["exists-reftarget"]
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "Each dashboard displays a sync state badge showing whether it's synced, modified, out of sync, or in conflict. Click a dashboard name to view its details and sync history. The dashboard details page shows commit information, recent changes, and available sync actions."
+    },
+    {
+      "type": "markdown",
+      "content": "The dashboard list displays with sync state indicators showing which dashboards are synced, modified, or out of sync. You can use these indicators to prioritize which dashboards need synchronization actions."
+    },
+    {
+      "type": "markdown",
+      "content": "In the next milestone, you'll learn how to manage dashboard sync states."
+    }
+  ]
+}

--- a/git-sync-use-lj/view-synced-dashboards/manifest.json
+++ b/git-sync-use-lj/view-synced-dashboards/manifest.json
@@ -1,0 +1,21 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "git-sync-use-view-synced-dashboards",
+  "type": "guide",
+  "description": "Explore the dashboards synced from your Git repository and understand their sync states.",
+  "category": "take-action",
+  "author": {
+    "team": "Grafana Documentation"
+  },
+  "startingLocation": "/admin/provisioning",
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": [
+    "git-sync-use-navigate-to-git-sync"
+  ],
+  "recommends": [
+    "git-sync-use-manage-dashboard-sync"
+  ],
+  "suggests": []
+}

--- a/git-sync-use-lj/view-synced-dashboards/website.yaml
+++ b/git-sync-use-lj/view-synced-dashboards/website.yaml
@@ -1,0 +1,12 @@
+menuTitle: View synced dashboards
+title: View synced dashboards
+description: Explore the dashboards synced from your Git repository and understand their sync states.
+weight: 600
+step: 7
+layout: single-journey
+cta:
+  type: continue
+keywords:
+  - Git Sync
+  - dashboards
+  - sync states

--- a/git-sync-use-lj/website.yaml
+++ b/git-sync-use-lj/website.yaml
@@ -1,0 +1,34 @@
+menuTitle: Use Git Sync to manage resources
+title: Use Git Sync to manage resources
+description: Welcome to the learning path that shows you how to use Git Sync to manage your Grafana resources with version control.
+weight: 850
+journey:
+  group: take-action
+  skill: Beginner
+  source: Docs & blog posts
+  logo:
+    src: /static/img/menu/gitsync.svg
+    background: '#0068FF'
+    width: 46
+    height: 55
+step: 1
+layout: single-journey
+cascade:
+  layout: single-journey
+cta:
+  type: start
+  title: Are you ready?
+  cta_text: Let's go!
+keywords:
+  - Git Sync
+  - version control
+  - dashboards
+  - resources
+  - collaboration
+  - Git
+related_journeys:
+  title: Related paths
+  heading: Consider taking the following journey after you complete this journey.
+  items:
+    - title: Work with dashboards using Git Sync
+      link: /docs/learning-paths/git-sync-dashboards/


### PR DESCRIPTION
Moving as Code LP to this repo.

Twin PR - https://github.com/grafana/website/pull/33184