### PR TITLE
Fix duplicate Install QuickPizza step on alerting paths

### DIFF
--- a/alerting-first-rule-lj/install-datasources/content.json
+++ b/alerting-first-rule-lj/install-datasources/content.json
@@ -40,8 +40,7 @@
             {
               "action": "highlight",
               "reftarget": "button[data-testid='install-quickpizza']",
-              "lazyRender": true,
-              "description": "Click **Install the Quick Pizza SRE demo**."
+              "lazyRender": true
             }
           ]
         }

--- a/alerting-query-language-lj/install-datasources/content.json
+++ b/alerting-query-language-lj/install-datasources/content.json
@@ -40,8 +40,7 @@
             {
               "action": "highlight",
               "reftarget": "button[data-testid='install-quickpizza']",
-              "lazyRender": true,
-              "description": "Click **Install the Quick Pizza SRE demo**."
+              "lazyRender": true
             }
           ]
         }


### PR DESCRIPTION
## Summary
- Removes the redundant guided-step `description` from both alerting install-datasources milestones so docs no longer nest a second identical “Click Install the Quick Pizza SRE demo” under step 2.
- Affects `alerting-first-rule-lj` and `alerting-query-language-lj`; the guided block `content` still carries the full install instruction.

## Test plan
- [ ] After sync, confirm https://grafana.com/docs/learning-paths/alerting-query-language/install-datasources/ shows only two top-level steps with no nested duplicate.
- [ ] Same check for https://grafana.com/docs/learning-paths/alerting-first-rule/install-datasources/
- [ ] In Pathfinder, confirm the install highlight still targets `button[data-testid='install-quickpizza']` with `lazyRender`.

Made with [Cursor](https://cursor.com)