### PR TITLE
Connections: Fix the Add new connection tile selector

### DIFF
--- a/grafana-cloud-tour-lj/explore-connect-data/content.json
+++ b/grafana-cloud-tour-lj/explore-connect-data/content.json
@@ -29,7 +29,7 @@
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "[role='button']:has([data-testid='icon-plus-circle'])",
+          "reftarget": "a[href='/connections/add-new-connection']",
           "content": "Click the **Add new connection** tile.",
           "requirements": ["on-page:/connections"]
         },

--- a/grafana-cloud-tour-lj/explore-send-data/content.json
+++ b/grafana-cloud-tour-lj/explore-send-data/content.json
@@ -29,7 +29,7 @@
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "[role='button']:has([data-testid='icon-plus-circle'])",
+          "reftarget": "a[href='/connections/add-new-connection']",
           "content": "Click the **Add new connection** tile.",
           "requirements": ["on-page:/connections"]
         },


### PR DESCRIPTION
## Summary
Two guides in the `grafana-cloud-tour-lj` journey used the same broken selector for the **Add new connection** tile on `/connections`. The old selector looked for `role='button'` on the tile. The tile is a `div` with a link inside. This role does not exist on the page.

The new selector matches the link by its `href` value. This is the same pattern already used later in each file for their respective next tile.

Fixed guides:
- `grafana-cloud-tour-lj/explore-send-data`
- `grafana-cloud-tour-lj/explore-connect-data`

## Root cause
Live telemetry showed 3 recent failed E2E cycles for `grafana-cloud-tour-explore-send-data`. All 3 failed at the same step, with the same error:
```
Element not found: [role='button']:has([data-testid='icon-plus-circle'])
```
A DOM snapshot from a failed run confirmed no element on the `/connections` page has `role="button"`.

`explore-connect-data` has not run yet in telemetry, because the journey chain is still blocked at `explore-send-data`. Its `content.json` had the exact same selector, targeting the same tile on the same page, so it would have failed the same way once the journey reached it.

## Testing
- Passed: `python3 -m json.tool` — confirmed both edited `content.json` files are still valid JSON.
- Not run: Pathfinder guide validation (`/lint`, `/check`) — no live Grafana Cloud session was available in this session.
- Not run: live E2E runner — the fix targets a selector observed against a real page DOM, but a fresh run against the E2E pipeline has not confirmed the fix yet.

## Documentation
No separate docs need an update. The fix only changes a CSS selector inside guide content.
