### PR TITLE
Fixes selector bugs that had crept into The Traitors dashboard guide for Play, adds video resource link.

### DIFF
--- a/play-traitors-uk-tour/content.json
+++ b/play-traitors-uk-tour/content.json
@@ -18,7 +18,7 @@
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "section[data-testid='data-testid Panel header '] div:nth-match(29)",
+          "reftarget": "section[data-testid='data-testid Panel header ']:nth-match(4)",
           "content": "We'll begin our tour with the Main Game section of the dashboard.",
           "requirements": [
             "exists-reftarget"
@@ -84,7 +84,7 @@
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "section[data-testid='data-testid Panel header '] div:nth-match(19)",
+          "reftarget": "section[data-testid='data-testid Panel header ']:nth-match(3)",
           "content": "Let's take a look at the End Game section of the dashboard.",
           "requirements": [
             "exists-reftarget"

--- a/play-traitors-uk-tour/content.json
+++ b/play-traitors-uk-tour/content.json
@@ -169,7 +169,7 @@
           "steps": [
             {
               "action": "highlight",
-              "reftarget": "label[aria-label='Table view']",
+              "reftarget": "div[data-testid='data-testid Switch container']",
               "description": "Click the toggle here.",
               "lazyRender": true
             },
@@ -178,8 +178,7 @@
               "reftarget": "button[data-testid='data-testid Hide response'] svg:nth-match(1)",
               "description": "Click here to show data returned by the query."
             }
-          ],
-          "completeEarly": true
+          ]
         },
         {
           "type": "interactive",
@@ -206,7 +205,7 @@
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "button[data-testid='data-testid Hide response'] svg:nth-match(1)",
+          "reftarget": "button[data-testid='data-testid Hide response']:nth-match(1)",
           "content": "Hide the results of the original Google Sheets query.",
           "lazyRender": true
         },
@@ -349,7 +348,7 @@
     },
     {
       "type": "markdown",
-      "content": "## Next Steps and Additional Resources\n\nWe hope you enjoyed our brief tour of this dashboard and the many SQL expressions that make it work.  Check out these additional resources to learn more about the topics covered in this guide:\n\n- [Read more about how this dashboard was built in our post on the Grafana Unprompted Medium publication.](https://medium.com/grafana-labs/tracking-the-traitors-tv-show-with-sql-expressions-in-grafana-33b8bd6fe84e)\n- [Build your own with our SQL Expressions workshop, suitable for community groups and individuals.](https://github.com/grafana/traitors-sql-expressions-workshop)\n- [The Google Sheet used for the Main Game](https://docs.google.com/spreadsheets/d/1VcaZ4q8ZM2k6O9f6BGMRiWbXYbPQ3gbjLlFuAM4BcJU/view).\n- [The Google Sheet used for the End Game](https://docs.google.com/spreadsheets/d/11FVTJmhYQAWG9BUddAcr2gNsjZVvcFaKN3V2DdK9Cnc/view).\n- [SQL expressions documentation](https://grafana.com/docs/grafana/latest/visualizations/panels-visualizations/query-transform-data/sql-expressions/).\n- [Google Sheets data source documentation](https://grafana.com/grafana/plugins/grafana-googlesheets-datasource/).\n- [Dynamic image panel](https://grafana.com/grafana/plugins/dalvany-image-panel/).\n- [The Traitors USA dashboard](https://play.grafana.org/d/adfhkge/usa-traitors-season-4) (a similar dashboard for the US version of the show).\n\n"
+      "content": "## Next Steps and Additional Resources\n\nWe hope you enjoyed our brief tour of this dashboard and the many SQL expressions that make it work.  Check out these additional resources to learn more about the topics covered in this guide:\n\n- [Read more about how this dashboard was built in our post on the Grafana Unprompted Medium publication](https://medium.com/grafana-labs/tracking-the-traitors-tv-show-with-sql-expressions-in-grafana-33b8bd6fe84e).\n\n- [Watch a video where dashboard creator Simon Prickett walks through the project](https://www.youtube.com/live/tx5fR1URaaY?t=2340s).\n- [Build your own with our SQL Expressions workshop, suitable for community groups and individuals.](https://github.com/grafana/traitors-sql-expressions-workshop)\n- [The Google Sheet used for the Main Game](https://docs.google.com/spreadsheets/d/1VcaZ4q8ZM2k6O9f6BGMRiWbXYbPQ3gbjLlFuAM4BcJU/view).\n- [The Google Sheet used for the End Game](https://docs.google.com/spreadsheets/d/11FVTJmhYQAWG9BUddAcr2gNsjZVvcFaKN3V2DdK9Cnc/view).\n- [SQL expressions documentation](https://grafana.com/docs/grafana/latest/visualizations/panels-visualizations/query-transform-data/sql-expressions/).\n- [Google Sheets data source documentation](https://grafana.com/grafana/plugins/grafana-googlesheets-datasource/).\n- [Dynamic image panel](https://grafana.com/grafana/plugins/dalvany-image-panel/).\n- [The Traitors USA dashboard](https://play.grafana.org/d/adfhkge/usa-traitors-season-4) (a similar dashboard for the US version of the show).\n\n"
     }
   ]
 }


### PR DESCRIPTION
This PR fixes a couple of bugs that had crept into The Traitors dashboard guide on Play, and also adds a link to a new resource which is a video of my talk about the project.

Dashboard can be seen on Play here: https://play.grafana.org/d/siqtdwm/the-traitors-uk-series-4?

I've tested this guide against Play dev here: https://playdev.grafana.net/d/siqtdwm/the-traitors-uk-series-4

Note targets the current query editor experience as that's what unauthenticated users on Play see.