### PR TITLE
Render learning paths in deploy preview like the website

### DIFF
--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   deploy-pr-preview:
     # Do not pin by SHA the WIF binding for github-docs-deploy-previews matches job_workflow_ref by branch ref. Pinning by SHA breaks getAccessToken.
-    uses: grafana/writers-toolkit/.github/workflows/deploy-preview.yml@jdb/deploy-preview
+    uses: grafana/writers-toolkit/.github/workflows/deploy-preview.yml@main
     if: >-
       !github.event.pull_request.head.repo.fork &&
       (

--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -16,8 +16,11 @@ jobs:
     uses: grafana/writers-toolkit/.github/workflows/deploy-preview.yml@jdb/deploy-preview
     if: >-
       !github.event.pull_request.head.repo.fork &&
-      (contains(github.event.pull_request.labels.*.name, 'deploy-preview') ||
-      github.event.action == 'closed')
+      (
+        github.event.action == 'closed' ||
+        (github.event.action == 'labeled' && github.event.label.name == 'deploy-preview') ||
+        contains(github.event.pull_request.labels.*.name, 'deploy-preview')
+      )
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   deploy-pr-preview:
     # Do not pin by SHA the WIF binding for github-docs-deploy-previews matches job_workflow_ref by branch ref. Pinning by SHA breaks getAccessToken.
-    uses: grafana/writers-toolkit/.github/workflows/deploy-preview.yml@main
+    uses: grafana/writers-toolkit/.github/workflows/deploy-preview.yml@jdb/deploy-preview
     if: >-
       !github.event.pull_request.head.repo.fork &&
       (contains(github.event.pull_request.labels.*.name, 'deploy-preview') ||

--- a/adaptive-metrics-lj/auto-apply/website.yaml
+++ b/adaptive-metrics-lj/auto-apply/website.yaml
@@ -1,0 +1,20 @@
+menuTitle: Auto-apply
+description: Learn how to enable auto-apply so Adaptive Metrics automatically applies
+  new optimization recommendations as they are generated.
+weight: 600
+step: 6
+layout: single-journey
+cta:
+  type: continue
+keywords:
+- adaptive-metrics
+- auto-apply
+- automation
+- recommendations
+- cardinality
+side_journeys:
+  title: More to explore (optional)
+  heading: 'At this point in your journey, you can explore the following paths:'
+  items:
+  - title: Configure auto-apply
+    link: /docs/grafana-cloud/adaptive-telemetry/adaptive-metrics/additional-configuration/auto-apply/

--- a/adaptive-metrics-lj/end-journey/website.yaml
+++ b/adaptive-metrics-lj/end-journey/website.yaml
@@ -1,0 +1,28 @@
+menuTitle: Destination reached
+description: Celebrate completing the Adaptive Metrics journey and discover next steps
+  to extend optimization across telemetry and cost management.
+weight: 800
+step: 8
+layout: single-journey
+cta:
+  type: conclusion
+  image:
+    src: /media/docs/learning-journey/linux-conclusion.svg
+    width: 735
+    height: 175
+keywords:
+- adaptive-metrics
+- optimization
+- cardinality
+- recommendations
+- cost
+side_journeys:
+  title: More to explore (optional)
+  heading: 'At this point in your journey, you can explore the following paths:'
+  items:
+  - title: Adaptive Logs
+    link: /docs/grafana-cloud/adaptive-telemetry/adaptive-logs/
+  - title: Adaptive Traces
+    link: /docs/grafana-cloud/adaptive-telemetry/adaptive-traces/
+  - title: Understand metrics usage and cost
+    link: /docs/grafana-cloud/cost-management-and-billing/understand-usage-cost/metrics/

--- a/adaptive-metrics-lj/how-it-works/website.yaml
+++ b/adaptive-metrics-lj/how-it-works/website.yaml
@@ -1,0 +1,14 @@
+menuTitle: How it works
+description: Learn how Adaptive Metrics analyzes, recommends, reduces, integrates,
+  and adapts to continuously optimize your metric usage.
+weight: 200
+step: 2
+layout: single-journey
+cta:
+  type: continue
+keywords:
+- adaptive-metrics
+- aggregation
+- recommendations
+- cardinality-reduction
+- metrics-optimization

--- a/adaptive-metrics-lj/monitor-validate/website.yaml
+++ b/adaptive-metrics-lj/monitor-validate/website.yaml
@@ -1,0 +1,20 @@
+menuTitle: Validate results
+description: Learn how to monitor dashboards and metrics volume to confirm applied
+  recommendations and customization are delivering expected outcomes.
+weight: 700
+step: 7
+layout: single-journey
+cta:
+  type: continue
+keywords:
+- adaptive-metrics
+- validation
+- monitoring
+- dashboards
+- cardinality
+side_journeys:
+  title: More to explore (optional)
+  heading: 'At this point in your journey, you can explore the following paths:'
+  items:
+  - title: Understand metrics usage and cost
+    link: /docs/grafana-cloud/cost-management-and-billing/understand-usage-cost/metrics/

--- a/adaptive-metrics-lj/review-apply/website.yaml
+++ b/adaptive-metrics-lj/review-apply/website.yaml
@@ -1,0 +1,20 @@
+menuTitle: Review and apply
+description: Learn how to review and apply Adaptive Metrics recommendations to reduce
+  cardinality while keeping dashboards and alerts working.
+weight: 300
+step: 3
+layout: single-journey
+cta:
+  type: continue
+keywords:
+- adaptive-metrics
+- recommendations
+- cardinality
+- metrics
+- observability
+side_journeys:
+  title: More to explore (optional)
+  heading: 'At this point in your journey, you can explore the following paths:'
+  items:
+  - title: Understand recommended rules
+    link: /docs/grafana-cloud/adaptive-telemetry/adaptive-metrics/manage-recommendations/understand-recommended-rules/

--- a/adaptive-metrics-lj/rules-exemptions/website.yaml
+++ b/adaptive-metrics-lj/rules-exemptions/website.yaml
@@ -1,0 +1,20 @@
+menuTitle: Rules and exemptions
+description: Learn how to create aggregation rules and exemptions to control which
+  metrics are aggregated and which are preserved.
+weight: 400
+step: 4
+layout: single-journey
+cta:
+  type: continue
+keywords:
+- adaptive-metrics
+- rules
+- exemptions
+- aggregation
+- cardinality
+side_journeys:
+  title: More to explore (optional)
+  heading: 'At this point in your journey, you can explore the following paths:'
+  items:
+  - title: Adaptive Metrics
+    link: /docs/grafana-cloud/adaptive-telemetry/adaptive-metrics/

--- a/adaptive-metrics-lj/segmentation/website.yaml
+++ b/adaptive-metrics-lj/segmentation/website.yaml
@@ -1,0 +1,20 @@
+menuTitle: Segmentation
+description: Learn how to create segments so each team can view and manage recommendations
+  and rules for only their own metrics.
+weight: 500
+step: 5
+layout: single-journey
+cta:
+  type: continue
+keywords:
+- adaptive-metrics
+- segmentation
+- teams
+- services
+- cardinality
+side_journeys:
+  title: More to explore (optional)
+  heading: 'At this point in your journey, you can explore the following paths:'
+  items:
+  - title: Configure segmentation
+    link: /docs/grafana-cloud/adaptive-telemetry/adaptive-metrics/additional-configuration/adaptive-metrics-rule-segmentation/

--- a/adaptive-metrics-lj/value-adaptive-metrics/website.yaml
+++ b/adaptive-metrics-lj/value-adaptive-metrics/website.yaml
@@ -1,0 +1,20 @@
+menuTitle: Value of Adaptive Metrics
+description: Understand how Adaptive Metrics helps you control costs, improve performance,
+  and maintain observability quality as your environment grows.
+weight: 100
+step: 1
+layout: single-journey
+cta:
+  type: continue
+keywords:
+- adaptive-metrics
+- cost-optimization
+- cardinality
+- metrics-management
+- observability
+side_journeys:
+  title: More to explore (optional)
+  heading: 'At this point in your journey, you can explore the following paths:'
+  items:
+  - title: Adaptive Telemetry
+    link: /docs/grafana-cloud/adaptive-telemetry/

--- a/adaptive-metrics-lj/website.yaml
+++ b/adaptive-metrics-lj/website.yaml
@@ -1,0 +1,27 @@
+menuTitle: Optimize Adaptive Metrics
+description: Welcome to the Grafana learning path that shows you how to use Adaptive
+  Metrics to automatically analyze and reduce unused or high-cardinality metrics.
+weight: 725
+journey:
+  group: data-availability
+  skill: Beginner
+  source: Docs & blog posts
+  logo:
+    src: /static/img/menu/grafana2.svg
+    background: '#FFFFFF'
+    width: 46
+    height: 55
+step: 1
+layout: single-journey
+cascade:
+  layout: single-journey
+cta:
+  type: start
+  title: Are you ready?
+  cta_text: Let's go!
+keywords:
+- adaptive-metrics
+- cardinality
+- cost-optimization
+- observability
+- grafana-cloud

--- a/fleet-mgt-monitor-health-lj/business-value-fleet-mgt/website.yaml
+++ b/fleet-mgt-monitor-health-lj/business-value-fleet-mgt/website.yaml
@@ -1,0 +1,8 @@
+menuTitle: Value of Fleet Management
+description: Learn how Grafana Fleet Management can make managing multiple collectors
+  easier
+weight: 100
+step: 2
+layout: single-journey
+cta:
+  type: continue

--- a/fleet-mgt-monitor-health-lj/check-health-status/website.yaml
+++ b/fleet-mgt-monitor-health-lj/check-health-status/website.yaml
@@ -1,0 +1,8 @@
+menuTitle: Check health status
+description: Learn how to determine which of your collectors are unhealthy and need
+  attention
+weight: 500
+step: 6
+layout: single-journey
+cta:
+  type: continue

--- a/fleet-mgt-monitor-health-lj/create-token/website.yaml
+++ b/fleet-mgt-monitor-health-lj/create-token/website.yaml
@@ -1,0 +1,18 @@
+menuTitle: Create access token
+description: Learn how to create an access policy token that you use to register a
+  collector to Fleet Management
+weight: 300
+step: 4
+layout: single-journey
+cta:
+  type: continue
+side_journeys:
+  title: More to explore (optional)
+  heading: 'At this point in your journey, you can explore the following paths:'
+  items:
+  - title: Onboard collectors deployed in Kubernetes to Fleet Management
+    link: /docs/grafana-cloud/send-data/fleet-management/set-up/onboard-collectors/kubernetes/
+  - title: Grafana Cloud Access Policies
+    link: /docs/grafana-cloud/security-and-account-management/authentication-and-permissions/access-policies/
+  - title: Create tokens for an access policy
+    link: /docs/grafana-cloud/security-and-account-management/authentication-and-permissions/access-policies/create-access-policies/#create-tokens-for-an-access-policy

--- a/fleet-mgt-monitor-health-lj/determine-config/website.yaml
+++ b/fleet-mgt-monitor-health-lj/determine-config/website.yaml
@@ -1,0 +1,20 @@
+menuTitle: Determine if collector configured
+description: Learn how to know if your collector has already been registered with
+  Fleet Management
+weight: 200
+step: 3
+layout: single-journey
+cta:
+  type: continue
+side_journeys:
+  title: More to explore (optional)
+  heading: 'At this point in your journey, you can explore the following paths:'
+  items:
+  - title: What is Grafana Alloy?
+    link: /oss/alloy-opentelemetry-collector
+  - title: Monitor multiple Linux hosts with the grafana_agent role
+    link: /docs/grafana-cloud/developer-resources/infrastructure-as-code/ansible/ansible-multiple-agents
+  - title: 'How Grafana Alloy Works: Demo (Video)'
+    link: https://www.youtube.com/watch?v=NrnLyDXpfq0
+  - title: Grafana Alloy on GitHub
+    link: https://github.com/grafana/alloy

--- a/fleet-mgt-monitor-health-lj/end-journey/website.yaml
+++ b/fleet-mgt-monitor-health-lj/end-journey/website.yaml
@@ -1,0 +1,12 @@
+menuTitle: Destination reached!
+description: Your journey concludes and it's time to learn about related paths you
+  can take
+weight: 800
+step: 9
+layout: single-journey
+cta:
+  type: conclusion
+  image:
+    src: /media/docs/learning-journey/journey-conclusion-header-1.svg
+    width: 735
+    height: 175

--- a/fleet-mgt-monitor-health-lj/register-collector/website.yaml
+++ b/fleet-mgt-monitor-health-lj/register-collector/website.yaml
@@ -1,0 +1,22 @@
+menuTitle: Register a collector
+description: Learn how to add a Grafana Alloy collector to Fleet Management
+weight: 400
+step: 5
+layout: single-journey
+cta:
+  type: success
+  troubleshooting:
+    title: 'Explore the following troubleshooting topics if you need help:'
+    items:
+    - title: Collector isn’t in Inventory
+      link: /docs/grafana-cloud/send-data/fleet-management/set-up/onboard-collectors/onboard-troubleshooting/#collector-isnt-in-inventory
+    - title: Collector was deleted from Inventory
+      link: /docs/grafana-cloud/send-data/fleet-management/set-up/onboard-collectors/onboard-troubleshooting/#collector-was-deleted-from-inventory
+side_journeys:
+  title: More to explore (optional)
+  heading: 'At this point in your journey, you can explore the following paths:'
+  items:
+  - title: Add remote attributes
+    link: /docs/grafana-cloud/send-data/fleet-management/set-up/onboard-collectors/standalone-installations/#add-remote-attributes
+  - title: Onboard collectors deployed in Kubernetes to Fleet Management
+    link: /docs/grafana-cloud/send-data/fleet-management/set-up/onboard-collectors/kubernetes/

--- a/fleet-mgt-monitor-health-lj/view-collector-logs/website.yaml
+++ b/fleet-mgt-monitor-health-lj/view-collector-logs/website.yaml
@@ -1,0 +1,12 @@
+menuTitle: View logs
+description: Learn how to view logs associated with a registered collector
+weight: 700
+step: 8
+layout: single-journey
+cta:
+  type: success
+  troubleshooting:
+    title: 'Explore the following troubleshooting topics if you need help:'
+    items:
+    - title: Logs don’t appear in app
+      link: /docs/grafana-cloud/send-data/fleet-management/set-up/onboard-collectors/onboard-troubleshooting/#logs-dont-appear-in-app

--- a/fleet-mgt-monitor-health-lj/view-health-dashboards/website.yaml
+++ b/fleet-mgt-monitor-health-lj/view-health-dashboards/website.yaml
@@ -1,0 +1,13 @@
+menuTitle: View health dashboards
+description: Learn how to identify issues and make decisions about scaling based on
+  collector resource usage
+weight: 600
+step: 7
+layout: single-journey
+cta:
+  type: success
+  troubleshooting:
+    title: 'Explore the following troubleshooting topics if you need help:'
+    items:
+    - title: Health dashboards have no data
+      link: /docs/grafana-cloud/send-data/fleet-management/set-up/onboard-collectors/onboard-troubleshooting/#health-dashboards-have-no-data

--- a/fleet-mgt-monitor-health-lj/website.yaml
+++ b/fleet-mgt-monitor-health-lj/website.yaml
@@ -1,0 +1,45 @@
+menuTitle: Monitor collector health
+description: Welcome to the Grafana learning path that teaches you how to use Grafana
+  Fleet Management to monitor and troubleshoot issues with your collectors.
+weight: 1600
+journey:
+  group: query-and-visualize
+  skill: Beginner
+  source: Docs & blog posts
+  logo:
+    src: /static/img/menu/icon_fleet.svg
+    background: '#FFFFFF'
+    width: 46
+    height: 55
+step: 1
+layout: single-journey
+show_play: false
+cascade:
+  layout: single-journey
+cta:
+  type: start
+  title: Are you ready?
+  cta_text: Let's go!
+related_journeys:
+  title: Related paths
+  heading: This journey expects Grafana Alloy to be installed. If you don't yet have
+    Grafana Alloy installed, any of these related paths will help you.
+  items:
+  - title: Monitor a Linux server in Grafana Cloud
+    link: /docs/learning-paths/linux-server-integration/
+  - title: Monitor Kubernetes cluster infrastructure in Grafana Cloud
+    link: /docs/learning-paths/kubernetes/
+  - title: Send logs to Grafana Cloud using Alloy
+    link: /docs/learning-paths/send-logs-alloy-loki/
+  - title: Monitor a macOS system in Grafana Cloud
+    link: /docs/learning-paths/macos-integration/
+source_docs:
+- /docs/grafana-cloud/send-data/fleet-management/
+- /docs/grafana-cloud/send-data/fleet-management/introduction/
+- /docs/grafana-cloud/send-data/fleet-management/set-up/onboard-collectors/standalone-installations/
+- /docs/grafana-cloud/send-data/fleet-management/manage-fleet/collectors/collector-status/
+- /docs/grafana-cloud/send-data/fleet-management/manage-fleet/collectors/troubleshoot-unhealthy-collector/
+- /docs/grafana-cloud/send-data/fleet-management/manage-fleet/collectors/troubleshoot-unhealthy-collector/internal-metrics/
+- /docs/grafana-cloud/send-data/fleet-management/manage-fleet/collectors/troubleshoot-unhealthy-collector/internal-logs/
+- /docs/grafana-cloud/send-data/fleet-management/set-up/onboard-collectors/onboard-troubleshooting/
+- /docs/grafana-cloud/security-and-account-management/authentication-and-permissions/access-policies/

--- a/grafana-irm-configuration-lj/build-mental-model/website.yaml
+++ b/grafana-irm-configuration-lj/build-mental-model/website.yaml
@@ -1,0 +1,14 @@
+menuTitle: Build mental model
+description: Review the core components that need to be configured and understand
+  how alerts move through IRM workflows.
+weight: 200
+step: 3
+layout: single-journey
+cta:
+  type: continue
+keywords:
+- Grafana IRM
+- integrations
+- escalation chains
+- schedules
+- notification rules

--- a/grafana-irm-configuration-lj/connect-alert-rule/website.yaml
+++ b/grafana-irm-configuration-lj/connect-alert-rule/website.yaml
@@ -1,0 +1,21 @@
+menuTitle: Connect alert rule
+description: Add the IRM contact point to a Grafana alert rule so alerts generate
+  IRM Alert Groups.
+weight: 600
+step: 7
+layout: single-journey
+cta:
+  type: continue
+keywords:
+- alert rules
+- contact point
+- IRM integration
+- alert delivery
+side_journeys:
+  title: More to explore (optional)
+  heading: 'At this point in your path, you can explore the following topics:'
+  items:
+  - title: Configure Grafana IRM for Alerting
+    link: /docs/grafana-cloud/alerting-and-irm/alerting/configure-notifications/manage-contact-points/integrations/configure-irm/
+  - title: Configure alert rules
+    link: /docs/grafana-cloud/alerting-and-irm/alerting/alerting-rules/

--- a/grafana-irm-configuration-lj/connect-grafana-alerting/website.yaml
+++ b/grafana-irm-configuration-lj/connect-grafana-alerting/website.yaml
@@ -1,0 +1,23 @@
+menuTitle: Connect Grafana Alerting
+description: Add Grafana Alerting as your first integration and route alerts to your
+  escalation chain.
+weight: 500
+step: 6
+layout: single-journey
+cta:
+  type: continue
+keywords:
+- Grafana Alerting
+- integration
+- Alert Groups
+- test alerts
+side_journeys:
+  title: More to explore (optional)
+  heading: 'At this point in your path, you can explore the following topics:'
+  items:
+  - title: Configure Grafana IRM for Alerting
+    link: /docs/grafana-cloud/alerting-and-irm/alerting/configure-notifications/manage-contact-points/integrations/configure-irm/
+  - title: Configure alert rules
+    link: /docs/grafana-cloud/alerting-and-irm/alerting/alerting-rules/
+  - title: Integrations in Grafana IRM
+    link: /docs/grafana-cloud/alerting-and-irm/irm/integrations/

--- a/grafana-irm-configuration-lj/create-escalation-chain/website.yaml
+++ b/grafana-irm-configuration-lj/create-escalation-chain/website.yaml
@@ -1,0 +1,23 @@
+menuTitle: Create an escalation chain
+description: Build a simple escalation chain that notifies a team and escalates if
+  unacknowledged, then test it using direct paging.
+weight: 400
+step: 5
+layout: single-journey
+cta:
+  type: continue
+keywords:
+- escalation chains
+- notification
+- direct paging
+- team alerts
+side_journeys:
+  title: More to explore (optional)
+  heading: 'At this point in your path, you can explore the following topics:'
+  items:
+  - title: Escalation and routing overview
+    link: /docs/grafana-cloud/alerting-and-irm/irm/escalation-and-routing/
+  - title: Types of escalation steps
+    link: /docs/grafana-cloud/alerting-and-irm/irm/escalation-and-routing/escalation-chains/#types-of-escalation-steps
+  - title: Default vs. Important notifications
+    link: /docs/grafana-cloud/alerting-and-irm/irm/escalation-and-routing/escalation-chains/#notification-types

--- a/grafana-irm-configuration-lj/create-on-call-schedule/website.yaml
+++ b/grafana-irm-configuration-lj/create-on-call-schedule/website.yaml
@@ -1,0 +1,23 @@
+menuTitle: Create an on-call schedule
+description: Define a single rotation layer for one team with at least one responder
+  to ensure coverage.
+weight: 300
+step: 4
+layout: single-journey
+cta:
+  type: continue
+keywords:
+- on-call schedule
+- rotation layers
+- coverage
+- team members
+side_journeys:
+  title: More to explore (optional)
+  heading: 'At this point in your path, you can explore the following topics:'
+  items:
+  - title: Overview of on-call schedules
+    link: /docs/grafana-cloud/alerting-and-irm/irm/on-call-schedules/
+  - title: On-call schedule examples
+    link: /docs/grafana-cloud/alerting-and-irm/irm/on-call-schedules/schedule-examples/
+  - title: Manage schedules as code
+    link: /docs/grafana-cloud/alerting-and-irm/irm/on-call-schedules/schedules-as-code/

--- a/grafana-irm-configuration-lj/end-journey/website.yaml
+++ b/grafana-irm-configuration-lj/end-journey/website.yaml
@@ -1,0 +1,18 @@
+menuTitle: Destination reached!
+description: Congratulations on completing the Grafana IRM configuration learning
+  path.
+weight: 800
+step: 9
+layout: single-journey
+cta:
+  type: conclusion
+  image:
+    src: /media/docs/learning-journey/journey-conclusion-header-1.svg
+    width: 735
+    height: 175
+related_journeys:
+  title: Related paths
+  heading: Consider taking the following paths after you complete this path.
+  items:
+  - title: Create infrastructure alerts in Grafana Cloud
+    link: /docs/learning-paths/infrastructure-alerting/

--- a/grafana-irm-configuration-lj/run-end-to-end-test/website.yaml
+++ b/grafana-irm-configuration-lj/run-end-to-end-test/website.yaml
@@ -1,0 +1,32 @@
+menuTitle: Test your configuration
+description: Trigger an alert to verify IRM creates an Alert Group and executes escalation
+  and notifications.
+weight: 700
+step: 8
+layout: single-journey
+cta:
+  type: success
+  troubleshooting:
+    title: 'Explore the following troubleshooting topics if you need help:'
+    items:
+    - title: No Alert group is created after the rule fires
+      link: /docs/grafana-cloud/alerting-and-irm/irm/escalation-and-routing/alert-grouping/
+    - title: You don't receive notifications from a created Alert group
+      link: /docs/grafana-cloud/alerting-and-irm/irm/notify-responders/personal-notification-rules/
+    - title: Escalation steps don't fire as configured
+      link: /docs/grafana-cloud/alerting-and-irm/irm/escalation-and-routing/escalation-chains/
+keywords:
+- end-to-end test
+- alert group
+- escalation
+- notification delivery
+side_journeys:
+  title: More to explore (optional)
+  heading: 'At this point in your path, you can explore the following topics:'
+  items:
+  - title: Respond to alerts in Grafana IRM
+    link: /docs/grafana-cloud/alerting-and-irm/irm/respond-to-alerts/
+  - title: Configure Grafana IRM for Alerting
+    link: /docs/grafana-cloud/alerting-and-irm/alerting/configure-notifications/manage-contact-points/integrations/configure-irm/
+  - title: Phone and SMS notifications
+    link: /docs/grafana-cloud/alerting-and-irm/irm/notify-responders/phone-and-sms/

--- a/grafana-irm-configuration-lj/understand-value/website.yaml
+++ b/grafana-irm-configuration-lj/understand-value/website.yaml
@@ -1,0 +1,20 @@
+menuTitle: Value of IRM
+description: Learn what incident response and management means in Grafana Cloud and
+  how IRM fits into observability workflows.
+weight: 100
+step: 2
+layout: single-journey
+cta:
+  type: continue
+keywords:
+- Grafana IRM
+- incident response
+- observability
+- monitoring
+- alerting
+side_journeys:
+  title: More to explore (optional)
+  heading: 'At this point in your path, you can explore the following topics:'
+  items:
+  - title: Introduction to Grafana IRM
+    link: /docs/grafana-cloud/alerting-and-irm/irm/introduction/

--- a/grafana-irm-configuration-lj/website.yaml
+++ b/grafana-irm-configuration-lj/website.yaml
@@ -1,0 +1,42 @@
+menuTitle: Configure Grafana IRM
+description: Welcome to the Grafana learning path that shows you how to configure
+  Grafana IRM to manage incidents and organize on-call response.
+weight: 1100
+journey:
+  group: take-action
+  skill: Beginner
+  source: Docs & blog posts
+  logo:
+    src: /static/img/menu/grafana2.svg
+    background: '#0068FF'
+    width: 46
+    height: 55
+step: 1
+layout: single-journey
+cascade:
+  layout: single-journey
+cta:
+  type: start
+  title: Are you ready?
+  cta_text: Let's go!
+keywords:
+- Grafana IRM
+- incident response
+- on-call management
+- escalation chains
+- alerting
+related_journeys:
+  title: Related paths
+  heading: Consider taking the following paths before you start this path.
+  items:
+  - title: Create infrastructure alerts in Grafana Cloud
+    link: /docs/learning-paths/infrastructure-alerting/
+source_docs:
+- /docs/grafana-cloud/alerting-and-irm/irm/introduction/
+- /docs/grafana-cloud/alerting-and-irm/irm/on-call-schedules/
+- /docs/grafana-cloud/alerting-and-irm/irm/escalation-and-routing/escalation-chains/
+- /docs/grafana-cloud/alerting-and-irm/alerting/configure-notifications/manage-contact-points/integrations/configure-irm/
+- /docs/grafana-cloud/alerting-and-irm/irm/integrations/
+- /docs/grafana-cloud/alerting-and-irm/irm/notify-responders/personal-notification-rules/
+- /docs/grafana-cloud/alerting-and-irm/irm/respond-to-alerts/
+- /docs/grafana-cloud/alerting-and-irm/irm/set-up/infra-as-code/

--- a/k6-script-authoring-assistant-lj/generate-from-prompt/website.yaml
+++ b/k6-script-authoring-assistant-lj/generate-from-prompt/website.yaml
@@ -1,0 +1,19 @@
+menuTitle: Generate script
+description: Use Script Authoring mode to turn a natural-language test request into
+  a runnable k6 draft in the Cloud script editor, with QuickPizza as the target.
+weight: 200
+step: 3
+layout: single-journey
+cta:
+  type: continue
+side_journeys:
+  title: More to explore (optional)
+  heading: 'At this point in your path, you can explore the following topics:'
+  items:
+  - title: Author and run tests in Grafana Cloud k6
+    link: /docs/grafana-cloud/testing/k6/author-run/
+keywords:
+- k6
+- prompt engineering
+- script generation
+- OpenAPI

--- a/k6-script-authoring-assistant-lj/website.yaml
+++ b/k6-script-authoring-assistant-lj/website.yaml
@@ -1,0 +1,42 @@
+menuTitle: k6 script authoring
+description: Welcome to the Grafana learning path that shows you how to use k6 Script
+  Authoring mode in Grafana Assistant to generate, convert, improve, and validate
+  k6 scripts for CI.
+weight: 2950
+journey:
+  group: take-action
+  skill: Intermediate
+  source: Docs & blog posts
+  logo:
+    src: /media/docs/k6/GrafanaLogo_k6_orange_icon.svg
+    background: '#FFFFFF'
+    width: 46
+    height: 55
+step: 1
+layout: single-journey
+cascade:
+  layout: single-journey
+cta:
+  type: start
+  title: Are you ready?
+  cta_text: Let's go!
+keywords:
+- k6
+- grafana assistant
+- script authoring
+- ai
+- ci
+related_journeys:
+  title: Related paths
+  heading: Consider the following paths if you're new to k6 or want to extend scripts
+    into baselines and Cloud workflows.
+  items:
+  - title: Run your first k6 performance test
+    link: /docs/learning-paths/run-first-k6-test/
+  - title: Establish a performance baseline with k6
+    link: /docs/learning-paths/establish-k6-baseline/
+source_docs:
+- /docs/grafana-cloud/testing/k6/author-run/k6-script-authoring-mode/
+- /docs/grafana-cloud/testing/k6/author-run/manage-secrets/
+- /docs/grafana-cloud/testing/k6/author-run/script-editor/
+- /docs/grafana-cloud/testing/k6/author-run/


### PR DESCRIPTION
Add missing metadata that was causing some pages to render as docs instead of paths.