### PR TITLE
Prometheus: Update the add data source guide

### DIFF
--- a/prometheus-lj/add-data-source/content.json
+++ b/prometheus-lj/add-data-source/content.json
@@ -13,7 +13,7 @@
     },
     {
       "type": "markdown",
-      "content": "In this milestone, you add the Prometheus data source and give it a name."
+      "content": "In this milestone, you add the Prometheus data source."
     },
     {
       "type": "markdown",
@@ -29,10 +29,10 @@
       "blocks": [
         {
           "type": "interactive",
-          "action": "highlight",
-          "reftarget": "a[href='/connections/datasources']",
-          "requirements": ["navmenu-open", "exists-reftarget"],
-          "content": "In the Grafana side menu, click **Connections > Data sources**."
+          "action": "navigate",
+          "reftarget": "/connections/datasources",
+          "verify": "on-page:/connections/datasources",
+          "content": "Open **Connections > Data sources**."
         },
         {
           "type": "interactive",
@@ -43,18 +43,11 @@
         },
         {
           "type": "interactive",
-          "action": "highlight",
-          "reftarget": "[aria-label=\"Add new data source Prometheus\"]",
+          "action": "button",
+          "reftarget": "Prometheus",
+          "verify": "on-page:/connections/datasources/edit",
           "requirements": ["on-page:/connections/datasources/new", "exists-reftarget"],
-          "content": "Select **Prometheus** from the list of data sources."
-        },
-        {
-          "type": "interactive",
-          "action": "formfill",
-          "reftarget": "[data-testid=\"data-testid Data source settings page name input field\"]",
-          "doIt": false,
-          "requirements": ["exists-reftarget"],
-          "content": "In the **Name** field, enter a descriptive name for your data source.\n\nFor example: `My Prometheus Server`\n\n> **Did you know?** The name of the data source is displayed on dashboard panels, so it's important to choose a meaningful name. If there are multiple data sources for a dashboard panel, the default toggle determines which data source appears by default."
+          "content": "Select **Prometheus**. Grafana creates the data source and opens its settings."
         }
       ]
     },


### PR DESCRIPTION
## Summary
- Navigate directly to the Data sources page and verify the destination. Updated approach used by newer guides, safe against nav bar item collapse state. Old approach: if "Connections" is collapsed, guide can't progress automatically.
- Select Prometheus by its visible button text and verify that settings open. Old aria label selector not available.
- Remove the obsolete data source name step.

## Testing
- Pathfinder strict guide validation passed.
- Pathfinder package validation passed.
- The updated flow passed manual testing on Grafana Cloud with a logged-in user.

## Known test limitation
Automated cloud E2E remains blocked by a Grafana service-account bug in the Kubernetes data source creation API. The logged-in user flow is not affected.

Co-Authored-By: Warp <agent@warp.dev>
