### PR TITLE
Onboarding: Stop targeting the collapsed Connections submenu

### DIFF
--- a/grafana-cloud-onboarding-lj/install-data-source/content.json
+++ b/grafana-cloud-onboarding-lj/install-data-source/content.json
@@ -48,13 +48,10 @@
       "blocks": [
         {
           "type": "interactive",
-          "action": "highlight",
-          "reftarget": "a[href='/connections/datasources']",
-          "requirements": [
-            "navmenu-open",
-            "exists-reftarget"
-          ],
-          "content": "In the Grafana side menu, click **Connections > Data sources**."
+          "action": "navigate",
+          "reftarget": "/connections/datasources",
+          "content": "In the navigation menu, go to **Connections > Data sources**.",
+          "verify": "on-page:/connections/datasources"
         },
         {
           "type": "interactive",

--- a/grafana-cloud-onboarding-lj/install-integration/content.json
+++ b/grafana-cloud-onboarding-lj/install-integration/content.json
@@ -48,13 +48,10 @@
       "blocks": [
         {
           "type": "interactive",
-          "action": "highlight",
-          "reftarget": "a[data-testid='data-testid Nav menu item'][href='/connections/add-new-connection']",
-          "requirements": [
-            "navmenu-open",
-            "exists-reftarget"
-          ],
-          "content": "In the Grafana side menu, click **Connections > Add new connection**."
+          "action": "navigate",
+          "reftarget": "/connections/add-new-connection",
+          "content": "In the navigation menu, go to **Connections > Add new connection**.",
+          "verify": "on-page:/connections/add-new-connection"
         },
         {
           "type": "interactive",


### PR DESCRIPTION
## Summary
`install-data-source`'s first onboarding step highlighted `a[href='/connections/datasources']` directly in the side menu. That link only shows once the **Connections** section of the mega-menu is expanded. The `navmenu-open` requirement opens the mega-menu, but does not expand any section inside it.

Fix: use the `navigate` action to go straight to `/connections/datasources` via `locationService.push`, the same pattern already used by `cloudwatch-data-source-lj/add-data-source` for this exact page. This avoids clicking through the mega-menu entirely, so it does not depend on the section's expand/collapse state at all.

`install-integration` has the same problem one milestone later: it highlights `a[data-testid='data-testid Nav menu item'][href='/connections/add-new-connection']` directly in the mega-menu. It has not failed yet, but only because the journey chain stalls at `install-data-source` — every run since 2026-08-24 23:47 UTC never reaches this step, so it has not been exercised under the same conditions..

## Root cause
The E2E runner passed this guide on every run through 2026-08-24 19:52 UTC, then failed on every run starting 2026-08-24 23:47 UTC (3 straight failures at the time of this fix). The content did not change between the passing and failing runs (same `content_digest`), so something in the live Grafana UI's menu behavior changed.

The failure report showed `currentUrl: /` at failure (the guide never left the home page), with:
```
Requirements not met: The target element must be visible and available on the page.
```
The DOM snapshot at failure confirmed the Connections section toggle had `aria-expanded="false"`, and `/connections/datasources` did not appear anywhere in the menu while collapsed.

### Suspected trigger
The failure DOM snapshots embed the Grafana build in the page's boot data. The first two failures used commit `7ad245a7925a4d49094f6e172cb78c8a3494858a`, built at 2026-08-24 07:22 UTC. This build was already live before the last passing run. The third failure used a later commit, `b3e12529a403348f061071fc534436ad5587b651`. The same failure happened on both builds.

A better lead is Grafana's `grafana.customizableMegaMenu` feature flag (grafana/grafana#127059, #127166, and #127167). The description of grafana/grafana#127166 states: "Pinned items move into a 'Pinned' area at the top of the menu, and the rest of the nav collapses below once something is pinned." This behavior matches the failure DOM. grafana/grafana#127489 adds A/B experiment instrumentation for this flag. It assigns organizations to "treatment" or "control" independent of a binary deployment. This experiment can explain a behavior change without a build change.

This cause is not confirmed. I cannot access this tenant's feature-flag or experiment-assignment history. The behavior in #127166 also requires an item to be pinned, which I cannot confirm for this account. These Grafana PRs are a concrete lead for a Grafana-side investigation.

## Testing
- Passed: `python3 -m json.tool` — confirmed the edited `content.json` is still valid JSON.
- Not run: Pathfinder guide validation (`/lint`, `/check`) — no live Grafana Cloud session was available in this session.
- Not run: live E2E runner — the fix targets a selector observed against a real failure DOM, but a fresh run against the E2E pipeline has not confirmed the fix yet.

## Documentation
No separate docs need an update. The fix only changes guide content steps.



