### PR TITLE
fix(detect-outages-sm): repair the Ping request-type selector

### DIFF
--- a/detect-outages-synthetic-monitoring-lj/create-ping-check/content.json
+++ b/detect-outages-synthetic-monitoring-lj/create-ping-check/content.json
@@ -43,7 +43,7 @@
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "label[for^='option-ping-radiogroup-']",
+          "reftarget": "input[data-testid='data-testid radio-button-option ping']",
           "content": "Under **Request type**, click **Ping**."
         },
         {


### PR DESCRIPTION
## The break

The **Request type → Ping** step in `detect-outages-synthetic-monitoring-lj/create-ping-check` could not run. Verified live on `learn.grafana.net` with the check editor open at `/a/grafana-synthetic-monitoring-app/checks/new/api-endpoint`:

| selector | matches |
|---|---|
| `label[for^='option-ping-radiogroup-']` | **0** |
| `input[data-testid='data-testid radio-button-option ping']` | **1** |

Request type is now a radio group with stable testids, and the label is overlaid by its own radio input, which intercepts pointer events — so the radio is the real click target. Clicking it moves the editor to `?checkType=ping` and leaves the radio `checked`, so the step both highlights and does the right thing.

Same break, same fix as `sm-ping-check-tutorial` in #526.

## Everything else verified clean

Checked against the same page, so nothing else changed:

| selector | matches | where |
|---|---|---|
| `a[data-testid='action create check']` | 1 | Synthetics home |
| `a[href='.../checks/new/api-endpoint']` | 1 | choose-type page |
| `input[data-testid='checkEditor form job']` | 1 | check editor |
| `button[data-testid='checkEditor navigation execution']` | 1 | check editor |
| `button[data-testid='checkEditor form submit']` | 1 | check editor |

## Two notes for reviewers — neither is a break in this path

- **Frequency** uses `label:contains('1m')`, not the `id^='option-60000-radiogroup-'` form that went stale in the sibling guide. It is 1 match and resolves to the label of the default-checked `60000` radio, so it works. It is page-global though, so `input[data-testid='data-testid radio-button-option 60000']` would be the sturdier target if we want to match #526.
- `input[name='target'][placeholder='grafana.com']` is 0 matches on load and 1 match once Ping is selected, because the placeholder tracks request type. The Ping step runs first, so the guide is fine — but the plain `input[name='target']` used in #526 does not depend on step order.

`select-probe-locations` picks probe locations in prose rather than an interactive step, so the `probeLabel:first-of-type` selector that matched all 22 probes in the sibling guide does not appear in this path. (Confirmed live: it is still 22 matches.)

## Validation

```
node {pathfinder-app}/dist/cli/cli/index.js validate --package detect-outages-synthetic-monitoring-lj/create-ping-check
✅ PASS
```

Remaining output is pre-existing manifest-level INFO/WARN, untouched by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)