### PR TITLE
ci: stamp computed manifest stats before building repository.json

### DIFF
--- a/.cursor/best-practices.mdc
+++ b/.cursor/best-practices.mdc
@@ -282,7 +282,7 @@ Run through this before opening the PR.
 - [ ] Backticks only for copy-paste values; illustrative examples use plain text
 
 **Validation**
-- [ ] Run the local schema check from a Pathfinder CLI checkout: `node {pathfinder-app}/dist/cli/cli/index.js validate --packages .`
+- [ ] Run the local schema check from this repository's root (not from the Pathfinder checkout — `.` must resolve to this repo; see [manifest-reference.md](../docs/manifest-reference.md#validation)): `node {pathfinder-app}/dist/cli/cli/index.js validate --packages .`
 
 ---
 

--- a/.cursor/best-practices.mdc
+++ b/.cursor/best-practices.mdc
@@ -282,7 +282,8 @@ Run through this before opening the PR.
 - [ ] Backticks only for copy-paste values; illustrative examples use plain text
 
 **Validation**
-- [ ] Run the local schema check from this repository's root (not from the Pathfinder checkout — `.` must resolve to this repo; see [manifest-reference.md](../docs/manifest-reference.md#validation)): `node {pathfinder-app}/dist/cli/cli/index.js validate --packages .`
+- [ ] Run the local schema check from this repository's root (not from the Pathfinder checkout — `.` must resolve to this repo): `node {pathfinder-app}/dist/cli/cli/index.js validate --packages .`
+- [ ] Edited a milestone inside a learning path? `--packages` is depth-1 only and skips it — validate that directory directly with `validate --package <dir>` (repo-wide loop: [manifest-reference.md](../docs/manifest-reference.md#validation))
 
 ---
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -56,16 +56,20 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: grafana/grafana-pathfinder-app
-          # Pin: pathfinder main after e6dde89 (TypeScript 6.0.3) has package.json/lock out of
-          # sync (npm ci: Missing typescript@5.9.3). Revisit when upstream lockfile is fixed.
-          ref: 342121e6ef884afeddcc680f2a8f6ca60b687488
+          # Pin: bumped from 342121e6 now the upstream lockfile is back in sync (npm ci passes).
+          # This pin must include grafana-pathfinder-app#1661, which added `build-stats`;
+          # the old pin predates it and has no such command.
+          ref: 4d697f8088262ec41b735a8ed0cc0ab2390b483f
           path: pathfinder-app
           persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '22'
+          # Track pathfinder-app's engines.node so `npm ci` and the built CLI run on a
+          # compatible version. The new pin declares ">=24"; a hardcoded 22 was fine for
+          # the old pin but is a mismatch for this one.
+          node-version-file: pathfinder-app/package.json
           cache: 'npm'
           cache-dependency-path: pathfinder-app/package-lock.json
 
@@ -136,16 +140,20 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: grafana/grafana-pathfinder-app
-          # Pin: pathfinder main after e6dde89 (TypeScript 6.0.3) has package.json/lock out of
-          # sync (npm ci: Missing typescript@5.9.3). Revisit when upstream lockfile is fixed.
-          ref: 342121e6ef884afeddcc680f2a8f6ca60b687488
+          # Pin: bumped from 342121e6 now the upstream lockfile is back in sync (npm ci passes).
+          # This pin must include grafana-pathfinder-app#1661, which added `build-stats`;
+          # the old pin predates it and has no such command.
+          ref: 4d697f8088262ec41b735a8ed0cc0ab2390b483f
           path: pathfinder-app
           persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '22'
+          # Track pathfinder-app's engines.node so `npm ci` and the built CLI run on a
+          # compatible version. The new pin declares ">=24"; a hardcoded 22 was fine for
+          # the old pin but is a mismatch for this one.
+          node-version-file: pathfinder-app/package.json
           cache: 'npm'
           cache-dependency-path: pathfinder-app/package-lock.json
 
@@ -186,6 +194,24 @@ jobs:
               cp -r "$dir" packages/
             fi
           done
+
+          # Stamp every staged manifest.json with its computed completion stats.
+          # This MUST run before build-repository: build-stats writes the manifests,
+          # build-repository denormalizes them into repository.json. Today the ordering
+          # is inert because build-repository never assigns `stats`; it becomes
+          # load-bearing the moment grafana-pathfinder-app#1662 (manifest-extension
+          # passthrough) lands, after which an index built before the manifests are
+          # stamped omits stats for every package.
+          #
+          # Stamping the staged copy only. The committed manifests in the repo root are
+          # untouched, so the CDN carries computed stats and no author ever asserts one.
+          #
+          # No --exclude here: the staging loop above already dropped every non-package
+          # directory, so packages/ holds nothing to exclude. build-stats is deliberately
+          # stricter than build-repository — a path milestone missing from the scanned
+          # tree aborts the whole run rather than being silently omitted — so keep the
+          # staging EXCLUDE list above free of anything a path lists as a milestone.
+          node pathfinder-app/dist/cli/cli/index.js build-stats packages/
 
           # repository.json must live inside packages/ so "path" entries
           # resolve as siblings on the CDN.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -66,10 +66,11 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          # Track pathfinder-app's engines.node so `npm ci` and the built CLI run on a
-          # compatible version. The new pin declares ">=24"; a hardcoded 22 was fine for
-          # the old pin but is a mismatch for this one.
-          node-version-file: pathfinder-app/package.json
+          # Pinned explicitly rather than read from pathfinder-app's engines.node, which is
+          # the open-ended ">=24" the new pin declares. 24 satisfies it, and pinning the
+          # major keeps this publish path from drifting onto a newer (possibly non-LTS
+          # Current) Node on its own as runner images update.
+          node-version: '24'
           cache: 'npm'
           cache-dependency-path: pathfinder-app/package-lock.json
 
@@ -150,10 +151,11 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          # Track pathfinder-app's engines.node so `npm ci` and the built CLI run on a
-          # compatible version. The new pin declares ">=24"; a hardcoded 22 was fine for
-          # the old pin but is a mismatch for this one.
-          node-version-file: pathfinder-app/package.json
+          # Pinned explicitly rather than read from pathfinder-app's engines.node, which is
+          # the open-ended ">=24" the new pin declares. 24 satisfies it, and pinning the
+          # major keeps this publish path from drifting onto a newer (possibly non-LTS
+          # Current) Node on its own as runner images update.
+          node-version: '24'
           cache: 'npm'
           cache-dependency-path: pathfinder-app/package-lock.json
 

--- a/.github/workflows/validate-json.yml
+++ b/.github/workflows/validate-json.yml
@@ -68,7 +68,9 @@ jobs:
         repository: grafana/grafana-pathfinder-app
         # Pin: bumped from 342121e6 now the upstream lockfile is back in sync (npm ci passes).
         # The old pin predated the input block's dataCheck* fields and rejected them as unknown.
-        ref: 2262da89e414858f1b760932dade3fd03f56d0fe
+        # Bumped again from 2262da89: this pin must include grafana-pathfinder-app#1661,
+        # which added `build-stats`; 2262da89 predates it and has no such command.
+        ref: 4d697f8088262ec41b735a8ed0cc0ab2390b483f
         path: pathfinder-app
         persist-credentials: false
 
@@ -245,6 +247,34 @@ jobs:
           echo "❌ $FAILED package(s) failed validation"
           exit 1
         fi
+
+    # Stamps every manifest.json with its computed completion stats. This step MUST
+    # stay immediately before "Build repository.json": build-stats writes the manifests,
+    # build-repository denormalizes them into repository.json. Today the ordering is
+    # inert because build-repository never assigns `stats`; it becomes load-bearing the
+    # moment grafana-pathfinder-app#1662 (manifest-extension passthrough) lands, after
+    # which an index built before the manifests are stamped omits stats for every package.
+    #
+    # This writes into the checkout and nothing commits it, so the stamped manifests
+    # live only for the duration of the job. The value here is fail-fast: build-stats is
+    # the strictest command in the pipeline, so running it at PR time catches a tree
+    # shape that would abort the deploy — an unresolvable, duplicated, or double-parented
+    # milestone — while the change is still reviewable.
+    #
+    # Same root and same excludes as build-repository below, deliberately. build-stats is
+    # stricter than its sibling: a package that a path lists as a milestone but that sits
+    # inside an excluded subtree aborts the whole run and leaves the tree unstamped, where
+    # build-repository would merely omit the entry and succeed. Verified against the real
+    # tree at the time of writing — 665 packages stamped, exit 0, no warnings — so neither
+    # `pathfinder-app` nor `shared` holds a milestone any path references. Adding an
+    # --exclude for a subtree that does hold one would turn this step into a hard stop.
+    - name: Stamp manifest stats
+      run: |
+        echo "🔢 Computing completion block stats into every manifest.json..."
+        echo ""
+        node pathfinder-app/dist/cli/cli/index.js build-stats . --exclude pathfinder-app --exclude shared
+        echo ""
+        echo "🔢 manifest stats stamped"
 
     - name: Build repository.json
       run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,3 +90,16 @@ Full reference documentation lives in `docs/`. AI-oriented references live in `.
 | [/build-interactive-lj](.cursor/commands/build-interactive-lj.md) | Convert an existing website learning path to an interactive package |
 | [/preflight-learning-path](.cursor/commands/preflight-learning-path.md) | Author pre-PR self-review for a learning path (mirrors review checks + shared claim-check, then optional fixes) |
 | [/review-learning-path-pr](.cursor/commands/review-learning-path-pr.md) | Full learning path PR review (audit, consistency, Playwright, Pathfinder, GitHub submit) |
+
+## Committing and pushing
+
+Branch protection on this repository enforces **verified commit signatures** as a push rule. An unsigned commit is not rejected when you make it — it is rejected by the remote at push time, with `GH013: Repository rule violations found` naming each offending SHA. Fixing it after the fact means rewriting the commit, which changes its SHA and can leave local tooling holding a diverged ref.
+
+So: leave `commit.gpgsign` enabled and never disable it for a commit here (no `-c commit.gpgsign=false`, no `--no-gpg-sign`). Check before pushing with `git log --pretty='%h %G? %s' main..HEAD` — every commit must show `G`.
+
+## Maintaining this file
+
+Keep this file for knowledge useful to almost every future agent session in this project.
+Do not repeat what the codebase already shows; point to the authoritative file or command instead.
+Prefer rewriting or pruning existing entries over appending new ones.
+When updating this file, preserve this bar for all agents and keep entries concise.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 This repository's authoring intelligence lives in [`.cursor/`](.cursor/) and [`docs/`](docs/). Both Claude Code and Cursor read these files; references use standard markdown links so both tools resolve them natively.
 
-The canonical critical rules list (21 rules; all blocking) lives in [`AGENTS.md`](AGENTS.md#critical-rules). Cursor reads `AGENTS.md` as its entry point; Claude reads this file. **Read those rules before authoring or reviewing any guide — every rule there is blocking.**
+The canonical critical rules list (21 rules; all blocking) lives in [`AGENTS.md`](AGENTS.md#critical-rules). Cursor reads `AGENTS.md` as its entry point; Claude reads this file. **Read those rules before authoring or reviewing any guide — every rule there is blocking.** Before committing or pushing, read [AGENTS.md — Committing and pushing](AGENTS.md#committing-and-pushing).
 
 When a doc here disagrees with the upstream schema, the schema wins. Authoritative schemas come from [`grafana-pathfinder-app`](https://github.com/grafana/grafana-pathfinder-app) (`src/types/json-guide.types.ts` and `src/types/json-guide.schema.ts`).
 
@@ -71,10 +71,10 @@ This repo's content is rendered by the Grafana Pathfinder app. Authoritative sch
 - `src/interactive-engine/action-handlers/` — action handlers (button, formfill, navigate, hover, popout, guided)
 - `src/cli/utils/block-registry.ts` — `CLI_EXCLUDED_BLOCK_TYPES` (e.g., `grot-guide` is hand-authored in the block editor)
 
-If a doc here disagrees with the schema, the schema wins. Validate locally from **this repository's root**, pointing at a built `grafana-pathfinder-app` checkout — `.` must resolve to this repo, or the run silently validates Pathfinder's own bundled packages instead:
+If a doc here disagrees with the schema, the schema wins. Validate locally from **this repository's root**, pointing at a built `grafana-pathfinder-app` checkout — `.` must resolve to this repo:
 
 ```bash
 node {pathfinder-app}/dist/cli/cli/index.js validate --packages .
 ```
 
-Working directory rules for the other CLI commands (`build-stats`, `build-repository`) live in [docs/manifest-reference.md](docs/manifest-reference.md#validation).
+This form is depth-1 only: it reaches the 128 immediate children that hold a `content.json`, not the 665 packages in the tree, so a nested milestone package is skipped in silence. Run it from the wrong root and it fails loudly (`No package directories found`) rather than false-passing; it is `build-stats` and `build-repository` that discover recursively and would quietly operate on Pathfinder's own manifests. The repo-wide enumeration loop and the working directory rules for those two commands live in [docs/manifest-reference.md](docs/manifest-reference.md#validation).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,8 +71,10 @@ This repo's content is rendered by the Grafana Pathfinder app. Authoritative sch
 - `src/interactive-engine/action-handlers/` — action handlers (button, formfill, navigate, hover, popout, guided)
 - `src/cli/utils/block-registry.ts` — `CLI_EXCLUDED_BLOCK_TYPES` (e.g., `grot-guide` is hand-authored in the block editor)
 
-If a doc here disagrees with the schema, the schema wins. Validate locally from a Pathfinder CLI checkout:
+If a doc here disagrees with the schema, the schema wins. Validate locally from **this repository's root**, pointing at a built `grafana-pathfinder-app` checkout — `.` must resolve to this repo, or the run silently validates Pathfinder's own bundled packages instead:
 
 ```bash
 node {pathfinder-app}/dist/cli/cli/index.js validate --packages .
 ```
+
+Working directory rules for the other CLI commands (`build-stats`, `build-repository`) live in [docs/manifest-reference.md](docs/manifest-reference.md#validation).

--- a/docs/manifest-reference.md
+++ b/docs/manifest-reference.md
@@ -430,7 +430,9 @@ Website learning path markdown location: `<website-repo>/content/docs/learning-p
 Validate individual packages:
 
 ```bash
-node dist/cli/cli/index.js validate --package <directory>
+# cwd: the interactive-tutorials repository root, with grafana-pathfinder-app
+# checked out (and built) at ./pathfinder-app.
+node pathfinder-app/dist/cli/cli/index.js validate --package <directory>
 ```
 
 Validate every package in the repo, nested milestones included — enumerate `manifest.json` recursively and validate each directory. This is the repo-wide check, and the form CI runs (`.github/workflows/validate-json.yml`):
@@ -438,12 +440,26 @@ Validate every package in the repo, nested milestones included — enumerate `ma
 ```bash
 # cwd: the interactive-tutorials repository root, with grafana-pathfinder-app
 # checked out (and built) at ./pathfinder-app.
-find . -name manifest.json -type f \
-  -not -path "./pathfinder-app/*" -not -path "./shared/*" -not -path "./.git/*" |
-  while IFS= read -r manifest_file; do
-    node pathfinder-app/dist/cli/cli/index.js validate --package "$(dirname "$manifest_file")"
-  done
+PASSED=0
+FAILED=0
+while IFS= read -r manifest_file; do
+  dir="$(dirname "$manifest_file")"
+  if node pathfinder-app/dist/cli/cli/index.js validate --package "$dir"; then
+    PASSED=$((PASSED + 1))
+  else
+    echo "❌ package validation failed: $dir"
+    FAILED=$((FAILED + 1))
+  fi
+done < <(find . -name manifest.json -type f \
+           -not -path "./pathfinder-app/*" \
+           -not -path "./shared/*" \
+           -not -path "./.git/*")
+
+echo "passed: $PASSED  failed: $FAILED"
+[ "$FAILED" -eq 0 ]
 ```
+
+Two details in that snippet are load-bearing. The counters must be fed by process substitution (`done < <(find ...)`), not by piping `find` into `while`: a pipe runs the loop body in a subshell, so the counters are discarded when it exits and the pipeline reports only the last iteration's status — a failure on package 200 of 665 would scroll away under 400-odd later `✅ PASS` trailers and still leave `$?` at 0. And the closing `[ "$FAILED" -eq 0 ]` is what makes the run's exit status reflect the whole tree; it is spelled as a test rather than `exit 1` so that pasting the block into an interactive shell does not close it.
 
 The `--packages` form — the one [CLAUDE.md](../CLAUDE.md) documents — is depth-1 only: `validatePackageTree` reads the root once and validates only immediate children containing `content.json`, which from this repository's root is 128 of the 665 packages. Nested milestone packages (`automate-k6-cicd-lj/<milestone>/`, for example) are skipped without a word, so do not rely on it after editing one:
 

--- a/docs/manifest-reference.md
+++ b/docs/manifest-reference.md
@@ -433,7 +433,19 @@ Validate individual packages:
 node dist/cli/cli/index.js validate --package <directory>
 ```
 
-Validate all packages in the repo — this is the form [CLAUDE.md](../CLAUDE.md) documents:
+Validate every package in the repo, nested milestones included — enumerate `manifest.json` recursively and validate each directory. This is the repo-wide check, and the form CI runs (`.github/workflows/validate-json.yml`):
+
+```bash
+# cwd: the interactive-tutorials repository root, with grafana-pathfinder-app
+# checked out (and built) at ./pathfinder-app.
+find . -name manifest.json -type f \
+  -not -path "./pathfinder-app/*" -not -path "./shared/*" -not -path "./.git/*" |
+  while IFS= read -r manifest_file; do
+    node pathfinder-app/dist/cli/cli/index.js validate --package "$(dirname "$manifest_file")"
+  done
+```
+
+The `--packages` form — the one [CLAUDE.md](../CLAUDE.md) documents — is depth-1 only: `validatePackageTree` reads the root once and validates only immediate children containing `content.json`, which from this repository's root is 128 of the 665 packages. Nested milestone packages (`automate-k6-cicd-lj/<milestone>/`, for example) are skipped without a word, so do not rely on it after editing one:
 
 ```bash
 # cwd: the interactive-tutorials repository root, with grafana-pathfinder-app
@@ -452,4 +464,4 @@ node pathfinder-app/dist/cli/cli/index.js build-repository . --exclude pathfinde
 
 `build-stats` rewrites every `manifest.json` in place, so the working directory matters: run it from a `grafana-pathfinder-app` checkout instead and `.` resolves to that repo, rewriting its own bundled package manifests. Do not commit the result; the stamped stats belong to CI, not to the repo. To check for drift without writing anything, add `--check`.
 
-Working directory differs by command, so check it before running one. `validate --package <directory>` takes an explicit path and is cwd-agnostic — point the CLI path at wherever your `grafana-pathfinder-app` checkout is. `validate --packages .`, `build-stats .`, and `build-repository .` all resolve `.` against the current directory and must run from this repository's root, with the CLI reached at `pathfinder-app/dist/cli/cli/index.js`; run any of them from a `grafana-pathfinder-app` checkout and they operate on that repo's own bundled packages instead — a silent false pass for `validate --packages`. CI runs them automatically; see `.github/workflows/validate-json.yml` for the PR-time run and `.github/workflows/deploy.yml` for the run that produces the published tree.
+Working directory differs by command, so check it before running one. `validate --package <directory>` takes an explicit path and is cwd-agnostic — point the CLI path at wherever your `grafana-pathfinder-app` checkout is. `validate --packages .`, `build-stats .`, and `build-repository .` all resolve `.` against the current directory and must run from this repository's root, with the CLI reached at `pathfinder-app/dist/cli/cli/index.js`; run `build-stats .` or `build-repository .` from a `grafana-pathfinder-app` checkout and they walk that repo's own tree instead, silently, because both discover packages recursively — and for `build-stats` that is a destructive in-place rewrite. `validate --packages .` fails loudly there rather than false-passing (`No package directories found under ...`, exit 1), since that checkout has no immediate child directory containing `content.json`. CI runs them automatically; see `.github/workflows/validate-json.yml` for the PR-time run and `.github/workflows/deploy.yml` for the run that produces the published tree.

--- a/docs/manifest-reference.md
+++ b/docs/manifest-reference.md
@@ -433,13 +433,15 @@ Validate individual packages:
 node dist/cli/cli/index.js validate --package <directory>
 ```
 
-Validate all packages in the repo:
+Validate all packages in the repo — this is the form [CLAUDE.md](../CLAUDE.md) documents:
 
 ```bash
-node dist/cli/cli/index.js validate --packages .
+# cwd: the interactive-tutorials repository root, with grafana-pathfinder-app
+# checked out (and built) at ./pathfinder-app.
+node pathfinder-app/dist/cli/cli/index.js validate --packages .
 ```
 
-Stamp computed completion stats into every manifest, then build `repository.json` from all packages. Run them in this order — see [stats](#stats). Unlike the two commands above, this block runs from the root of **this** repository, with a `grafana-pathfinder-app` checkout at `./pathfinder-app`, which is how CI invokes it:
+Stamp computed completion stats into every manifest, then build `repository.json` from all packages. Run them in this order — see [stats](#stats). Same working directory as the command above, which is how CI invokes them:
 
 ```bash
 # cwd: the interactive-tutorials repository root, with grafana-pathfinder-app
@@ -450,4 +452,4 @@ node pathfinder-app/dist/cli/cli/index.js build-repository . --exclude pathfinde
 
 `build-stats` rewrites every `manifest.json` in place, so the working directory matters: run it from a `grafana-pathfinder-app` checkout instead and `.` resolves to that repo, rewriting its own bundled package manifests. Do not commit the result; the stamped stats belong to CI, not to the repo. To check for drift without writing anything, add `--check`.
 
-The `validate --package` and `validate --packages` commands above are run from a [grafana-pathfinder-app](https://github.com/grafana/grafana-pathfinder-app) checkout, where the CLI sits at `dist/cli/cli/index.js`; the `build-stats`/`build-repository` block is run from this repository's root, where the CLI sits at `pathfinder-app/dist/cli/cli/index.js`. CI runs them automatically; see `.github/workflows/validate-json.yml` for the PR-time run and `.github/workflows/deploy.yml` for the run that produces the published tree.
+Working directory differs by command, so check it before running one. `validate --package <directory>` takes an explicit path and is cwd-agnostic — point the CLI path at wherever your `grafana-pathfinder-app` checkout is. `validate --packages .`, `build-stats .`, and `build-repository .` all resolve `.` against the current directory and must run from this repository's root, with the CLI reached at `pathfinder-app/dist/cli/cli/index.js`; run any of them from a `grafana-pathfinder-app` checkout and they operate on that repo's own bundled packages instead — a silent false pass for `validate --packages`. CI runs them automatically; see `.github/workflows/validate-json.yml` for the PR-time run and `.github/workflows/deploy.yml` for the run that produces the published tree.

--- a/docs/manifest-reference.md
+++ b/docs/manifest-reference.md
@@ -14,7 +14,7 @@ Run this from a [grafana-pathfinder-app](https://github.com/grafana/grafana-path
 
 - [PATHFINDER-PACKAGE-DESIGN.md](https://github.com/grafana/grafana-pathfinder-app/blob/main/docs/design/PATHFINDER-PACKAGE-DESIGN.md) — package format spec
 - [package-authoring.md](https://github.com/grafana/grafana-pathfinder-app/blob/main/docs/developer/package-authoring.md) — manifest field reference and templates
-- [CLI_TOOLS.md](https://github.com/grafana/grafana-pathfinder-app/blob/main/docs/developer/CLI_TOOLS.md) — `validate --package`, `build-repository`, `build-graph`, `schema manifest`
+- [CLI_TOOLS.md](https://github.com/grafana/grafana-pathfinder-app/blob/main/docs/developer/CLI_TOOLS.md) — `validate --package`, `build-repository`, `build-stats`, `build-graph`, `schema manifest`
 
 ---
 
@@ -73,6 +73,7 @@ prometheus-lj/
 | `conflicts` | `string[]` | No | `[]` | Packages that conflict (mutually exclusive). Schema-only in MVP. |
 | `replaces` | `string[]` | No | `[]` | Packages this one supersedes entirely. Schema-only in MVP. |
 | `milestones` | `string[]` | **Yes** (paths only) | — | Ordered list of step package IDs. Only for `type: "path"` or `"journey"`. |
+| `stats` | `object` | **No — never hand-author** | — | Completion block counts, computed by CI. See [stats](#stats). |
 
 ### author
 
@@ -149,6 +150,42 @@ Rules are evaluated most-specific-first:
 > **Note:** `"play"` is not a valid `tier` value. Play.grafana.org is a specific cloud instance — model it as `tier: "cloud"` + `instance: "play.grafana.org"`, not as a distinct tier.
 >
 > **Note:** Never copy a regex pattern into `instance`. The `instance` field is a concrete hostname used to target a specific test environment. A regex `source` predicate in the match expression is a routing rule, not an instance identifier. `.*\\.grafana\\.net` specifically means "all Grafana Cloud instances" → `tier: "cloud"` with no `instance`.
+
+---
+
+### stats
+
+`stats` holds the block counts that completion tracking measures a reader against. **Do not write this field by hand, and do not commit it.** It is computed from the guide's own content by `pathfinder-cli build-stats` during CI, so the denominator is guaranteed to match the content it describes and no author can assert a wrong one.
+
+```json
+"stats": {
+  "version": 1,
+  "blockCount": 22,
+  "sectionCount": 2,
+  "completableBlockCount": 18,
+  "finalCompletablePosition": 21
+}
+```
+
+| Key | Meaning |
+|-----|---------|
+| `version` | Rule version of the stamp, bumped when the counting rule changes. Says nothing about whether the guide changed. |
+| `blockCount` | The completion denominator. |
+| `sectionCount` | Section containers. Authoring insight only; not part of the denominator. |
+| `completableBlockCount` | Counted blocks that can emit completion evidence. |
+| `finalCompletablePosition` | Position of the last completable block, `0` when there is none. |
+
+**What counts.** Every block counts once, except containers (`section`, `assistant`, `collapsible`), which contribute their contents and nothing of their own. `multistep` and `guided` each count as one; their inner steps are outside the denominator. `conditional` counts as one and neither branch is descended into. `snippet-ref` counts as one, and its resolved contents inherit that single position — the stamped number is the pre-inlining count. A `path` rolls up as its own cover page followed by its milestones in declared order.
+
+**Reaching 100%.** Completion is `n / blockCount` with no special case, so a guide reaches 100% only when `finalCompletablePosition === blockCount`. Anything less means the guide needs a "Mark as complete" affordance at its foot; that field is the signal for it. Most packages in this repo are currently in that state.
+
+**Where it comes from.** Both CI workflows run `build-stats` over the package tree immediately before `build-repository` — `.github/workflows/deploy.yml` stamps the staged `packages/` tree that ships to the CDN, and `.github/workflows/validate-json.yml` stamps a throwaway copy at PR time as a fail-fast gate. Neither commits the result: like `repository.json`, `graph.json`, and the snippet and course indexes, `stats` is a build artifact, and the committed `manifest.json` files in this repo stay free of it.
+
+The ordering of the two commands matters. `build-stats` writes the manifests and `build-repository` denormalizes them into `repository.json`. As of this writing `build-repository` does not forward the `stats` key, so `repository.json` carries no stats either way; the ordering becomes load-bearing once [grafana-pathfinder-app#1662](https://github.com/grafana/grafana-pathfinder-app/pull/1662) lands and unknown manifest keys start flowing through.
+
+**`build-stats` is deliberately stricter than its siblings.** A milestone missing from the scanned tree, a duplicated milestone, a milestone reachable through two parents, or a manifest that fails schema validation each abort the whole run and leave the tree completely unstamped rather than half-stamped. `build-graph` warns in the same situations and `build-repository` degrades a bad manifest to a warning. The practical consequence for CI: if an `--exclude`d subtree contains a package that a path lists as a milestone, `build-stats` fails where `build-repository` would have quietly omitted the entry. Before adding an `--exclude` to either workflow, check that the excluded tree holds no milestone any path references.
+
+**`stats.blockCount` is not `inspect`'s `blockCount`.** `pathfinder-cli inspect --format json` counts the whole tree, containers included and conditional branches descended; `stats.blockCount` counts neither. The two disagree by design on the same guide — `inspect` answers "how many blocks are in this file", `stats` answers "what is the reader measured against". On `explore-drilldowns-101`, `inspect` reports 24 and `stats` reports 22; the difference is its two `section` containers.
 
 ---
 
@@ -402,10 +439,13 @@ Validate all packages in the repo:
 node dist/cli/cli/index.js validate --packages .
 ```
 
-Build `repository.json` from all packages:
+Stamp computed completion stats into every manifest, then build `repository.json` from all packages. Run them in this order — see [stats](#stats):
 
 ```bash
-node dist/cli/cli/index.js build-repository . -o repository.json
+node dist/cli/cli/index.js build-stats . --exclude pathfinder-app --exclude shared
+node dist/cli/cli/index.js build-repository . --exclude pathfinder-app --exclude shared -o repository.json
 ```
 
-These commands are run from a [grafana-pathfinder-app](https://github.com/grafana/grafana-pathfinder-app) checkout. CI runs them automatically; see `.github/workflows/validate-json.yml`.
+`build-stats` rewrites every `manifest.json` in place. Do not commit the result; the stamped stats belong to CI, not to the repo. To check for drift without writing anything, add `--check`.
+
+These commands are run from a [grafana-pathfinder-app](https://github.com/grafana/grafana-pathfinder-app) checkout. CI runs them automatically; see `.github/workflows/validate-json.yml` for the PR-time run and `.github/workflows/deploy.yml` for the run that produces the published tree.

--- a/docs/manifest-reference.md
+++ b/docs/manifest-reference.md
@@ -439,13 +439,15 @@ Validate all packages in the repo:
 node dist/cli/cli/index.js validate --packages .
 ```
 
-Stamp computed completion stats into every manifest, then build `repository.json` from all packages. Run them in this order — see [stats](#stats):
+Stamp computed completion stats into every manifest, then build `repository.json` from all packages. Run them in this order — see [stats](#stats). Unlike the two commands above, this block runs from the root of **this** repository, with a `grafana-pathfinder-app` checkout at `./pathfinder-app`, which is how CI invokes it:
 
 ```bash
-node dist/cli/cli/index.js build-stats . --exclude pathfinder-app --exclude shared
-node dist/cli/cli/index.js build-repository . --exclude pathfinder-app --exclude shared -o repository.json
+# cwd: the interactive-tutorials repository root, with grafana-pathfinder-app
+# checked out (and built) at ./pathfinder-app.
+node pathfinder-app/dist/cli/cli/index.js build-stats . --exclude pathfinder-app --exclude shared
+node pathfinder-app/dist/cli/cli/index.js build-repository . --exclude pathfinder-app --exclude shared -o repository.json
 ```
 
-`build-stats` rewrites every `manifest.json` in place. Do not commit the result; the stamped stats belong to CI, not to the repo. To check for drift without writing anything, add `--check`.
+`build-stats` rewrites every `manifest.json` in place, so the working directory matters: run it from a `grafana-pathfinder-app` checkout instead and `.` resolves to that repo, rewriting its own bundled package manifests. Do not commit the result; the stamped stats belong to CI, not to the repo. To check for drift without writing anything, add `--check`.
 
-These commands are run from a [grafana-pathfinder-app](https://github.com/grafana/grafana-pathfinder-app) checkout. CI runs them automatically; see `.github/workflows/validate-json.yml` for the PR-time run and `.github/workflows/deploy.yml` for the run that produces the published tree.
+The `validate --package` and `validate --packages` commands above are run from a [grafana-pathfinder-app](https://github.com/grafana/grafana-pathfinder-app) checkout, where the CLI sits at `dist/cli/cli/index.js`; the `build-stats`/`build-repository` block is run from this repository's root, where the CLI sits at `pathfinder-app/dist/cli/cli/index.js`. CI runs them automatically; see `.github/workflows/validate-json.yml` for the PR-time run and `.github/workflows/deploy.yml` for the run that produces the published tree.


### PR DESCRIPTION
> **On the branch name.** The `-signed` suffix is a mechanical artifact, not a second attempt at the work. This repository enforces verified commit signatures as a push rule, and my original base commit was unsigned — I had disabled `commit.gpgsign` when creating it. Re-signing it changed its SHA, which left the local validation gate holding a diverged ref for the original branch name, and no supported command advances a diverged gate ref. Rather than force-push into that shared store, the same four commits — identical content, tree `3bce18af`, now all signed — were moved to a fresh branch the gate had no ref for. Nothing about the change itself differs. The deliverable is this PR, not the branch name.

## What this does

`pathfinder-cli build-stats` now runs over the same package tree immediately before each `build-repository` call, so every published guide package carries a machine-computed completion denominator and no author ever asserts one.

| Workflow | Where | Command added |
|---|---|---|
| `.github/workflows/deploy.yml` | inside the `Build Pathfinder Repo` run block, directly above `build-repository` | `build-stats packages/` |
| `.github/workflows/validate-json.yml` | new `Stamp manifest stats` step, immediately before `Build repository.json` | `build-stats . --exclude pathfinder-app --exclude shared` |

Those are the only two `build-repository` call sites in `.github/workflows/` — verified by grepping every `cli/index.js` invocation across all six workflow files. `deploy-pr-preview.yml`, `validate-html.yml`, `freeze-index-json.yml`, and `validate-website-yaml.yml` do not touch the CLI.

In `deploy.yml` the invocation is inline in the existing run block rather than a separate step, because `packages/` is staged in that same block. In `validate-json.yml` it is a distinct step, matching that file's one-step-per-concern style and giving `build-stats` its own failure attribution in the log — it is the strictest command in the pipeline and its aborts have their own remediation.

`--check` is deliberately **not** used as the pipeline mode. Both invocations are stamping runs. See *Proposed follow-up* for a drift gate.

## Ordering

`build-stats` writes the manifests; `build-repository` denormalizes them into `repository.json`. At the CLI pin this PR carries the ordering is still inert — `build-repository` builds each `RepositoryEntry` field by field and never assigns `stats`. It becomes load-bearing the moment the pin advances past grafana/grafana-pathfinder-app#1662 (manifest-extension passthrough), after which an index built before the manifests are stamped omits stats for every package. #1662 **merged upstream on 2026-08-24 at 11:41Z**, so that moment is now one pin bump away rather than one PR away — see *`repository.json` does not carry stats yet* below for exactly where this PR sits. Verified in parsed YAML rather than by eye:

```
== .github/workflows/deploy.yml
  job=build-packages step='Build Pathfinder Repo'
     > node pathfinder-app/dist/cli/cli/index.js build-stats packages/
     > node pathfinder-app/dist/cli/cli/index.js build-repository packages/ -o packages/repository.json
== .github/workflows/validate-json.yml
  job=validate-packages step='Stamp manifest stats'
     > node pathfinder-app/dist/cli/cli/index.js build-stats . --exclude pathfinder-app --exclude shared
  job=validate-packages step='Build repository.json'
     > node pathfinder-app/dist/cli/cli/index.js build-repository . --exclude pathfinder-app --exclude shared -o repository.json
```

## The pin bump — a consequence with its own blast radius, wider than the stats step

**Read this section as a separate change riding along with the stats work, because that is what it is.** Wiring in `build-stats` forced a pathfinder-app pin bump, and the pin does not select a command — **it selects the CLI version that every step of the publish pipeline runs.** The blast radius is not "the new stats step"; it is validation, indexing, snippet building, and graph building, in both workflows.

### Why it was unavoidable

`build-stats` **does not exist at either workflow's current pin.** `deploy.yml` pinned `342121e6`, `validate-json.yml` pinned `2262da89`; both predate grafana/grafana-pathfinder-app#1661 (`4c18e0d9`, merged 2026-08-21). Adding the invocation without moving the pins would have been an immediate `error: unknown command 'build-stats'`. There is no version of this change that leaves the pins alone.

Both pins move to **`4d697f8088262ec41b735a8ed0cc0ab2390b483f`**, confirmed via the GitHub API to be `grafana/grafana-pathfinder-app` `main` HEAD and `identical` to it, two commits after #1661.

### What else the bump drags in

That is a **month of CLI change** for `deploy.yml` (`342121e6` was pinned 2026-07-31) landing on the path that produces the published CDN tree, and a smaller jump for `validate-json.yml`. Every command below changes version at the same time as the stats step is added:

| Command | Used by | Now runs at a different CLI version |
|---|---|---|
| `validate --strict` | validate-json.yml, 665 content.json files | yes |
| `validate --package` | validate-json.yml, 665 package dirs | yes |
| `build-snippets` | both workflows | yes |
| `build-repository` | both workflows | yes |
| `build-graph` | both workflows | yes |
| `build-courses` | deploy.yml | yes — and see the incidental finding below |

The risk that matters: a newer CLI validating *unrelated, untouched* guide content more strictly would fail CI on every open PR in the repo, not just this one. So I ran the entire command sequence locally at the new pin over this repository's real 665-package tree rather than discovering it in CI:

| Step | Result at pin `4d697f80` |
|---|---|
| `npm ci` | ✅ 11s, no error |
| `npm run build:cli` | ✅ 1.4s |
| `build-snippets shared/snippets` | ✅ 20 snippets |
| `validate --strict` over every `content.json` | ✅ **665 passed, 0 failed** |
| `validate --package` over every package dir | ✅ **665 passed, 0 failed** |
| `build-stats` | ✅ 665 stamped, exit 0, no warnings |
| `build-repository` | ✅ 665 packages |
| `build-graph` | ✅ 666 nodes, 1510 edges |

No content in this repo validates differently at the new pin. That is the evidence for the bump being safe; it is not an assumption.

### Two knock-on changes the bump itself forced

**1. `deploy.yml`'s stale lockfile note is now false, and I removed it.** Both of its pin comments read *"pathfinder main after e6dde89 (TypeScript 6.0.3) has package.json/lock out of sync (npm ci: Missing typescript@5.9.3). Revisit when upstream lockfile is fixed."* It is fixed: `npm ci` at the new pin completes in 11s with no error. This is the same finding that already justified `validate-json.yml`'s earlier bump past that commit, so `deploy.yml` was simply the last holdout.

**2. `deploy.yml`'s Node version had to move — and it is pinned, not read from file.** It hardcoded `node-version: '22'`; the new pin declares `engines.node: ">=24"`, so leaving 22 in place would knowingly ship a runtime mismatch against the CLI's own declared engine.

My first attempt pointed it at `node-version-file: pathfinder-app/package.json`, mirroring `validate-json.yml`. Review caught the problem with that on the publish path: `>=24` is an **open-ended semver range**, and `setup-node` resolves it to the highest satisfying Node in the runner tool cache. Correct today (24.x), but it means the credentialed CDN publish job silently moves onto a newer major — including a non-LTS Current line — the moment runner images start caching one. So **both `deploy.yml` jobs now pin `node-version: '24'` explicitly**, and the publish runtime moves only when a human changes it.

`validate-json.yml` deliberately keeps `node-version-file: pathfinder-app/package.json`. **The asymmetry between the two workflows is intentional, not an oversight:** the validation workflow tracking upstream's declared engine is a feature (it fails loudly at PR time if upstream's floor moves), whereas the workflow that pushes to the CDN with `id-token: write` should not change runtime major on its own. Both `deploy.yml` jobs are pinned rather than only the credentialed one, because leaving one job on the open range would recreate the same drift inside a single file.

### Scope note on `deploy-guides`

`deploy.yml` has two pathfinder-app checkouts. Only `build-packages` runs `build-repository` and therefore needs `build-stats`. I bumped the `deploy-guides` pin and Node version too, rather than leaving two divergent pins in one file — it runs `build-snippets` only, verified above, and a file with two different pathfinder-app SHAs is a maintenance trap. Say the word and I will revert that job to the old pin, at the cost of the divergence.

### If you would rather not carry this

The alternative is to pin both workflows to `4c18e0d9` (#1661's own merge commit) instead of `main` HEAD, which is two commits less exposure. I chose `main` HEAD because it is what I built and tested locally, so the evidence in this PR describes the exact CLI the pipeline will run. Pinning to `4c18e0d9` would mean the evidence no longer matches the pin.

The `publish-packages` integrity gate is unaffected either way: it checks `repository.json` shape and a 500 MB size bound with plain `jq` and never invokes the CLI, and stamping adds ~98 KB across 665 manifests.

## The exclude hazard — established empirically, not in CI

`validate-json.yml` scans `.` with `--exclude pathfinder-app --exclude shared`. CLI_TOOLS.md warns that if an excluded subtree holds a package a path lists as a milestone, `build-stats` aborts and leaves the tree completely unstamped, where `build-repository` with the same excludes would merely omit the entry and succeed.

**Run against this repo's real content with that exact root and those exact excludes: safe.**

```
$ node .../index.js build-stats . --exclude pathfinder-app --exclude shared
✅ 665 manifest(s) updated, 0 already up to date
EXIT=0
```

Zero `❌` lines, zero `⚠️` lines, 666 lines of output total. Neither `pathfinder-app` nor `shared` holds a package any path references as a milestone. The `deploy.yml` shape is safe too: its staging loop drops `pathfinder-app .github docs .cursor shared guides packages courses` and the resulting `packages/` tree still holds all **665** manifests across 130 top-level dirs, so nothing a path needs was staged away. No `--exclude` is passed there — there is nothing left in `packages/` to exclude.

Both workflow comments record this, and record the standing rule: before adding an `--exclude` to either, check that the excluded tree holds no milestone any path references.

Idempotency and drift, same tree:

```
$ build-stats . --exclude ... --check    →  ✅ 665 manifest(s) up to date   (exit 0)
$ build-stats . --exclude ...            →  ✅ 0 manifest(s) updated, 665 already up to date
```

## Evidence: the computed manifests, pre-publish

Full staged sequence, run locally over this repository's real package tree: CLI built from `pathfinder-app` `main` (`4d697f80`), then `build-stats`, then `build-repository`. The tree was exported with `git archive HEAD` into a scratch directory so this is the committed content exactly, and so nothing landed in the working tree.

### 1. A single standalone guide — `explore-drilldowns-101/manifest.json`

Standalone in the strict sense: `type: "guide"`, top level, and its ID appears in no `milestones` array anywhere in the repo.

```json
{
  "id": "explore-drilldowns-101",
  "type": "guide",
  "description": "Hands-on guide: Explore drilldowns in Grafana.",
  "category": "general",
  "author": {
    "team": "interactive-learning"
  },
  "startingLocation": "/drilldown",
  "targeting": {
    "match": {
      "or": [
        { "urlPrefix": "/drilldown" },
        { "urlPrefix": "/a/grafana-metricsdrilldown-app" },
        { "urlPrefix": "/a/grafana-lokiexplore-app" },
        { "urlPrefix": "/a/grafana-exploretraces-app" },
        { "urlPrefix": "/a/grafana-pyroscope-app" }
      ]
    }
  },
  "testEnvironment": {
    "tier": "local"
  },
  "depends": [],
  "recommends": [],
  "suggests": [],
  "provides": [],
  "stats": {
    "version": 1,
    "blockCount": 22,
    "sectionCount": 2,
    "completableBlockCount": 18,
    "finalCompletablePosition": 21
  }
}
```

### 2. A milestone inside a path — `windows-integration-lp/install-alloy/manifest.json`

```json
{
  "id": "windows-integration-install-alloy",
  "type": "guide",
  "description": "Learn how to install Grafana Alloy on Windows.",
  "category": "data-availability",
  "author": {
    "name": "chri2547",
    "team": "Grafana Documentation"
  },
  "testEnvironment": {
    "tier": "cloud"
  },
  "depends": ["windows-integration-select-platform"],
  "recommends": ["windows-integration-configure-alloy"],
  "suggests": [],
  "provides": [],
  "stats": {
    "version": 1,
    "blockCount": 10,
    "sectionCount": 1,
    "completableBlockCount": 1,
    "finalCompletablePosition": 3
  }
}
```

### 3. The path that rolls those milestones up — `windows-integration-lp/manifest.json`

```json
{
  "id": "windows-integration",
  "type": "path",
  "description": "Set up a Windows integration to monitor your Windows system in Grafana Cloud with pre-built dashboards and alerts.",
  "category": "data-availability",
  "author": {
    "name": "chri2547",
    "team": "Grafana Documentation"
  },
  "testEnvironment": {
    "tier": "cloud"
  },
  "milestones": [
    "windows-integration-select-platform",
    "windows-integration-install-alloy",
    "windows-integration-configure-alloy",
    "windows-integration-test-connection",
    "windows-integration-install-dashboards-alerts",
    "windows-integration-understand-dashboards",
    "windows-integration-understand-alerts",
    "windows-integration-end-journey"
  ],
  "depends": [],
  "recommends": [],
  "suggests": [
    "drilldown-metrics-lj",
    "drilldown-logs-lj",
    "fleet-mgt-monitor-health-lj"
  ],
  "provides": [],
  "stats": {
    "version": 1,
    "blockCount": 66,
    "sectionCount": 5,
    "completableBlockCount": 7,
    "finalCompletablePosition": 40
  }
}
```

The rollup arithmetic checks out — path cover page (1 block) followed by its eight milestones in declared order:

```
  select-platform                  blockCount=5    completable=3
  install-alloy                    blockCount=10   completable=1
  configure-alloy                  blockCount=12   completable=0
  test-connection                  blockCount=6    completable=0
  install-dashboards-alerts        blockCount=8    completable=3
  understand-dashboards            blockCount=8    completable=0
  understand-alerts                blockCount=12   completable=0
  end-journey                      blockCount=4    completable=0
  ────────────────────────────────────────────────────────────
  milestones sum = 65 + own cover page = 1  →  path blockCount = 66  ✅
```

No journeys exist in this repo to show as a fourth shape: the 665 packages are 596 `guide` and 69 `path`, zero `journey`.

## `repository.json` does NOT carry stats yet — stated plainly

**`stats` does not reach `repository.json` under this PR, and the CDN does not carry stats today.** That was originally because grafana/grafana-pathfinder-app#1662 was unmerged. #1662 has since **merged upstream — 2026-08-24 11:41Z, merge commit `acbf39b4`** — so the reason has changed, and it is worth being exact about it rather than letting the merge imply more than it delivers:

This PR pins the CLI at `4d697f8088262ec41b735a8ed0cc0ab2390b483f`, which was chosen because it is the first pin containing #1661 (`build-stats`). That pin **predates #1662 by five commits**, confirmed against the upstream compare API:

```
$ gh api repos/grafana/grafana-pathfinder-app/compare/4d697f80...main
  status: ahead   ahead_by: 5   behind_by: 0

  f73eb50b  fix(completion-records): serve unverifiable write identity as a structural 404 (#1660)
  9bc39c15  fix(security/medium/): update dependency react-router-dom to v6.30.5 [security] (#1680)
  03df7476  feat: add callout block for highlighting content in guides (#1684)
  543256cd  fix(e2e): extend Pathfinder bootstrap retry budget (#1688)
  acbf39b4  feat(cli): forward unknown top-level manifest keys into repository.json (#1662)   <-- the passthrough

$ gh api .../compare/acbf39b4...4d697f80   →  status: behind   (the pin does not contain #1662)
```

So: the passthrough exists upstream, but not in the CLI this PR builds. The stamping is real and the ordering is correct; the denormalization into `repository.json` still does not happen. **Do not read this PR as putting stats on the CDN index — it does not.** Advancing the pin to pick up #1662 is a deliberately separate change: this pin bump already drags in a documented blast radius (see *The pin bump* above), and a second bump would pull in four unrelated upstream commits including a `callout` block type and a security dependency bump, invalidate the evidence run below, and re-open the review that has already been done on this tree. Kept out of scope on purpose, not overlooked.

The measured numbers below are therefore still the current, accurate behaviour of this PR as it stands.

Measured over the stamped tree, both call shapes:

```
$ jq 'length' repository.json                                              → 665
$ jq '[to_entries[] | select(.value.stats != null)] | length' repository.json → 0
```

Zero of 665. The entry for the path shown above, as it stands after `build-stats` ran first — note the absence of a `stats` key despite `windows-integration-lp/manifest.json` carrying one on disk at that moment. This is exactly the shape a pin bump past #1662 would change, and nothing else in this PR would need to move:

```json
{
  "path": "windows-integration-lp/",
  "title": "Monitor a Windows system in Grafana Cloud",
  "type": "path",
  "description": "Set up a Windows integration to monitor your Windows system in Grafana Cloud with pre-built dashboards and alerts.",
  "category": "data-availability",
  "author": {
    "name": "chri2547",
    "team": "Grafana Documentation"
  },
  "milestones": [
    "windows-integration-select-platform",
    "windows-integration-install-alloy",
    "windows-integration-configure-alloy",
    "windows-integration-test-connection",
    "windows-integration-install-dashboards-alerts",
    "windows-integration-understand-dashboards",
    "windows-integration-understand-alerts",
    "windows-integration-end-journey"
  ],
  "suggests": [
    "drilldown-metrics-lj",
    "drilldown-logs-lj",
    "fleet-mgt-monitor-health-lj"
  ],
  "testEnvironment": {
    "tier": "cloud"
  }
}
```

## Counts, warnings, and the surprising numbers

**665 packages stamped**, both tree shapes, exit 0. **Zero warnings, zero errors** in either run. All 665 carry `stats.version: 1`.

Three numbers are surprising, and none of them is a `build-stats` bug — each is a fact about this repo's content that the stamp has made visible for the first time:

1. **321 of 665 packages have `completableBlockCount: 0`.** Nearly half of everything we publish contains no block that can emit completion evidence at all. Those packages can never move off 0% by reading, only by an explicit "Mark as complete". `windows-integration-lp` shows the shape in miniature: five of its eight milestones are 0. Two whole paths land there too — `core-grafana-concepts-lj` at `blockCount: 30` with `completableBlockCount: 0`, and `find-k6-limits-lj` at `blockCount: 8` with `completableBlockCount: 0`, whose seven milestones are each a single markdown block.

2. **Only 9 of 665 packages have `finalCompletablePosition == blockCount`.** Per CLI_TOOLS.md, that equality is the condition for reaching 100% by reading, so **656 packages need a "Mark as complete" affordance at the foot or a reader can never finish them.** `windows-integration-lp` is `finalCompletablePosition: 40` against `blockCount: 66` — its last completable block sits 26 blocks from the end. This is a content finding, not a pipeline finding, but it is the one I would flag hardest: the denominator is now correct and it says most of the catalogue is uncompletable as authored.

3. **Seven of the eight `automate-k6-cicd-lj` milestones have `blockCount: 1`.** Checked, and it is honest: `add-pipeline-step`, `end-journey`, `handle-exit-code`, `parameterize-script`, `run-first-automated-test`, `understand-performance-gates`, and `verify-thresholds` each contain exactly one `markdown` block and nothing else. Only `stream-results-cloud` (10 blocks) has real content. That learning path is a prose skeleton; `build-stats` is reporting it accurately.

Largest and smallest, for scale:

```
path   interactive-dashboards-lj      blockCount=104  completable=39  final=95
path   infinity-json-lj                blockCount=96   completable=34  final=90
path   kafka-monitoring-lj             blockCount=95   completable=12  final=79
guide  automate-k6-cicd-end-journey    blockCount=1    completable=0   final=0
```

## `stats.blockCount` is not `inspect`'s `blockCount` — by design

`pathfinder-cli inspect --format json` counts the whole tree, containers included and conditional branches descended. `manifest.stats.blockCount` counts neither: containers contribute their contents and nothing of their own, and a `conditional` counts as one with no branch descended. The two answer different questions — `inspect` answers "how many blocks are in this file", `stats` answers "what is the reader measured against" — so they disagree on the same guide and that is not a bug.

Demonstrated on the standalone guide above:

```
$ inspect explore-drilldowns-101 --format json  →  data.blockCount = 24
  typeCounts: { markdown: 4, section: 2, interactive: 18 }
$ manifest.stats.blockCount                     →  22
```

24 − 22 = 2, exactly its two `section` containers (`drilldown-metrics`, `drilldown-logs`).

## Generated manifests are NOT committed — what the repo's convention actually is

Asked and answered from the repo itself, not assumed:

- **`.gitignore` excludes every CI-generated index**: `repository.json`, `graph.json`, `shared/snippets/index.json`, `courses/oss.json`, `courses/cloud.json` — the last three with comments saying explicitly "built by `pathfinder-cli ...` during the deploy workflow ... let CI rebuild".
- **No workflow commits anything back.** Grepping all six workflows for `git commit`, `git push`, `add-and-commit`, `create-pull-request` returns nothing. There is no CI commit-back path in this repo at all.
- **All 665 `manifest.json` files are tracked**, and **zero** currently carry a `stats` key.
- Upstream design decision **D28** names this repo specifically: high-velocity repositories "generate it as a CI build artifact and publish directly to CDN, keeping it out of git entirely."
- The 2026-08-19 rule for CDN content is "computed at build time and written into `manifest.json`" — which is what both invocations do, in CI, to a tree that is then published and discarded.

**So: not committed.** `manifest.json` is authored source; `stats` is the one generated field inside it, and it lives only in CI. Nothing in this PR touches guide content or a committed manifest — verified on the final tree: no `content.json` or `manifest.json` appears in the diff at all.

For the record, had it gone the other way it would have been **665 changed files**. If you want that instead, say so and I will raise it separately rather than fold a 665-file content diff into a workflow change.

## Documentation

`docs/manifest-reference.md` is where this repo documents manifest fields, so that is where the knowledge went:

- `stats` added to the field table, marked **"No — never hand-author"**.
- A new `### stats` section: the five keys and what each means, the counting rule (containers, `multistep`/`guided`, `conditional`, `snippet-ref` pre-inlining, path rollup), the `finalCompletablePosition == blockCount` condition for reaching 100%, where the stamp comes from in CI, why the ordering matters and when it becomes load-bearing, the strictness and the exclude hazard as a standing rule, and the `inspect` divergence with the concrete 24-vs-22 example.
- The `## Validation` section now shows `build-stats` before `build-repository` in the required order, with `--check` mentioned as the read-only drift check, and every snippet in that section now states its own working directory. That last part came out of review: `build-stats` writes in place, so a snippet ambiguous about its cwd is destructive rather than merely confusing — copy-pasted from a `pathfinder-app` checkout it would rewrite that repo's own bundled manifests. `validate --package <directory>` is cwd-agnostic because it takes an explicit path; `validate --packages .`, `build-stats .`, and `build-repository .` are all root-relative and are now documented with the nested `pathfinder-app/dist/cli/cli/index.js` path, matching both CI and the form `CLAUDE.md:74-77` already documents.
- `build-stats` added to the upstream CLI_TOOLS.md link line.

Two files outside `docs/` picked up the same working-directory correction, because they documented the old ambiguous form of the very command review flagged: `CLAUDE.md` (its `validate --packages .` example now says `.` must resolve to this repo, with a pointer to the manifest reference for `build-stats`/`build-repository`) and `.cursor/best-practices.mdc` (the pre-PR validation checkbox, same fix). Six files total: two workflows and four docs (`docs/manifest-reference.md`, `CLAUDE.md`, `.cursor/best-practices.mdc`, `AGENTS.md`). No guide content and no committed manifest.

No Critical Rule was added or renumbered: rule 21 is still the last one and the "21 rules" assertion in `CLAUDE.md` remains accurate.

`AGENTS.md` does gain two short sections, as durable project knowledge rather than as part of this change's subject matter. **"Committing and pushing"** records that branch protection here enforces verified signatures as a *push-time* rule — an unsigned commit is accepted locally and only rejected by the remote with `GH013`, and fixing it afterwards means rewriting SHAs. That is precisely the trap I fell into on this PR, and it cost a full pipeline run, so the next person should not have to rediscover it. **"Maintaining this file"** is the standard self-governance section, which the file previously lacked.

I deliberately did **not** add a 22nd entry to `AGENTS.md`'s Critical Rules. That list's count is asserted as "21" in eight places across `CLAUDE.md` and four `.cursor/skills/**` files; renumbering it would have meant a sweep through guide-authoring skills unrelated to this change. `docs/manifest-reference.md` is the documented route for manifest work from both `AGENTS.md` and `CLAUDE.md`, and the rule ("never hand-author `stats`") is stated there in bold.

## Incidental finding, out of scope: `build-courses` has never worked

While checking that every CLI command the workflows call exists at the new pin, I found one that exists at **no** pin. `deploy.yml` calls:

```yaml
- name: Build courses platform indexes
  continue-on-error: true
  run: node pathfinder-app/dist/cli/cli/index.js build-courses courses/ -o courses/
```

`build-courses` is not in the CLI at the new pin, **and it was not at the old `342121e6` pin either**. The only commit implementing it (`02283f5f`, "externalize courses to interactive-learning CDN") is not an ancestor of `main` — it lives on unmerged `cursor/*` branches; `git merge-base --is-ancestor` says no and the GitHub compare API says `diverged`.

So this step has been failing silently since it was added, masked by `continue-on-error: true`, and `courses/oss.json` / `courses/cloud.json` — both gitignored on the grounds that CI builds them — are never built. The downstream `if-no-files-found: warn` and `continue-on-error` download make it invisible all the way through.

Pre-existing, unrelated to this PR, untouched here. Worth its own issue.

One knock-on worth naming, since it lands in a doc I touched: the new `### stats` section says `stats` is a build artifact "like `repository.json`, `graph.json`, and the snippet and course indexes", and `.gitignore`'s own comment likewise says CI rebuilds `courses/oss.json` and `courses/cloud.json`. For the course indexes specifically that is aspirational rather than true today, for exactly the reason above. I left the wording as-is rather than hedging it: the sentence describes the intended category, it is inherited phrasing rather than new, and the correct fix is to restore `build-courses` (or amend the `.gitignore` comment) — not to encode a transient breakage into reference documentation. Same issue, flagged so it is not a surprise.

## Proposed follow-up, not added here

A `--check` drift gate in `validate-json.yml` would be pointless today: nothing commits `stats`, so there is no committed state to drift from and `--check` would pass vacuously. It becomes worth adding only if the answer to the commit question above ever flips to "commit them". Flagging rather than adding, per instruction.

## What review found, and what happened to each finding

Ten findings across three rounds. Recording all of them, because several changed the diff, one changed nothing but is worth knowing, and one round **disproved an earlier round's finding that I had already acted on** — which is the single most useful thing in this table.

| Round | Finding | Severity | Disposition |
|---|---|---|---|
| 1 | `deploy-publish-fail-closed` | warning | **Approved, fail-closed kept deliberately** |
| 1 | `node-version-open-range` | info | **Fixed** — both `deploy.yml` jobs pin `node-version: '24'` |
| 1 | `doc-command-wrong-cwd` | info | **Fixed** — snippet now states its cwd |
| 1 | `legacy-guides-tree-unstamped` | info | **Approved after establishing the fact** |
| 2 | `doc-validate-packages-cwd` | info | **Fixed, then later found to rest on a false premise** — see below |
| 2 | `intent-narrative-node-version-stale` | info | **No code change** — corrected this document instead |
| 3 | `validate-packages-shallow-scan` | warning | **Fixed** — `--packages` documented as depth-1; CI's recursive loop documented as the repo-wide check |
| 3 | `silent-false-pass-rationale-inverted` | info | **Fixed** — inverted rationale corrected in both files |
| 3 | `push-rule-only-in-cursor-entry-point` | info | **Fixed** — one-line pointer added from `CLAUDE.md` |
| 3 | `cdn-manifests-now-cli-authored` | info | **No action — accepted tradeoff, recorded below** |

Four of these deserve more than a table row.

**`deploy-publish-fail-closed` — a failure mode I had not thought through, kept anyway.** Review found a reachable path my own analysis missed. I tested the `--exclude` hazard as asked, but not the **two-PR race**: PR A adds `foo-lp` with milestone `foo-step-3`; PR B renames or deletes `foo-step-3`. Each is green alone under `validate-json.yml`, and `validate-json.yml` does not gate `deploy.yml` — they are independent workflows on the same push event. After both merge, `build-stats` exits 1, `bash -e` aborts the step, `build-repository` never runs, `publish-packages` is skipped by `needs:`, and **not one of the 665 packages reaches the CDN** until a revert lands. `build-repository` alone would have warned and published everything else.

This is a genuinely new failure mode for the publish job, and it is being kept on purpose: a wrong denominator is worse than a stale CDN. No mitigation, no `continue-on-error`, no pre-flight check. Flagging it because it is the kind of thing worth knowing before it fires, not after.

**`legacy-guides-tree-unstamped` — approved only after establishing the fact.** The concern: `deploy-guides` copies `"$dir"/*.json` into the legacy tree, `manifest.json` included, so the CDN would carry a stamped `packages/<dir>/manifest.json` and an unstamped legacy copy. I traced every runtime `manifest.json` reader in `grafana-pathfinder-app` rather than assuming it was inert:

| Reader | Resolves via | Reads the legacy tree? |
|---|---|---|
| `package-engine/online-cdn-resolver.ts:58` | `buildPackageFileUrl(baseUrl, …)` | no — `/packages/` |
| `context-engine/context.service.ts:1698` | same backend `baseUrl` | no — `/packages/` |
| `pkg/plugin/package_recommendations.go:335` | same | no — `/packages/` |
| `docs-retrieval/package-info-from-url.ts:35` | regex `/\/packages\/([^/]+)\/content\.json/` | no — pattern *requires* `/packages/` |
| `package-engine/resolver.ts`, `loader.ts` | `bundled:` scheme | no — in-plugin assets |
| `components/PrTester/github-api.ts` | GitHub raw PR URLs | no — not the CDN |

`baseUrl` is not overridable: `packageRepositoryURL` is a hardcoded const (`https://interactive-learning.grafana.net/packages/repository.json`) and `baseURLFromRepositoryURL` strips only the filename, so every manifest URL is `/packages/<path>/manifest.json` — the stamped tree. The two consumers that *do* hit the legacy tree, `GitHubPRModal.tsx:19` and `kiosk-rules.ts`, fetch `content.json` only; `docs-retrieval/content-fetcher.ts`, the legacy fetch ladder itself, contains **zero** references to `manifest`.

**No consumer reads a manifest from the legacy path**, so the duplicate is inert and the legacy tree stays unstamped. One correction to the finding's own wording: the kiosk URLs show that tree served under `/guides/`, not the bucket root. Does not change the conclusion.

**`doc-validate-packages-cwd` — a finding I accepted without verifying, and which round 3 disproved.** Round 2 claimed that `validate --packages .` run from a `pathfinder-app` checkout silently validates five bundled packages and exits green — a false pass under a heading reading "Validate all packages in the repo". I fixed the docs on that basis and wrote that rationale into two files. Round 3 flagged it, and I then **ran the command** instead of reasoning about it: from a `pathfinder-app` checkout it prints `No package directories found under ...` and **exits 1**. A loud failure, not a silent false pass — that repo has no immediate child directory containing `content.json`, so `runPackagesValidation` hits `results.size === 0` and bails.

The cwd *instruction* was right for a different reason than the one I gave. The silent-wrong-tree hazard is real, but it belongs to `build-stats` and `build-repository`, which use the recursive `discoverPackages` and would happily reach `pathfinder-app`'s own bundled manifests. `validate --packages` fails loudly. Both files now say that.

Round 3 also found the larger defect underneath: **`validate --packages .` is depth-1 only.** `validatePackageTree` does a single `readdirSync(rootDir)` and validates only immediate children containing `content.json` — from this repository's root that is **128 of 665 packages**, and every nested milestone package (`automate-k6-cicd-lj/<milestone>/`, and so on) is silently skipped. My change had anchored the "validate all packages in the repo" claim in three files. All three now state the depth-1 limit and point at the recursive enumeration loop `validate-json.yml:214-238` already uses as the actual repo-wide check.

Worth stating plainly: two rounds of review agreed with a claim that running the command for thirty seconds falsified. The corrected text is in the diff; the process lesson is that "the reviewer verified it" was not true, and I propagated it.

**`cdn-manifests-now-cli-authored` — accepted tradeoff, no action, flagged so it is not a surprise.** Before this change the sandboxed `build-packages` job only *copied* `manifest.json` verbatim into `packages/`, and the untrusted `ref: main` CLI authored only `repository.json` and `graph.json`. `build-stats` now **rewrites all 665 staged manifests in place**, so every manifest reaching the CDN is CLI-authored output from that checkout. The integrity gate at `deploy.yml:291` is deliberately shallow — `repository.json` shape, `graph.json` parse, total size bound — so it does not cover `targeting`, `dependencies`, or `startingLocation` in the regenerated manifests. This widens what that untrusted ref can influence. **No integrity check is being added here:** that follow-up was explicitly declined, and re-proposing it would re-litigate a settled call. Recorded as an accepted tradeoff, which is the disposition asked for.

## Verification summary

- Isolation verified before any work: disposable treehouse worktree, not the primary checkout.
- Both workflow files parse as YAML; ordering re-verified from the parsed structure, not by reading the diff.
- Full staged sequence run locally over the real 665-package tree, both call shapes, from a CLI built at the new pin.
- Working tree carries no stamped manifests — all evidence runs used `git archive HEAD` exports in a scratch directory. No `content.json` or `manifest.json` appears anywhere in this diff; the changed files are the two workflows plus the documentation they required.
