### PR TITLE
chore(ci): bump pathfinder CLI pin to 2262da89

### DIFF
--- a/.github/workflows/validate-json.yml
+++ b/.github/workflows/validate-json.yml
@@ -66,9 +66,9 @@ jobs:
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       with:
         repository: grafana/grafana-pathfinder-app
-        # Pin: pathfinder main after e6dde89 (TypeScript 6.0.3) has package.json/lock out of
-        # sync (npm ci: Missing typescript@5.9.3). Revisit when upstream lockfile is fixed.
-        ref: 342121e6ef884afeddcc680f2a8f6ca60b687488
+        # Pin: bumped from 342121e6 now the upstream lockfile is back in sync (npm ci passes).
+        # The old pin predated the input block's dataCheck* fields and rejected them as unknown.
+        ref: 2262da89e414858f1b760932dade3fd03f56d0fe
         path: pathfinder-app
         persist-credentials: false
 


### PR DESCRIPTION
## What

Bumps the `grafana-pathfinder-app` CLI pin in `validate-json.yml` from `342121e6` to `2262da89`.

## Why

The old pin predates the `input` block's data check fields. `validate --strict` rejects them as unknown:

```
- Unknown field 'dataCheckQuery' at blocks[15]
- Unknown field 'dataCheckFailureMessage' at blocks[15]
- Unknown field 'dataCheckBlocking' at blocks[15]
```

So a guide using a data check fails CI even though it is valid against the schema Pathfinder actually ships. This came up on #519, where a data check block is being added to the Frontend Observability guide.

The comment on the old pin explained it was held back because upstream had `package.json` and the lockfile out of sync. That is resolved: `npm ci` passes at `2262da89`.

## Verification

Built the CLI at both the old pin and the new one, then ran every step this workflow runs against the whole tree:

| Step | `342121e6` | `2262da89` |
|---|---|---|
| `validate --strict` on 679 `content.json` | 0 failures | 0 failures |
| `validate --package` on 678 packages | 0 failures | 0 failures |
| `build-snippets shared/snippets` | OK | OK |
| `build-repository` | OK | OK |

No existing content changes behaviour, and the data check fields validate on the new pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)