### PR TITLE
beyla: add stable section ids to tempo guide sections

### DIFF
--- a/beyla-tempo-lj/configure-otlp-endpoint/content.json
+++ b/beyla-tempo-lj/configure-otlp-endpoint/content.json
@@ -17,6 +17,7 @@
     },
     {
       "type": "section",
+      "id": "configure-otlp-endpoint",
       "blocks": [
         {
           "type": "markdown",

--- a/beyla-tempo-lj/explore-traces/content.json
+++ b/beyla-tempo-lj/explore-traces/content.json
@@ -13,6 +13,7 @@
     },
     {
       "type": "section",
+      "id": "query-traces",
       "autoCollapse": false,
       "blocks": [
         {
@@ -28,7 +29,7 @@
           "reftarget": "[data-testid='data-testid Select a data source']",
           "requirements": ["on-page:/explore", "exists-reftarget"],
           "doIt": false,
-          "content": "From the data source dropdown list at the top left, select your traces data source.\n\nFor example, select `grafanacloud-traces`."
+          "content": "From the data source menu at the top left, select your traces data source.\n\nFor example, select `grafanacloud-traces`."
         },
         {
           "type": "code-block",

--- a/beyla-tempo-lj/instrument-application/content.json
+++ b/beyla-tempo-lj/instrument-application/content.json
@@ -17,6 +17,7 @@
     },
     {
       "type": "section",
+      "id": "run-beyla",
       "blocks": [
         {
           "type": "markdown",


### PR DESCRIPTION
Fixes #535

Adds stable internal IDs to Beyla Tempo section blocks and makes a small guide-style terminology cleanup in the Explore milestone.