### PR TITLE
fix(prometheus): improve interactive steps in prometheus-lj

### DIFF
--- a/prometheus-lj/add-data-source-url/content.json
+++ b/prometheus-lj/add-data-source-url/content.json
@@ -24,10 +24,10 @@
           "type": "interactive",
           "action": "formfill",
           "reftarget": "#connection-url",
-          "doIt": false,
+          "targetvalue": "http://localhost:9090",
           "requirements": ["exists-reftarget"],
           "tooltip": "Enter the server root address only: Grafana appends the Prometheus API paths itself, so a /metrics or /api/v1 suffix here makes the connection test fail.",
-          "content": "In the **Prometheus server URL** field, enter your Prometheus server address.\n\nFor example: `http://localhost:9090`\n\nPrivate data source connect (PDC) enables connection requests to resolve to this private address."
+          "content": "In the **Prometheus server URL** field, enter your Prometheus server address.\n\n**Do it** fills in the default local address, `http://localhost:9090`. Replace it with your own server address if Prometheus runs elsewhere.\n\nPrivate data source connect (PDC) enables connection requests to resolve to this private address."
         }
       ]
     },

--- a/prometheus-lj/add-data-source-url/content.json
+++ b/prometheus-lj/add-data-source-url/content.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "1.0.0",
+  "schemaVersion": "1.1.0",
   "id": "prometheus-add-data-source-url",
   "title": "Enter the Prometheus data source URL",
   "blocks": [
@@ -17,6 +17,7 @@
     },
     {
       "type": "section",
+      "id": "enter-prometheus-url",
       "autoCollapse": false,
       "blocks": [
         {
@@ -25,6 +26,7 @@
           "reftarget": "#connection-url",
           "doIt": false,
           "requirements": ["exists-reftarget"],
+          "tooltip": "Enter the server root address only: Grafana appends the Prometheus API paths itself, so a /metrics or /api/v1 suffix here makes the connection test fail.",
           "content": "In the **Prometheus server URL** field, enter your Prometheus server address.\n\nFor example: `http://localhost:9090`\n\nPrivate data source connect (PDC) enables connection requests to resolve to this private address."
         }
       ]

--- a/prometheus-lj/add-data-source/content.json
+++ b/prometheus-lj/add-data-source/content.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "1.0.0",
+  "schemaVersion": "1.1.0",
   "id": "prometheus-add-data-source",
   "title": "Add the Prometheus data source",
   "blocks": [
@@ -25,6 +25,7 @@
     },
     {
       "type": "section",
+      "id": "add-prometheus-data-source",
       "autoCollapse": false,
       "blocks": [
         {
@@ -32,13 +33,16 @@
           "action": "navigate",
           "reftarget": "/connections/datasources",
           "verify": "on-page:/connections/datasources",
+          "tooltip": "This page lists every data source already connected to your instance, so scan it first — an existing Prometheus connection is often reusable.",
           "content": "Open **Connections > Data sources**."
         },
         {
           "type": "interactive",
           "action": "highlight",
           "reftarget": "[data-testid=\"data-testid data-source-add-button\"]",
+          "verify": "on-page:/connections/datasources/new",
           "requirements": ["on-page:/connections/datasources", "exists-reftarget"],
+          "tooltip": "The next screen is a searchable catalogue of the data source plugins installed here; nothing is created until you choose a type.",
           "content": "Click **Add new data source**."
         },
         {
@@ -47,6 +51,7 @@
           "reftarget": "Prometheus",
           "verify": "on-page:/connections/datasources/edit",
           "requirements": ["on-page:/connections/datasources/new", "exists-reftarget"],
+          "tooltip": "Your choice here decides which settings form and query editor you get, so pick Prometheus even when your metrics live in a Prometheus-compatible store such as Mimir or Thanos.",
           "content": "Select **Prometheus**. Grafana creates the data source and opens its settings."
         }
       ]

--- a/prometheus-lj/config-authentication/content.json
+++ b/prometheus-lj/config-authentication/content.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "1.0.0",
+  "schemaVersion": "1.1.0",
   "id": "prometheus-config-authentication",
   "title": "Enter Prometheus data source authentication credentials",
   "blocks": [
@@ -29,6 +29,7 @@
     },
     {
       "type": "section",
+      "id": "configure-prometheus-authentication",
       "autoCollapse": false,
       "blocks": [
         {
@@ -36,12 +37,10 @@
           "action": "highlight",
           "reftarget": "#auth-method-select",
           "doIt": false,
+          "skippable": true,
           "requirements": ["exists-reftarget"],
-          "content": "In the **Authentication method** dropdown, select a method of authentication.\n\nFor example: **Basic authentication**."
-        },
-        {
-          "type": "markdown",
-          "content": "For basic authentication, enter the username and password."
+          "tooltip": "Basic authentication adds User and Password fields for the credentials your Prometheus server itself expects, not your Grafana Cloud login; a bare local Prometheus usually needs No authentication.",
+          "content": "In the **Authentication method** dropdown, select the method your Prometheus server enforces.\n\nFor example, **Basic authentication** adds a **User** field for the Prometheus account name and a **Password** field for that account's password. Enter both yourself — this guide never fills in credentials."
         }
       ]
     },

--- a/prometheus-lj/select-private-connection/content.json
+++ b/prometheus-lj/select-private-connection/content.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "1.0.0",
+  "schemaVersion": "1.1.0",
   "id": "prometheus-select-private-connection",
   "title": "Select PDC and test connection",
   "blocks": [
@@ -29,22 +29,25 @@
     },
     {
       "type": "section",
+      "id": "select-pdc-and-test",
       "autoCollapse": false,
       "blocks": [
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "[aria-label=\"Private data source connect\"]",
+          "reftarget": "input[aria-label='Private data source connect']",
           "doIt": false,
+          "skippable": true,
           "requirements": ["exists-reftarget"],
+          "tooltip": "Only PDC agents already registered in your Grafana Cloud stack appear in this list, so an empty list means no agent has connected yet.",
           "content": "In the **Private data source connect** field, select the name of a PDC agent.\n\n> For the test connection to be successful, you must select a PDC agent that's running."
         },
         {
           "type": "interactive",
           "action": "button",
           "reftarget": "Save & test",
-          "doIt": false,
           "requirements": ["exists-reftarget"],
+          "tooltip": "Saving runs a health check that queries the Prometheus API over the connection you just configured, so a green result proves the whole path works end to end.",
           "content": "Click **Save & test**.\n\nWhen successful, you'll see the message: `Successfully queried the Prometheus API.`"
         }
       ]

--- a/prometheus-lj/verify-ds-connection/content.json
+++ b/prometheus-lj/verify-ds-connection/content.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "1.0.0",
+  "schemaVersion": "1.1.0",
   "id": "prometheus-verify-ds-connection",
   "title": "Verify Prometheus data source query successful",
   "blocks": [
@@ -16,13 +16,16 @@
     },
     {
       "type": "section",
+      "id": "verify-metrics-in-drilldown",
       "autoCollapse": false,
       "blocks": [
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "a[href=\"/a/grafana-metricsdrilldown-app/drilldown\"]",
+          "reftarget": "a[data-testid=\"data-testid Nav menu item\"][href=\"/a/grafana-metricsdrilldown-app/drilldown\"]",
+          "verify": "on-page:/a/grafana-metricsdrilldown-app",
           "requirements": ["navmenu-open", "exists-reftarget"],
+          "tooltip": "Metrics Drilldown queries your data sources live rather than reading a saved dashboard, so every metric name it lists has come back from Prometheus just now.",
           "content": "In the Grafana side menu, click **Drilldown > Metrics**."
         },
         {


### PR DESCRIPTION
## What

A course-design pass over the **interactive steps** of the Prometheus data source learning path. Prose and content are otherwise untouched — every change is a step property, a selector, or step-level metadata.

## Why

The path's steps had no tooltips at all, so the show-only steps (`doIt: false`) gave learners a highlight and nothing else — no explanation of what the field is for or what goes wrong if they get it wrong. The server URL step offered no way to fill anything, and a few conditional steps could dead-end learners who don't use PDC or don't have authentication configured.

## Changes

**Tooltips on all 8 interactive steps.** Each one adds information the surrounding prose doesn't already give — why the step matters, or the mistake it prevents. Examples:

- Prometheus server URL: "Enter the server root address only: Grafana appends the Prometheus API paths itself, so a `/metrics` or `/api/v1` suffix here makes the connection test fail."
- Authentication method: "**Basic authentication** adds **User** and **Password** fields for the credentials your Prometheus server itself expects, not your Grafana Cloud login; a bare local Prometheus usually needs **No authentication**."
- Private data source connect: "Only PDC agents already registered in your Grafana Cloud stack appear in this list, so an empty list means no agent has connected yet."

All are a single sentence, under 250 characters, and none names the element it highlights (critical rule 12).

**`add-data-source-url`** — the URL step was already a `formfill`, but `doIt: false` meant it offered no fill affordance at all. **Do it** is now enabled with a literal default of `http://localhost:9090` — the address the guide already used as its example — and the step copy says plainly that it's a default to overwrite.

**`config-authentication`** — the vague markdown line "For basic authentication, enter the username and password" is folded into the auth-method step itself, so the step copy and its tooltip explain what the **User** and **Password** fields are for and whose credentials belong there. No step targets the credential fields directly, by design: a section's **Do section** run executes every step with `buttonType: 'do'` regardless of `doIt`, so pointing steps at those fields would risk acting on secrets (critical rule 13).

**`select-private-connection`** — dropped `doIt: false` from **Save & test** so the action that completes the journey can actually run (matches `mysql-data-source-lj` and `infinity-json-lj`), and switched the PDC field to `input[aria-label='Private data source connect']` to match those same paths.

**`verify-ds-connection`** — uses the documented nav-menu selector form (`a[data-testid="data-testid Nav menu item"][href=...]`) instead of a bare `href` match, and verifies the Drilldown app was actually reached.

**Resilience and rule compliance** — `skippable: true` on the conditional authentication and PDC steps so learners with no auth or no PDC agent aren't blocked (rule 16); `verify` on the **Add new data source** navigation (rule 8); kebab-case section ids; `schemaVersion` → `1.1.0` (rule 18).

## Validation

```
pathfinder-cli validate --strict   → all 9 content.json files pass
pathfinder-cli validate --package  → path + all 9 step packages PASS
```

## Deliberately not changed

- **No `validateInput` / `formHint` on the URL step.** `formHint` only takes effect when `validateInput: true`, which in turn requires a `targetvalue`. The validation hook treats a `^`-anchored `targetvalue` as a regex, but the fill path is not regex-aware — so **Do it** would type `^https?://` verbatim into the field. A literal `targetvalue` with exact-match validation is worse still: it would flag every learner whose Prometheus isn't on `localhost` as invalid.
- Five numbered step slots are `markdown` blocks and can't take a tooltip (no such field on `markdown`). Four are in `verify-prom-data` — actions on the learner's own machine, with no Grafana DOM to target, where a `noop` step would render a fake interactive card. The fifth is the conditional "If you see a **Let's start!** button" line, which has no verified selector; `drilldown-metrics-lj` keeps it as markdown for the same reason.
- No `on-page` requirement was added to the data-source settings steps. It would match (substring check against `/connections/datasources/edit/<uid>`), but on failure it sets `canFix: true` with `targetHref: /connections/datasources/edit`, so the **Fix this** button would send learners to a UID-less broken URL. `exists-reftarget` already gates those steps correctly.

## Known follow-ups (not in this PR)

- `verify-prom-data` has two orphaned screenshots: both `image` blocks sit *after* the section, so the two "You should see something similar to the following:" steps have nothing beneath them. Fix is to inline them as markdown images inside each step's own block.
- No section has the "what you learned" closing bookend required by critical rule 14 — six one-liners across the path.
- `verify-prom-data`, both `business-value-*`, and `end-journey` are still on `schemaVersion: "1.0.0"`.
- The step manifests still chain through `business-value-olly` / `business-value-prom`, which were intentionally dropped from the path's `milestones` in c8e708e1 — that wiring is now dead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
