### PR TITLE
Add leslie-heinzen as owner for package content files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,12 +14,12 @@
 /shared/ @Jayclifford345 @tomglenn
 
 # Docs can approve content PRs
-**/content.json      @chri2547 @tacole02 @moxious @Jayclifford345 @tomglenn
-**/manifest.json     @chri2547 @tacole02 @moxious @Jayclifford345 @tomglenn
-**/website.yaml      @chri2547 @tacole02 @moxious @Jayclifford345 @tomglenn
-**/assets/*          @chri2547 @tacole02 @moxious @Jayclifford345 @tomglenn
-/.github/CODEOWNERS  @chri2547 @tacole02 @moxious @Jayclifford345 @tomglenn
-/index.json          @chri2547 @tacole02 @moxious @Jayclifford345 @tomglenn
+**/content.json      @chri2547 @tacole02 @moxious @Jayclifford345 @tomglenn @leslie-heinzen
+**/manifest.json     @chri2547 @tacole02 @moxious @Jayclifford345 @tomglenn @leslie-heinzen
+**/website.yaml      @chri2547 @tacole02 @moxious @Jayclifford345 @tomglenn @leslie-heinzen
+**/assets/*          @chri2547 @tacole02 @moxious @Jayclifford345 @tomglenn @leslie-heinzen
+/.github/CODEOWNERS  @chri2547 @tacole02 @moxious @Jayclifford345 @tomglenn @leslie-heinzen
+/index.json          @chri2547 @tacole02 @moxious @Jayclifford345 @tomglenn @leslie-heinzen
 
 /.cursor/commands/build-interactive-lj/ @chri2547
 


### PR DESCRIPTION
This lets leslie-heinzen approve PRs that add or change content.json,
manifest.json, website.yaml, assets, CODEOWNERS, and index.json.