### PR TITLE
Fixed selector bugs and tidied up Carbon Intensity Play dashboard tour.

### DIFF
--- a/play-carbon-intensity/content.json
+++ b/play-carbon-intensity/content.json
@@ -94,22 +94,25 @@
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "div[data-testid=\"query-editor-row\"] > :first-child",
+          "reftarget": "button[data-testid='data-testid Tab Queries']",
+          "content": "Click the Queries tab.",
+          "doIt": true,
+          "lazyRender": true
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "div[data-testid='infinity-query-row-wrapper-query-options']",
           "content": "Here's the Infinity query. It's configured to make a simple HTTP GET call to the API. The parser is set to **jq-backend**, which means the raw JSON response is handed straight to a JQ expression before any data reaches Grafana.",
           "doIt": false,
           "lazyRender": true
         },
         {
-          "type": "guided",
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "button[data-testid='infinity-query-row-collapse-show-parsing-options-&-result-fields']",
           "content": "Let's open up the parsing options section so that we can see the JQ expression.",
-          "steps": [
-            {
-              "action": "highlight",
-              "reftarget": "button[data-testid='infinity-query-row-collapse-show-parsing-options-&-result-fields'] svg",
-              "description": "Click here to open the parsing options section.",
-              "lazyRender": true
-            }
-          ]
+          "lazyRender": true
         },
         {
           "type": "interactive",
@@ -120,17 +123,11 @@
           "lazyRender": true
         },
         {
-          "type": "guided",
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "button[data-testid='data-testid Back to dashboard button']",
           "content": "Head back to the dashboard to continue the tour.",
-          "steps": [
-            {
-              "action": "highlight",
-              "reftarget": "button[data-testid='data-testid Back to dashboard button']",
-              "description": "Click here to return to the dashboard.",
-              "lazyRender": true
-            }
-          ],
-          "completeEarly": true
+          "lazyRender": true
         }
       ]
     },
@@ -152,16 +149,11 @@
           "lazyRender": true
         },
         {
-          "type": "guided",
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "button[data-testid='data-testid Edit dashboard button']",
           "content": "Let's conclude our tour by exiting edit mode.",
-          "steps": [
-            {
-              "action": "highlight",
-              "reftarget": "button[data-testid='data-testid Edit dashboard button']",
-              "description": "Click the Exit edit button."
-            }
-          ],
-          "completeEarly": true
+          "lazyRender": true
         }
       ]
     },


### PR DESCRIPTION
The [Carbon Intensity dashboard](https://play.grafana.org/d/siw7lpj/uk-carbon-intensity?from=now-6h&to=now&timezone=utc&var-region=$__all) on Play's interactive guide stopped working with one selector issue.  This PR fixes it and also tidies up a couple of guided sections into simple show me / do it as the guided sections only had one interaction.