### PR TITLE
beyla: align tempo docker sample with current setup docs

### DIFF
--- a/beyla-tempo-lj/instrument-application/content.json
+++ b/beyla-tempo-lj/instrument-application/content.json
@@ -20,7 +20,7 @@
       "blocks": [
         {
           "type": "markdown",
-          "content": "Start the application you want to instrument. If you don't have an application, run the following command to start a sample Go blog application:\n\n```bash\ndocker run --rm -d \\\n  --name goblog \\\n  -p 8443:8443 \\\n  mariomac/goblog:dev\n```\n\nThe sample application runs in the background and listens on port `8443`."
+          "content": "Start the application you want to instrument. If you don't have an application, run the following command to start a sample Go blog application:\n\n```bash\ndocker run --rm -d \\\n  --name goblog \\\n  -p 18443:8443 \\\n  mariomac/goblog:dev\n```\n\nThe sample application runs in the background, listens on container port `8443`, and is available at `https://localhost:18443`."
         },
         {
           "type": "markdown",
@@ -32,11 +32,11 @@
         },
         {
           "type": "markdown",
-          "content": "Open a new terminal window and generate application traffic from a browser or terminal. If using your own application, make a request to its listening port using the appropriate protocol. For example, for an HTTP application:\n\n```bash\ncurl http://localhost:<YOUR_PORT>/\n```\n\nIf using the sample application, run the following command:\n\n```bash\ncurl -k https://localhost:8443/\n```"
+          "content": "Open a new terminal window and generate application traffic from a browser or terminal. If using your own application, make a request to its listening port using the appropriate protocol. For example, for an HTTP application:\n\n```bash\ncurl http://localhost:<YOUR_PORT>/\n```\n\nIf using the sample application, run the following command:\n\n```bash\ncurl -k https://localhost:18443/\n```"
         },
         {
           "type": "markdown",
-          "content": "Return to the terminal window where Beyla is running and verify the trace output. You should see output similar to the following:\n\n```text\n2026-02-02 14:03:53 (19.06ms) [200] GET /\n```\n\nThis output confirms that Beyla intercepted the request and generated a trace."
+          "content": "Return to the terminal window where Beyla is running and verify the trace output. You should see output similar to the following:\n\n```text\n2026-02-02 14:03:53 (19.06ms) [200] GET / [172.17.0.1]->[localhost:18443]\n```\n\nThis output confirms that Beyla intercepted the request and generated a trace."
         }
       ]
     },


### PR DESCRIPTION
Fixes #534

Updates the sample Go blog container port mapping, curl command, and example trace output to match the current Beyla Docker setup docs.