### PR TITLE
Unpin reusable workflow and stop Renovate from pinning it

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,12 @@
+{
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+  packageRules: [
+    {
+      description: "Keep deploy preview on writers-toolkit@main because WIF matches job_workflow_ref by branch ref and fails when pinned to a SHA.",
+      matchManagers: ["github-actions"],
+      matchFileNames: [".github/workflows/deploy-pr-preview.yml"],
+      matchPackageNames: ["grafana/writers-toolkit"],
+      enabled: false,
+    },
+  ],
+}

--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   deploy-pr-preview:
     # Do not pin by SHA the WIF binding for github-docs-deploy-previews matches job_workflow_ref by branch ref. Pinning by SHA breaks getAccessToken.
-    uses: grafana/writers-toolkit/.github/workflows/deploy-preview.yml@16a5b420c91098549277466eb15e0327ec3a8eab # main
+    uses: grafana/writers-toolkit/.github/workflows/deploy-preview.yml@main
     if: >-
       !github.event.pull_request.head.repo.fork &&
       (


### PR DESCRIPTION
Example of similar configuration: https://github.com/grafana/terraform-provider-grafana/blob/main/.github/renovate.json5.

More context in https://github.com/grafana/interactive-tutorials/pull/459

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>
