### PR TITLE
Narrow manifest targeting so recommendations are page-specific

### DIFF
--- a/.cursor/how-to-write-recommendations.mdc
+++ b/.cursor/how-to-write-recommendations.mdc
@@ -15,7 +15,29 @@ repo are good examples of valid `targeting.match` blocks.
 The `targeting.match` value uses the same expression syntax the old `index.json` rules used, so the decisions are
 the same -- they just live in the manifest now.
 
+Before writing a match block, read [How matching scores](#how-matching-scores) below. The
+engine returns everything scoring above zero and sorts on score alone, so a broad match does
+not lose to a precise one -- it crowds it out. Breadth is the thing to get right.
+
 - ALWAYS set `targeting.match` in the guide's `manifest.json` (never edit `index.json`).
+- NEVER use `{ "urlPrefix": "/" }`. It matches every page in the product. A guide that is
+  relevant everywhere is relevant nowhere.
+- Target the page where the guide's first step actually happens; that should be the same value
+  as `startingLocation`. Prefer the deepest prefix that still covers the intended pages -- for
+  an integration, its own tile (`/connections/add-new-connection/kafka`), not the catalog that
+  lists every tile.
+- Keep the root of `match` an `or`, so scoring stays binary. See
+  [How matching scores](#how-matching-scores).
+- Catalog and listing pages (`/dashboards`, `/connections/infrastructure`,
+  `/connections/add-new-connection`) are shared by every guide in their area. Put one or two
+  overview guides there, and let specific guides live on the page that signals intent.
+- It is fine to target an adjacent page where the guide would prompt a user to try something
+  they have not discovered yet -- a playlists guide belongs on `/dashboards`, because nobody
+  visits `/playlists` before they know playlists exist. Budget those nudges: aim for a handful
+  of guides per page, not a dozen.
+- Verify every URL against a real stack before committing it. `urlPrefix` is a literal
+  `startsWith` with no route awareness, so a typo silently never matches -- and a prefix that
+  is one segment too short silently matches far more than intended.
 - The guide's `description` and `category` also live in `manifest.json`. Read the guide and base the
   description on what's in it.
 - ASK THE USER whether the guide pertains to things that are cloud, or both cloud & OSS.
@@ -43,11 +65,69 @@ and that means that they cannot be run on environments like Play, where users do
 {
   "targeting": {
     "match": {
-      "and": [
-        { "targetPlatform": "cloud" },
-        { "urlPrefixIn": ["/a/grafana-cmab-app/usage-alerts", "/a/grafana-cmab-app"] }
+      "or": [
+        {
+          "and": [
+            { "targetPlatform": "cloud" },
+            { "urlPrefixIn": ["/a/grafana-cmab-app/usage-alerts", "/a/grafana-cmab-app"] }
+          ]
+        }
       ]
     }
   }
 }
 ```
+
+## How matching scores
+
+Authoritative source: `internal/recommender/rules.go` and `cmd/recommender/v1recommend.go` in
+[`grafana-recommender`](https://github.com/grafana/grafana-recommender).
+
+Three behaviours decide whether a guide is seen:
+
+1. **A guide is returned when its score is above zero, not when it matches.** The recommender
+   discards the `matched` boolean and keeps only the accuracy.
+2. **`and` scores the fraction of children that matched; `or` scores 1 or 0.** So
+   `{"and": [{"urlPrefix": "/explore"}, {"targetPlatform": "cloud"}]}` scores 0.5 on *every*
+   page of a Cloud stack, because the platform child is true regardless of the page -- and 0.5
+   is above zero, so the guide is returned everywhere. Wrapping that same `and` in an `or` makes
+   the expression score 1.0 on `/explore` and 0 elsewhere.
+3. **There is no reward for specificity and no tie-break.** Every criterion weighs 1 and the
+   maximum is 1.0, so an exact path and `urlPrefix: "/"` score identically. Results are sorted
+   on score alone and capped at 10, and the sort is unstable, so guides tied at 1.0 appear in
+   arbitrary order. The only way to get a guide seen is for fewer guides to match that page.
+
+Practical rules that follow:
+
+- **Keep the root of `match` an `or`.** Every branch then scores 1.0 or 0, and the guide is
+  either fully relevant or absent. Put platform and tag criteria inside the branch's `and`.
+- **Every branch of an `or` must constrain the URL.** A branch with no URL criterion matches
+  every page and drags the whole expression with it.
+- **Only `source` and `sourceIn` can exclude.** They are hard pre-filters evaluated before
+  scoring. `targetPlatform`, `tag`, `datasource` and `userRole` cannot keep a guide off a page --
+  they only lower its score, which still leaves it above zero. A Cloud-only guide will surface
+  on OSS unless its URL simply does not exist there.
+- **One criterion per object.** Evaluation is a `switch`, so only the first key in precedence
+  order is read: `{"urlPrefix": "/d/", "datasource": "prometheus"}` ignores the datasource.
+  Split criteria into `and`/`or` children.
+- **Only these criterion names exist**: `and`, `or`, `urlRegex`, `urlPrefix`, `urlPrefixIn`,
+  `datasource`, `datasourceIn`, `allDatasources`, `noDatasources`, `userRole`, `userRoleIn`,
+  `tag`, `tagIn`, `allTags`, `cohort`, `cohortIn`, `targetPlatform`, `targetPlatformIn`,
+  `source`, `sourceIn`. An unrecognised name is dropped, which leaves an always-true child --
+  a typo makes a guide *more* broad, not less.
+
+`urlRegex`, `tag`, `source`, `userRole` and `cohort` work in the recommender but are dropped by
+the plugin's own matcher, which handles only `urlPrefix`, `urlPrefixIn`, `targetPlatform`, `and`
+and `or`. That matcher runs when the online recommender is disabled (the OSS default), and it
+discards the whole entry if any other predicate appears anywhere in the tree. Use the richer
+predicates when a guide is Cloud-gated anyway; avoid them if it must also surface on OSS.
+
+## Checking your work
+
+```bash
+python3 scripts/lint-targeting.py
+```
+
+Flags `urlPrefix: "/"`, root-level `and` blocks that score partially, `or` branches with no URL
+constraint, unknown criterion names, and multiple criteria in one object. Add `--report` for a
+per-page count of how many guides compete on each representative page.

--- a/adaptive-metrics-lj/manifest.json
+++ b/adaptive-metrics-lj/manifest.json
@@ -7,15 +7,21 @@
   "startingLocation": "/a/grafana-adaptive-metrics-app/overview",
   "targeting": {
     "match": {
-      "and": [
+      "or": [
         {
-          "urlPrefixIn": [
-            "/a/grafana-adaptive-metrics-app/overview",
-            "/a/grafana-adaptive-metrics-app/rule-management",
-            "/a/grafana-adaptive-metrics-app/configuration"
+          "and": [
+            {
+              "urlPrefixIn": [
+                "/a/grafana-adaptive-metrics-app/overview",
+                "/a/grafana-adaptive-metrics-app/rule-management",
+                "/a/grafana-adaptive-metrics-app/configuration"
+              ]
+            },
+            {
+              "targetPlatform": "cloud"
+            }
           ]
-        },
-        { "targetPlatform": "cloud" }
+        }
       ]
     }
   },

--- a/adaptive-metrics-recommendations/manifest.json
+++ b/adaptive-metrics-recommendations/manifest.json
@@ -7,12 +7,18 @@
   "startingLocation": "/adaptive-telemetry",
   "targeting": {
     "match": {
-      "and": [
-        { "targetPlatform": "cloud" },
+      "or": [
         {
-          "urlPrefixIn": [
-            "/adaptive-telemetry",
-            "/a/grafana-adaptivemetrics-app"
+          "and": [
+            {
+              "targetPlatform": "cloud"
+            },
+            {
+              "urlPrefixIn": [
+                "/adaptive-telemetry",
+                "/a/grafana-adaptivemetrics-app"
+              ]
+            }
           ]
         }
       ]

--- a/alerting-first-rule-lj/manifest.json
+++ b/alerting-first-rule-lj/manifest.json
@@ -10,12 +10,16 @@
   "startingLocation": "/alerting",
   "targeting": {
     "match": {
-      "and": [
+      "or": [
         {
-          "urlPrefix": "/alerting"
-        },
-        {
-          "targetPlatform": "cloud"
+          "and": [
+            {
+              "urlPrefix": "/alerting"
+            },
+            {
+              "targetPlatform": "cloud"
+            }
+          ]
         }
       ]
     }

--- a/alerting-query-language-lj/manifest.json
+++ b/alerting-query-language-lj/manifest.json
@@ -5,7 +5,22 @@
   "category": "take-action",
   "author": { "name": "JohnnyK-Grafana", "team": "Grafana Documentation" },
   "startingLocation": "/alerting",
-  "targeting": { "match": { "and": [ { "urlPrefix": "/alerting" }, { "targetPlatform": "cloud" } ] } },
+  "targeting": {
+    "match": {
+      "or": [
+        {
+          "and": [
+            {
+              "urlPrefix": "/alerting"
+            },
+            {
+              "targetPlatform": "cloud"
+            }
+          ]
+        }
+      ]
+    }
+  },
   "testEnvironment": { "tier": "cloud" },
   "milestones": [
     "alerting-query-language-install-datasources",

--- a/assistant-self-hosted/manifest.json
+++ b/assistant-self-hosted/manifest.json
@@ -10,15 +10,27 @@
   "startingLocation": "/",
   "targeting": {
     "match": {
-      "and": [
+      "or": [
         {
-          "or": [
-            { "urlRegex": "^/?$" },
-            { "urlPrefix": "/connections" },
-            { "urlPrefix": "/plugins/grafana-assistant-app" }
+          "and": [
+            {
+              "or": [
+                {
+                  "urlRegex": "^/?$"
+                },
+                {
+                  "urlPrefix": "/connections"
+                },
+                {
+                  "urlPrefix": "/plugins/grafana-assistant-app"
+                }
+              ]
+            },
+            {
+              "targetPlatform": "oss"
+            }
           ]
-        },
-        { "targetPlatform": "oss" }
+        }
       ]
     }
   },

--- a/automate-k6-cicd-lj/manifest.json
+++ b/automate-k6-cicd-lj/manifest.json
@@ -10,12 +10,16 @@
   "startingLocation": "/a/k6-app",
   "targeting": {
     "match": {
-      "and": [
+      "or": [
         {
-          "urlPrefix": "/a/k6-app"
-        },
-        {
-          "targetPlatform": "cloud"
+          "and": [
+            {
+              "urlPrefix": "/a/k6-app"
+            },
+            {
+              "targetPlatform": "cloud"
+            }
+          ]
         }
       ]
     }

--- a/beyla-tempo-lj/manifest.json
+++ b/beyla-tempo-lj/manifest.json
@@ -7,17 +7,24 @@
   "startingLocation": "/explore",
   "targeting": {
     "match": {
-      "and": [
+      "or": [
         {
-          "targetPlatform": "cloud"
+          "and": [
+            {
+              "urlPrefix": "/connections/add-new-connection/beyla"
+            },
+            {
+              "targetPlatform": "cloud"
+            }
+          ]
         },
         {
-          "or": [
+          "and": [
             {
               "urlPrefix": "/explore"
             },
             {
-              "urlPrefix": "/connections"
+              "targetPlatform": "cloud"
             }
           ]
         }

--- a/billing-usage-lj/manifest.json
+++ b/billing-usage-lj/manifest.json
@@ -10,17 +10,21 @@
   "startingLocation": "/a/grafana-cmab-app",
   "targeting": {
     "match": {
-      "and": [
+      "or": [
         {
-          "urlPrefixIn": [
-            "/a/grafana-cmab-app",
-            "/a/grafana-cmab-app/usage-alerts",
-            "/a/grafana-cmab-app/invoices",
-            "/a/grafana-cmab-app/attributions/overview"
+          "and": [
+            {
+              "urlPrefixIn": [
+                "/a/grafana-cmab-app",
+                "/a/grafana-cmab-app/usage-alerts",
+                "/a/grafana-cmab-app/invoices",
+                "/a/grafana-cmab-app/attributions/overview"
+              ]
+            },
+            {
+              "targetPlatform": "cloud"
+            }
           ]
-        },
-        {
-          "targetPlatform": "cloud"
         }
       ]
     }

--- a/build-dashboard-sdk-lp/manifest.json
+++ b/build-dashboard-sdk-lp/manifest.json
@@ -7,15 +7,22 @@
     "name": "grafana-docs",
     "team": "Grafana Documentation"
   },
-  "startingLocation": "/",
+  "startingLocation": "/dashboards",
   "targeting": {
     "match": {
-      "and": [
+      "or": [
         {
-          "urlPrefix": "/"
-        },
-        {
-          "targetPlatform": "cloud"
+          "and": [
+            {
+              "urlPrefixIn": [
+                "/dashboards",
+                "/dashboard/new"
+              ]
+            },
+            {
+              "targetPlatform": "cloud"
+            }
+          ]
         }
       ]
     }

--- a/categorize-collector-fleet-lj/manifest.json
+++ b/categorize-collector-fleet-lj/manifest.json
@@ -7,12 +7,16 @@
   "startingLocation": "/a/grafana-collector-app/fleet-management",
   "targeting": {
     "match": {
-      "and": [
+      "or": [
         {
-          "urlPrefix": "/a/grafana-collector-app/fleet-management"
-        },
-        {
-          "targetPlatform": "cloud"
+          "and": [
+            {
+              "urlPrefix": "/a/grafana-collector-app/fleet-management"
+            },
+            {
+              "targetPlatform": "cloud"
+            }
+          ]
         }
       ]
     }

--- a/cloudwatch-data-source-lj/manifest.json
+++ b/cloudwatch-data-source-lj/manifest.json
@@ -10,27 +10,37 @@
   "startingLocation": "/connections/datasources/new",
   "targeting": {
     "match": {
-      "and": [
+      "or": [
         {
-          "targetPlatform": "cloud"
+          "and": [
+            {
+              "urlPrefix": "/connections/datasources"
+            },
+            {
+              "tag": "selected-datasource:cloudwatch"
+            },
+            {
+              "targetPlatform": "cloud"
+            }
+          ]
         },
         {
-          "or": [
-            {
-              "and": [
-                {
-                  "urlPrefix": "/connections/datasources"
-                },
-                {
-                  "tag": "selected-datasource:cloudwatch"
-                }
-              ]
-            },
+          "and": [
             {
               "urlPrefix": "/connections/datasources/cloudwatch"
             },
             {
-              "urlPrefix": "/connections/add-new-connection"
+              "targetPlatform": "cloud"
+            }
+          ]
+        },
+        {
+          "and": [
+            {
+              "urlRegex": "/connections/add-new-connection/?$"
+            },
+            {
+              "targetPlatform": "cloud"
             }
           ]
         }

--- a/configure-grafana-terraform-lp/manifest.json
+++ b/configure-grafana-terraform-lp/manifest.json
@@ -7,15 +7,19 @@
     "name": "grafana-docs",
     "team": "Grafana Documentation"
   },
-  "startingLocation": "/",
+  "startingLocation": "/admin",
   "targeting": {
     "match": {
-      "and": [
+      "or": [
         {
-          "urlPrefix": "/"
-        },
-        {
-          "targetPlatform": "cloud"
+          "and": [
+            {
+              "urlPrefix": "/admin"
+            },
+            {
+              "targetPlatform": "cloud"
+            }
+          ]
         }
       ]
     }

--- a/create-availability-slo-lj/manifest.json
+++ b/create-availability-slo-lj/manifest.json
@@ -10,15 +10,19 @@
   "startingLocation": "/a/grafana-slo-app/home/insights",
   "targeting": {
     "match": {
-      "and": [
+      "or": [
         {
-          "urlPrefixIn": [
-            "/a/grafana-slo-app/home/insights",
-            "/a/grafana-slo-app/wizard/new"
+          "and": [
+            {
+              "urlPrefixIn": [
+                "/a/grafana-slo-app/home/insights",
+                "/a/grafana-slo-app/wizard/new"
+              ]
+            },
+            {
+              "targetPlatform": "cloud"
+            }
           ]
-        },
-        {
-          "targetPlatform": "cloud"
         }
       ]
     }

--- a/create-usage-alert/manifest.json
+++ b/create-usage-alert/manifest.json
@@ -11,12 +11,18 @@
   "startingLocation": "/a/grafana-cmab-app/usage-alerts",
   "targeting": {
     "match": {
-      "and": [
-        { "targetPlatform": "cloud" },
+      "or": [
         {
-          "urlPrefixIn": [
-            "/a/grafana-cmab-app/usage-alerts",
-            "/a/grafana-cmab-app"
+          "and": [
+            {
+              "targetPlatform": "cloud"
+            },
+            {
+              "urlPrefixIn": [
+                "/a/grafana-cmab-app/usage-alerts",
+                "/a/grafana-cmab-app"
+              ]
+            }
           ]
         }
       ]

--- a/dashboard-playlists-guide/manifest.json
+++ b/dashboard-playlists-guide/manifest.json
@@ -11,8 +11,12 @@
   "targeting": {
     "match": {
       "or": [
-        { "urlPrefix": "/playlists" },
-        { "urlPrefix": "/dashboards" }
+        {
+          "urlPrefixIn": [
+            "/playlists",
+            "/dashboards"
+          ]
+        }
       ]
     }
   },

--- a/data-transformation-lp/manifest.json
+++ b/data-transformation-lp/manifest.json
@@ -7,15 +7,22 @@
     "name": "grafana-docs",
     "team": "Grafana Documentation"
   },
-  "startingLocation": "/",
+  "startingLocation": "/dashboard/new",
   "targeting": {
     "match": {
-      "and": [
+      "or": [
         {
-          "urlPrefix": "/"
-        },
-        {
-          "targetPlatform": "cloud"
+          "and": [
+            {
+              "urlPrefixIn": [
+                "/d/",
+                "/dashboard/new"
+              ]
+            },
+            {
+              "targetPlatform": "cloud"
+            }
+          ]
         }
       ]
     }

--- a/deploy-dashboard-terraform-lp/manifest.json
+++ b/deploy-dashboard-terraform-lp/manifest.json
@@ -7,15 +7,19 @@
     "name": "grafana-docs",
     "team": "Grafana Documentation"
   },
-  "startingLocation": "/",
+  "startingLocation": "/dashboards",
   "targeting": {
     "match": {
-      "and": [
+      "or": [
         {
-          "urlPrefix": "/"
-        },
-        {
-          "targetPlatform": "cloud"
+          "and": [
+            {
+              "urlPrefix": "/dashboards"
+            },
+            {
+              "targetPlatform": "cloud"
+            }
+          ]
         }
       ]
     }

--- a/detect-outages-synthetic-monitoring-lj/manifest.json
+++ b/detect-outages-synthetic-monitoring-lj/manifest.json
@@ -11,12 +11,16 @@
   "startingLocation": "/a/grafana-synthetic-monitoring-app/home",
   "targeting": {
     "match": {
-      "and": [
+      "or": [
         {
-          "urlPrefix": "/a/grafana-synthetic-monitoring-app/home"
-        },
-        {
-          "targetPlatform": "cloud"
+          "and": [
+            {
+              "urlPrefix": "/a/grafana-synthetic-monitoring-app/home"
+            },
+            {
+              "targetPlatform": "cloud"
+            }
+          ]
         }
       ]
     }

--- a/docs/manifest-reference.md
+++ b/docs/manifest-reference.md
@@ -114,12 +114,42 @@ The `targeting` object contains a `match` expression that determines when the gu
 
 | Predicate | Example | Meaning |
 |-----------|---------|---------|
-| `urlPrefix` | `"/alerting"` | Current URL path starts with value |
+| `urlPrefix` | `"/alerting"` | Current URL path starts with value (literal `startsWith`) |
 | `urlPrefixIn` | `["/alerting", "/alerts"]` | Current URL path starts with any value |
+| `urlRegex` | `"/connections/add-new-connection/?$"` | Current URL path matches (auto-anchored with `^`, case-insensitive) |
 | `source` | `"play.grafana.org"` | Request origin matches (regex) |
-| `targetPlatform` | `"cloud"` | Grafana deployment type |
+| `targetPlatform` | `"cloud"` | Grafana deployment type (`"oss"`, `"cloud"`, or `"any"`) |
+| `tag` | `"selected-datasource:prometheus"` | Context tag is present |
+| `userRole` | `"Admin"` | Org role equals value |
+
+The engine also accepts `datasource`, `datasourceIn`, `allDatasources`, `noDatasources`,
+`userRoleIn`, `tagIn`, `allTags`, `cohort`, `cohortIn`, `targetPlatformIn` and `sourceIn`, none
+of which are currently used in this repository. Any name outside that vocabulary is silently
+dropped, which leaves an always-true child — so a typo widens a match instead of narrowing it.
+
+`tag` values come from the plugin's context engine. The ones in use here are
+`selected-datasource:<type>` (a Grafana datasource *type* id, e.g. `prometheus`,
+`yesoreyeram-infinity-datasource`) and `panel-type:<viz>` (e.g. `timeseries`, `logs`, `traces`).
 
 **Combinators:** `and` (all must match), `or` (any must match). Can be nested.
+
+**Scoring matters as much as correctness.** A match expression is scored, not just tested, and
+the recommender returns everything above zero: `and` yields the *fraction* of children that
+matched, while `or` yields 1 or 0. An `and` holding a child that is true regardless of the page
+(`targetPlatform`, `tag`, `userRole`, `datasource`) therefore scores above zero on every page and
+surfaces the guide everywhere. Keep the root of `match` an `or` so scoring stays binary, and make
+sure every `or` branch constrains the URL. Results are sorted on score alone with no tie-break
+and capped at 10, so specificity earns nothing — reducing how many guides match a page is the
+only lever. See
+[.cursor/how-to-write-recommendations.mdc](../.cursor/how-to-write-recommendations.mdc#how-matching-scores)
+for the full rules and `scripts/lint-targeting.py` to check a change.
+
+**Two matchers, different vocabularies.** The recommender service understands every predicate
+above. The plugin's built-in matcher — used when the online recommender is disabled, the OSS
+default — understands only `urlPrefix`, `urlPrefixIn`, `targetPlatform`, `and` and `or`, and
+discards an entry entirely if any other predicate appears anywhere in its tree. `urlRegex`,
+`tag`, `source` and `userRole` are safe for guides that are Cloud-gated regardless; avoid them
+when a guide must also surface on OSS.
 
 ### testEnvironment
 

--- a/drilldown-logs-lj/manifest.json
+++ b/drilldown-logs-lj/manifest.json
@@ -10,12 +10,16 @@
   "startingLocation": "/a/grafana-lokiexplore-app/explore",
   "targeting": {
     "match": {
-      "and": [
+      "or": [
         {
-          "urlPrefix": "/a/grafana-lokiexplore-app/explore"
-        },
-        {
-          "targetPlatform": "cloud"
+          "and": [
+            {
+              "urlPrefix": "/a/grafana-lokiexplore-app/explore"
+            },
+            {
+              "targetPlatform": "cloud"
+            }
+          ]
         }
       ]
     }

--- a/drilldown-metrics-lj/manifest.json
+++ b/drilldown-metrics-lj/manifest.json
@@ -11,12 +11,16 @@
   "startingLocation": "/a/grafana-metricsdrilldown-app/drilldown",
   "targeting": {
     "match": {
-      "and": [
+      "or": [
         {
-          "urlPrefix": "/a/grafana-metricsdrilldown-app/drilldown"
-        },
-        {
-          "targetPlatform": "cloud"
+          "and": [
+            {
+              "urlPrefix": "/a/grafana-metricsdrilldown-app/drilldown"
+            },
+            {
+              "targetPlatform": "cloud"
+            }
+          ]
         }
       ]
     }

--- a/drilldown-traces-lj/manifest.json
+++ b/drilldown-traces-lj/manifest.json
@@ -10,12 +10,16 @@
   "startingLocation": "/a/grafana-exploretraces-app/explore",
   "targeting": {
     "match": {
-      "and": [
+      "or": [
         {
-          "urlPrefix": "/a/grafana-exploretraces-app/explore"
-        },
-        {
-          "targetPlatform": "cloud"
+          "and": [
+            {
+              "urlPrefix": "/a/grafana-exploretraces-app/explore"
+            },
+            {
+              "targetPlatform": "cloud"
+            }
+          ]
         }
       ]
     }

--- a/dynamic-dashboards-tour/manifest.json
+++ b/dynamic-dashboards-tour/manifest.json
@@ -10,9 +10,17 @@
   "startingLocation": "/dashboards",
   "targeting": {
     "match": {
-      "and": [
-        { "source": "learn.grafana.net" },
-        { "urlPrefix": "/dashboards" }
+      "or": [
+        {
+          "and": [
+            {
+              "source": "learn.grafana.net"
+            },
+            {
+              "urlPrefix": "/dashboards"
+            }
+          ]
+        }
       ]
     }
   },

--- a/elasticsearch-logs-lj/manifest.json
+++ b/elasticsearch-logs-lj/manifest.json
@@ -10,20 +10,43 @@
   "startingLocation": "/explore",
   "targeting": {
     "match": {
-      "and": [
+      "or": [
         {
-          "targetPlatform": "cloud"
-        },
-        {
-          "or": [
-            {
-              "urlPrefix": "/explore"
-            },
+          "and": [
             {
               "urlPrefix": "/connections/datasources"
             },
             {
               "tag": "selected-datasource:elasticsearch"
+            },
+            {
+              "targetPlatform": "cloud"
+            }
+          ]
+        },
+        {
+          "and": [
+            {
+              "urlPrefixIn": [
+                "/connections/datasources/elasticsearch",
+                "/connections/add-new-connection/elasticsearch"
+              ]
+            },
+            {
+              "targetPlatform": "cloud"
+            }
+          ]
+        },
+        {
+          "and": [
+            {
+              "urlPrefix": "/explore"
+            },
+            {
+              "tag": "selected-datasource:elasticsearch"
+            },
+            {
+              "targetPlatform": "cloud"
             }
           ]
         }

--- a/enable-coda/manifest.json
+++ b/enable-coda/manifest.json
@@ -10,9 +10,17 @@
   "startingLocation": "/plugins/grafana-pathfinder-app",
   "targeting": {
     "match": {
-      "and": [
-        { "source": "learn.grafana.net" },
-        { "urlPrefix": "/plugins/grafana-pathfinder-app" }
+      "or": [
+        {
+          "and": [
+            {
+              "source": "learn.grafana.net"
+            },
+            {
+              "urlPrefix": "/plugins/grafana-pathfinder-app"
+            }
+          ]
+        }
       ]
     }
   },

--- a/establish-k6-baseline-lj/manifest.json
+++ b/establish-k6-baseline-lj/manifest.json
@@ -10,12 +10,16 @@
   "startingLocation": "/a/k6-app",
   "targeting": {
     "match": {
-      "and": [
+      "or": [
         {
-          "urlPrefix": "/a/k6-app"
-        },
-        {
-          "targetPlatform": "cloud"
+          "and": [
+            {
+              "urlPrefix": "/a/k6-app"
+            },
+            {
+              "targetPlatform": "cloud"
+            }
+          ]
         }
       ]
     }

--- a/explore-cardinality/manifest.json
+++ b/explore-cardinality/manifest.json
@@ -10,16 +10,20 @@
   "startingLocation": "/a/grafana-cmab-app/usage",
   "targeting": {
     "match": {
-      "and": [
+      "or": [
         {
-          "urlPrefixIn": [
-            "/a/grafana-cmab-app",
-            "/a/grafana-cmab-app/usage",
-            "/a/grafana-cmab-app/cardinality"
+          "and": [
+            {
+              "urlPrefixIn": [
+                "/a/grafana-cmab-app",
+                "/a/grafana-cmab-app/usage",
+                "/a/grafana-cmab-app/cardinality"
+              ]
+            },
+            {
+              "targetPlatform": "cloud"
+            }
           ]
-        },
-        {
-          "targetPlatform": "cloud"
         }
       ]
     }

--- a/explore-getting-started/manifest.json
+++ b/explore-getting-started/manifest.json
@@ -11,9 +11,17 @@
   "startingLocation": "/explore",
   "targeting": {
     "match": {
-      "and": [
-        { "targetPlatform": "cloud" },
-        { "urlPrefix": "/explore" }
+      "or": [
+        {
+          "and": [
+            {
+              "targetPlatform": "cloud"
+            },
+            {
+              "urlPrefix": "/explore"
+            }
+          ]
+        }
       ]
     }
   },

--- a/find-and-investigate-your-first-insight-ml8n/manifest.json
+++ b/find-and-investigate-your-first-insight-ml8n/manifest.json
@@ -10,12 +10,16 @@
   "startingLocation": "/a/grafana-asserts-app/catalog",
   "targeting": {
     "match": {
-      "and": [
+      "or": [
         {
-          "urlPrefix": "/a/grafana-asserts-app/catalog"
-        },
-        {
-          "targetPlatform": "cloud"
+          "and": [
+            {
+              "urlPrefix": "/a/grafana-asserts-app/catalog"
+            },
+            {
+              "targetPlatform": "cloud"
+            }
+          ]
         }
       ]
     }

--- a/find-k6-limits-lj/manifest.json
+++ b/find-k6-limits-lj/manifest.json
@@ -10,12 +10,16 @@
   "startingLocation": "/a/k6-app",
   "targeting": {
     "match": {
-      "and": [
+      "or": [
         {
-          "urlPrefix": "/a/k6-app"
-        },
-        {
-          "targetPlatform": "cloud"
+          "and": [
+            {
+              "urlPrefix": "/a/k6-app"
+            },
+            {
+              "targetPlatform": "cloud"
+            }
+          ]
         }
       ]
     }

--- a/first-dashboard/manifest.json
+++ b/first-dashboard/manifest.json
@@ -9,9 +9,12 @@
   "startingLocation": "/dashboards",
   "targeting": {
     "match": {
-      "and": [
+      "or": [
         {
-          "urlPrefix": "/dashboards"
+          "urlPrefixIn": [
+            "/dashboards",
+            "/dashboard/new"
+          ]
         }
       ]
     }

--- a/fleet-management-onboarding/manifest.json
+++ b/fleet-management-onboarding/manifest.json
@@ -10,9 +10,17 @@
   "startingLocation": "/a/grafana-collector-app",
   "targeting": {
     "match": {
-      "and": [
-        { "source": "learn.grafana.net" },
-        { "urlPrefix": "/a/grafana-collector-app" }
+      "or": [
+        {
+          "and": [
+            {
+              "source": "learn.grafana.net"
+            },
+            {
+              "urlPrefix": "/a/grafana-collector-app"
+            }
+          ]
+        }
       ]
     }
   },

--- a/fleet-mgt-monitor-health-lj/manifest.json
+++ b/fleet-mgt-monitor-health-lj/manifest.json
@@ -9,12 +9,16 @@
   "startingLocation": "/a/grafana-collector-app/fleet-management",
   "targeting": {
     "match": {
-      "and": [
+      "or": [
         {
-          "urlPrefix": "/a/grafana-collector-app/fleet-management"
-        },
-        {
-          "targetPlatform": "cloud"
+          "and": [
+            {
+              "urlPrefix": "/a/grafana-collector-app/fleet-management"
+            },
+            {
+              "targetPlatform": "cloud"
+            }
+          ]
         }
       ]
     }

--- a/fleet-mgt-staged-rollout-lj/manifest.json
+++ b/fleet-mgt-staged-rollout-lj/manifest.json
@@ -9,10 +9,20 @@
   "startingLocation": "/a/grafana-collector-app/fleet-management",
   "targeting": {
     "match": {
-      "and": [
-        { "urlPrefix": "/a/grafana-collector-app/fleet-management" },
-        { "targetPlatform": "cloud" },
-        { "userRole": "Admin" }
+      "or": [
+        {
+          "and": [
+            {
+              "urlPrefix": "/a/grafana-collector-app/fleet-management"
+            },
+            {
+              "targetPlatform": "cloud"
+            },
+            {
+              "userRole": "Admin"
+            }
+          ]
+        }
       ]
     }
   },

--- a/get-started-grafana-assistant-lj/manifest.json
+++ b/get-started-grafana-assistant-lj/manifest.json
@@ -11,12 +11,16 @@
   "startingLocation": "/plugins/grafana-assistant-app",
   "targeting": {
     "match": {
-      "and": [
+      "or": [
         {
-          "urlPrefix": "/plugins/grafana-assistant-app"
-        },
-        {
-          "targetPlatform": "cloud"
+          "and": [
+            {
+              "urlPrefix": "/plugins/grafana-assistant-app"
+            },
+            {
+              "targetPlatform": "cloud"
+            }
+          ]
         }
       ]
     }

--- a/git-sync-dashboards-lj/manifest.json
+++ b/git-sync-dashboards-lj/manifest.json
@@ -14,37 +14,17 @@
         {
           "and": [
             {
-              "urlPrefix": "/dashboards"
-            },
-            {
-              "targetPlatform": "cloud"
-            }
-          ]
-        },
-        {
-          "and": [
-            {
-              "urlPrefix": "/d/"
-            },
-            {
-              "targetPlatform": "cloud"
-            }
-          ]
-        },
-        {
-          "and": [
-            {
-              "urlPrefix": "/dashboard/"
-            },
-            {
-              "targetPlatform": "cloud"
-            }
-          ]
-        },
-        {
-          "and": [
-            {
               "urlPrefix": "/admin/provisioning"
+            },
+            {
+              "targetPlatform": "cloud"
+            }
+          ]
+        },
+        {
+          "and": [
+            {
+              "urlPrefix": "/dashboard/new"
             },
             {
               "targetPlatform": "cloud"

--- a/git-sync-guide/manifest.json
+++ b/git-sync-guide/manifest.json
@@ -10,12 +10,22 @@
   "startingLocation": "/admin/provisioning",
   "targeting": {
     "match": {
-      "and": [
-        { "source": "learn.grafana.net" },
+      "or": [
         {
-          "or": [
-            { "urlPrefix": "/admin/provisioning" },
-            { "urlPrefix": "/dashboards" }
+          "and": [
+            {
+              "source": "learn.grafana.net"
+            },
+            {
+              "or": [
+                {
+                  "urlPrefix": "/admin/provisioning"
+                },
+                {
+                  "urlPrefix": "/dashboards"
+                }
+              ]
+            }
           ]
         }
       ]

--- a/git-sync-use-lp/manifest.json
+++ b/git-sync-use-lp/manifest.json
@@ -7,15 +7,19 @@
     "name": "grafana-docs",
     "team": "Grafana Documentation"
   },
-  "startingLocation": "/",
+  "startingLocation": "/admin/provisioning",
   "targeting": {
     "match": {
-      "and": [
+      "or": [
         {
-          "urlPrefix": "/"
-        },
-        {
-          "targetPlatform": "cloud"
+          "and": [
+            {
+              "urlPrefix": "/admin/provisioning"
+            },
+            {
+              "targetPlatform": "cloud"
+            }
+          ]
         }
       ]
     }

--- a/github-data-source-lj/manifest.json
+++ b/github-data-source-lj/manifest.json
@@ -7,10 +7,14 @@
     "name": "chri2547",
     "team": "Grafana Documentation"
   },
-  "startingLocation": "/add-new-connection",
+  "startingLocation": "/connections/add-new-connection/github",
   "targeting": {
     "match": {
-      "urlPrefix": "/add-new-connection"
+      "or": [
+        {
+          "urlPrefix": "/connections/add-new-connection/github"
+        }
+      ]
     }
   },
   "testEnvironment": {

--- a/github-visualize-lj/manifest.json
+++ b/github-visualize-lj/manifest.json
@@ -10,7 +10,21 @@
   "startingLocation": "/dashboards",
   "targeting": {
     "match": {
-      "urlPrefix": "/dashboards"
+      "or": [
+        {
+          "and": [
+            {
+              "urlPrefix": "/connections/datasources"
+            },
+            {
+              "tag": "selected-datasource:grafana-github-datasource"
+            }
+          ]
+        },
+        {
+          "urlPrefix": "/connections/add-new-connection/github"
+        }
+      ]
     }
   },
   "testEnvironment": {

--- a/grafana-13-tour-learn/manifest.json
+++ b/grafana-13-tour-learn/manifest.json
@@ -7,12 +7,16 @@
   "startingLocation": "/d/ja6hlhh/welcome-to-learn-grafana",
   "targeting": {
     "match": {
-      "and": [
+      "or": [
         {
-          "urlPrefix": "/d/ja6hlhh/welcome-to-learn-grafana"
-        },
-        {
-          "source": "learn.grafana.net"
+          "and": [
+            {
+              "urlPrefix": "/d/ja6hlhh/welcome-to-learn-grafana"
+            },
+            {
+              "source": "learn.grafana.net"
+            }
+          ]
         }
       ]
     }

--- a/grafana-13-tour-play/manifest.json
+++ b/grafana-13-tour-play/manifest.json
@@ -7,12 +7,16 @@
   "startingLocation": "/d/to6j8mh/grafana-play-home",
   "targeting": {
     "match": {
-      "and": [
+      "or": [
         {
-          "urlPrefix": "/d/to6j8mh/grafana-play-home"
-        },
-        {
-          "source": "play.grafana.org"
+          "and": [
+            {
+              "urlPrefix": "/d/to6j8mh/grafana-play-home"
+            },
+            {
+              "source": "play.grafana.org"
+            }
+          ]
         }
       ]
     }

--- a/grafana-cloud-onboarding-lj/manifest.json
+++ b/grafana-cloud-onboarding-lj/manifest.json
@@ -10,15 +10,19 @@
   "startingLocation": "/a/cloud-home-app",
   "targeting": {
     "match": {
-      "and": [
+      "or": [
         {
-          "urlPrefixIn": [
-            "/a/cloud-home-app",
-            "/a/grafana-setupguide-app/getting-started"
+          "and": [
+            {
+              "urlPrefixIn": [
+                "/a/cloud-home-app",
+                "/a/grafana-setupguide-app/getting-started"
+              ]
+            },
+            {
+              "targetPlatform": "cloud"
+            }
           ]
-        },
-        {
-          "targetPlatform": "cloud"
         }
       ]
     }

--- a/grafana-cloud-tour-lj/manifest.json
+++ b/grafana-cloud-tour-lj/manifest.json
@@ -10,15 +10,19 @@
   "startingLocation": "/a/cloud-home-app",
   "targeting": {
     "match": {
-      "and": [
+      "or": [
         {
-          "urlPrefixIn": [
-            "/a/cloud-home-app",
-            "/a/grafana-setupguide-app/getting-started"
+          "and": [
+            {
+              "urlPrefixIn": [
+                "/a/cloud-home-app",
+                "/a/grafana-setupguide-app/getting-started"
+              ]
+            },
+            {
+              "targetPlatform": "cloud"
+            }
           ]
-        },
-        {
-          "targetPlatform": "cloud"
         }
       ]
     }

--- a/grafana-irm-configuration-lj/manifest.json
+++ b/grafana-irm-configuration-lj/manifest.json
@@ -10,15 +10,19 @@
   "startingLocation": "/a/grafana-irm-app",
   "targeting": {
     "match": {
-      "and": [
+      "or": [
         {
-          "urlPrefixIn": [
-            "/a/grafana-irm-app",
-            "/alerting"
+          "and": [
+            {
+              "urlPrefixIn": [
+                "/a/grafana-irm-app",
+                "/alerting"
+              ]
+            },
+            {
+              "targetPlatform": "cloud"
+            }
           ]
-        },
-        {
-          "targetPlatform": "cloud"
         }
       ]
     }

--- a/haproxy-load-balancer-lj/manifest.json
+++ b/haproxy-load-balancer-lj/manifest.json
@@ -10,15 +10,16 @@
   "startingLocation": "/connections/add-new-connection/haproxy",
   "targeting": {
     "match": {
-      "and": [
+      "or": [
         {
-          "urlPrefixIn": [
-            "/connections/add-new-connection/haproxy",
-            "/connections/infrastructure"
+          "and": [
+            {
+              "urlPrefix": "/connections/add-new-connection/haproxy"
+            },
+            {
+              "targetPlatform": "cloud"
+            }
           ]
-        },
-        {
-          "targetPlatform": "cloud"
         }
       ]
     }

--- a/how-to-import-external-alerting-resource-5e08/manifest.json
+++ b/how-to-import-external-alerting-resource-5e08/manifest.json
@@ -10,9 +10,17 @@
   "startingLocation": "/alerting",
   "targeting": {
     "match": {
-      "and": [
-        { "source": "learn.grafana.net" },
-        { "urlPrefix": "/alerting" }
+      "or": [
+        {
+          "and": [
+            {
+              "source": "learn.grafana.net"
+            },
+            {
+              "urlPrefix": "/alerting"
+            }
+          ]
+        }
       ]
     }
   },

--- a/how-to-setup-secrets-tutorial/manifest.json
+++ b/how-to-setup-secrets-tutorial/manifest.json
@@ -10,9 +10,17 @@
   "startingLocation": "/a/grafana-synthetic-monitoring-app",
   "targeting": {
     "match": {
-      "and": [
-        { "targetPlatform": "cloud" },
-        { "urlPrefix": "/a/grafana-synthetic-monitoring-app" }
+      "or": [
+        {
+          "and": [
+            {
+              "targetPlatform": "cloud"
+            },
+            {
+              "urlPrefix": "/a/grafana-synthetic-monitoring-app"
+            }
+          ]
+        }
       ]
     }
   },

--- a/iis-web-server-lj/manifest.json
+++ b/iis-web-server-lj/manifest.json
@@ -10,15 +10,16 @@
   "startingLocation": "/connections/add-new-connection/microsoft-iis",
   "targeting": {
     "match": {
-      "and": [
+      "or": [
         {
-          "urlPrefixIn": [
-            "/connections/add-new-connection/microsoft-iis",
-            "/connections/infrastructure"
+          "and": [
+            {
+              "urlPrefix": "/connections/add-new-connection/microsoft-iis"
+            },
+            {
+              "targetPlatform": "cloud"
+            }
           ]
-        },
-        {
-          "targetPlatform": "cloud"
         }
       ]
     }

--- a/infinity-csv-lj/manifest.json
+++ b/infinity-csv-lj/manifest.json
@@ -10,15 +10,19 @@
   "startingLocation": "/connections/datasources",
   "targeting": {
     "match": {
-      "and": [
+      "or": [
         {
-          "urlPrefix": "/connections/datasources"
-        },
-        {
-          "targetPlatform": "cloud"
-        },
-        {
-          "tag": "selected-datasource:yesoreyeram-infinity-datasource"
+          "and": [
+            {
+              "urlPrefix": "/connections/datasources"
+            },
+            {
+              "targetPlatform": "cloud"
+            },
+            {
+              "tag": "selected-datasource:yesoreyeram-infinity-datasource"
+            }
+          ]
         }
       ]
     }

--- a/infinity-json-lj/manifest.json
+++ b/infinity-json-lj/manifest.json
@@ -7,7 +7,31 @@
   "startingLocation": "/connections/datasources",
   "targeting": {
     "match": {
-      "and": [{ "urlPrefix": "/connections" }, { "targetPlatform": "cloud" }]
+      "or": [
+        {
+          "and": [
+            {
+              "urlPrefix": "/connections/add-new-connection/infinity"
+            },
+            {
+              "targetPlatform": "cloud"
+            }
+          ]
+        },
+        {
+          "and": [
+            {
+              "urlPrefix": "/connections/datasources"
+            },
+            {
+              "tag": "selected-datasource:yesoreyeram-infinity-datasource"
+            },
+            {
+              "targetPlatform": "cloud"
+            }
+          ]
+        }
+      ]
     }
   },
   "testEnvironment": { "tier": "cloud" },

--- a/influxdb-data-source-lj/manifest.json
+++ b/influxdb-data-source-lj/manifest.json
@@ -10,27 +10,40 @@
   "startingLocation": "/connections/datasources/influxdb",
   "targeting": {
     "match": {
-      "and": [
+      "or": [
         {
-          "targetPlatform": "cloud"
+          "and": [
+            {
+              "urlPrefix": "/connections/datasources"
+            },
+            {
+              "tag": "selected-datasource:influxdb"
+            },
+            {
+              "targetPlatform": "cloud"
+            }
+          ]
         },
         {
-          "or": [
+          "and": [
             {
-              "and": [
-                {
-                  "urlPrefix": "/connections/datasources"
-                },
-                {
-                  "tag": "selected-datasource:influxdb"
-                }
+              "urlPrefixIn": [
+                "/connections/datasources/influxdb",
+                "/connections/add-new-connection/influxdb"
               ]
             },
             {
-              "urlPrefix": "/connections/datasources/influxdb"
+              "targetPlatform": "cloud"
+            }
+          ]
+        },
+        {
+          "and": [
+            {
+              "urlRegex": "/connections/add-new-connection/?$"
             },
             {
-              "urlPrefix": "/connections/add-new-connection"
+              "targetPlatform": "cloud"
             }
           ]
         }

--- a/infrastructure-alerting-lj/manifest.json
+++ b/infrastructure-alerting-lj/manifest.json
@@ -10,12 +10,16 @@
   "startingLocation": "/alerting",
   "targeting": {
     "match": {
-      "and": [
+      "or": [
         {
-          "urlPrefix": "/alerting"
-        },
-        {
-          "targetPlatform": "cloud"
+          "and": [
+            {
+              "urlPrefix": "/alerting"
+            },
+            {
+              "targetPlatform": "cloud"
+            }
+          ]
         }
       ]
     }

--- a/interactive-dashboards-lj/manifest.json
+++ b/interactive-dashboards-lj/manifest.json
@@ -14,14 +14,12 @@
       "or": [
         {
           "and": [
-            { "urlPrefix": "/dashboards" },
-            { "targetPlatform": "cloud" }
-          ]
-        },
-        {
-          "and": [
-            { "urlPrefix": "/d/" },
-            { "targetPlatform": "cloud" }
+            {
+              "urlPrefix": "/d/"
+            },
+            {
+              "targetPlatform": "cloud"
+            }
           ]
         }
       ]

--- a/k6-extensions-grafana-cloud/manifest.json
+++ b/k6-extensions-grafana-cloud/manifest.json
@@ -10,9 +10,17 @@
   "startingLocation": "/a/k6-app",
   "targeting": {
     "match": {
-      "and": [
-        { "source": "learn.grafana.net" },
-        { "urlPrefix": "/a/k6-app" }
+      "or": [
+        {
+          "and": [
+            {
+              "source": "learn.grafana.net"
+            },
+            {
+              "urlPrefix": "/a/k6-app"
+            }
+          ]
+        }
       ]
     }
   },

--- a/k6-script-authoring-assistant-lj/manifest.json
+++ b/k6-script-authoring-assistant-lj/manifest.json
@@ -10,9 +10,17 @@
   "startingLocation": "/a/k6-app",
   "targeting": {
     "match": {
-      "and": [
-        { "urlPrefix": "/a/k6-app" },
-        { "targetPlatform": "cloud" }
+      "or": [
+        {
+          "and": [
+            {
+              "urlPrefix": "/a/k6-app"
+            },
+            {
+              "targetPlatform": "cloud"
+            }
+          ]
+        }
       ]
     }
   },

--- a/k6-soak-testing-lj/manifest.json
+++ b/k6-soak-testing-lj/manifest.json
@@ -10,12 +10,16 @@
   "startingLocation": "/a/k6-app",
   "targeting": {
     "match": {
-      "and": [
+      "or": [
         {
-          "urlPrefix": "/a/k6-app"
-        },
-        {
-          "targetPlatform": "cloud"
+          "and": [
+            {
+              "urlPrefix": "/a/k6-app"
+            },
+            {
+              "targetPlatform": "cloud"
+            }
+          ]
         }
       ]
     }

--- a/k6-spike-testing-lp/manifest.json
+++ b/k6-spike-testing-lp/manifest.json
@@ -7,15 +7,19 @@
     "name": "grafana-docs",
     "team": "Grafana Documentation"
   },
-  "startingLocation": "/",
+  "startingLocation": "/a/k6-app",
   "targeting": {
     "match": {
-      "and": [
+      "or": [
         {
-          "urlPrefix": "/"
-        },
-        {
-          "targetPlatform": "cloud"
+          "and": [
+            {
+              "urlPrefix": "/a/k6-app"
+            },
+            {
+              "targetPlatform": "cloud"
+            }
+          ]
         }
       ]
     }

--- a/k8s-cpu/manifest.json
+++ b/k8s-cpu/manifest.json
@@ -10,9 +10,17 @@
   "startingLocation": "/a/grafana-k8s-app",
   "targeting": {
     "match": {
-      "and": [
-        { "urlPrefix": "/a/grafana-k8s-app" },
-        { "source": "play.grafana.org" }
+      "or": [
+        {
+          "and": [
+            {
+              "urlPrefix": "/a/grafana-k8s-app"
+            },
+            {
+              "source": "play.grafana.org"
+            }
+          ]
+        }
       ]
     }
   },

--- a/k8s-mem/manifest.json
+++ b/k8s-mem/manifest.json
@@ -10,9 +10,17 @@
   "startingLocation": "/a/grafana-k8s-app",
   "targeting": {
     "match": {
-      "and": [
-        { "urlPrefix": "/a/grafana-k8s-app" },
-        { "source": "play.grafana.org" }
+      "or": [
+        {
+          "and": [
+            {
+              "urlPrefix": "/a/grafana-k8s-app"
+            },
+            {
+              "source": "play.grafana.org"
+            }
+          ]
+        }
       ]
     }
   },

--- a/kafka-monitoring-lj/manifest.json
+++ b/kafka-monitoring-lj/manifest.json
@@ -10,22 +10,23 @@
   "startingLocation": "/connections/add-new-connection/kafka",
   "targeting": {
     "match": {
-      "and": [
+      "or": [
         {
-          "or": [
+          "and": [
             {
-              "urlPrefixIn": [
-                "/connections/add-new-connection/kafka",
-                "/connections/infrastructure"
+              "or": [
+                {
+                  "urlPrefix": "/connections/add-new-connection/kafka"
+                },
+                {
+                  "urlRegex": "/connections/add-new-connection/?$"
+                }
               ]
             },
             {
-              "urlRegex": "/connections/add-new-connection/?$"
+              "targetPlatform": "cloud"
             }
           ]
-        },
-        {
-          "targetPlatform": "cloud"
         }
       ]
     }

--- a/knowledge-graph-guide/manifest.json
+++ b/knowledge-graph-guide/manifest.json
@@ -10,14 +10,28 @@
   "startingLocation": "/a/grafana-asserts-app/catalog",
   "targeting": {
     "match": {
-      "and": [
-        { "source": "learn.grafana.net" },
+      "or": [
         {
-          "or": [
-            { "urlPrefix": "/a/grafana-asserts-app/catalog" },
-            { "urlPrefix": "/a/grafana-asserts-app/assertions" },
-            { "urlPrefix": "/a/grafana-asserts-app/entities" },
-            { "urlPrefix": "/observability" }
+          "and": [
+            {
+              "source": "learn.grafana.net"
+            },
+            {
+              "or": [
+                {
+                  "urlPrefix": "/a/grafana-asserts-app/catalog"
+                },
+                {
+                  "urlPrefix": "/a/grafana-asserts-app/assertions"
+                },
+                {
+                  "urlPrefix": "/a/grafana-asserts-app/entities"
+                },
+                {
+                  "urlPrefix": "/observability"
+                }
+              ]
+            }
           ]
         }
       ]

--- a/kubernetes-lp/manifest.json
+++ b/kubernetes-lp/manifest.json
@@ -7,15 +7,19 @@
     "name": "grafana-docs",
     "team": "Grafana Documentation"
   },
-  "startingLocation": "/",
+  "startingLocation": "/a/grafana-k8s-app",
   "targeting": {
     "match": {
-      "and": [
+      "or": [
         {
-          "urlPrefix": "/"
-        },
-        {
-          "targetPlatform": "cloud"
+          "and": [
+            {
+              "urlPrefix": "/a/grafana-k8s-app"
+            },
+            {
+              "targetPlatform": "cloud"
+            }
+          ]
         }
       ]
     }

--- a/linux-server-integration-lj/manifest.json
+++ b/linux-server-integration-lj/manifest.json
@@ -10,22 +10,23 @@
   "startingLocation": "/connections/add-new-connection/linux-node",
   "targeting": {
     "match": {
-      "and": [
+      "or": [
         {
-          "or": [
+          "and": [
             {
-              "urlPrefixIn": [
-                "/connections/add-new-connection/linux-node",
-                "/connections/infrastructure"
+              "or": [
+                {
+                  "urlPrefix": "/connections/add-new-connection/linux-node"
+                },
+                {
+                  "urlRegex": "/connections/add-new-connection/?$"
+                }
               ]
             },
             {
-              "urlRegex": "/connections/add-new-connection/?$"
+              "targetPlatform": "cloud"
             }
           ]
-        },
-        {
-          "targetPlatform": "cloud"
         }
       ]
     }

--- a/macos-integration-lj/manifest.json
+++ b/macos-integration-lj/manifest.json
@@ -10,15 +10,16 @@
   "startingLocation": "/connections/add-new-connection/macos-node",
   "targeting": {
     "match": {
-      "and": [
+      "or": [
         {
-          "urlPrefixIn": [
-            "/connections/add-new-connection/macos-node",
-            "/connections/infrastructure"
+          "and": [
+            {
+              "urlPrefix": "/connections/add-new-connection/macos-node"
+            },
+            {
+              "targetPlatform": "cloud"
+            }
           ]
-        },
-        {
-          "targetPlatform": "cloud"
         }
       ]
     }

--- a/mongodb-integration-lj/manifest.json
+++ b/mongodb-integration-lj/manifest.json
@@ -7,16 +7,16 @@
   "startingLocation": "/connections/add-new-connection/mongodb",
   "targeting": {
     "match": {
-      "and": [
+      "or": [
         {
-          "urlPrefixIn": [
-            "/connections/add-new-connection/mongodb",
-            "/connections/infrastructure",
-            "/connections/add-new-connection"
+          "and": [
+            {
+              "urlPrefix": "/connections/add-new-connection/mongodb"
+            },
+            {
+              "targetPlatform": "cloud"
+            }
           ]
-        },
-        {
-          "targetPlatform": "cloud"
         }
       ]
     }

--- a/monitor-aws-resources-lj/manifest.json
+++ b/monitor-aws-resources-lj/manifest.json
@@ -10,16 +10,20 @@
   "startingLocation": "/a/grafana-csp-app/aws",
   "targeting": {
     "match": {
-      "and": [
+      "or": [
         {
-          "urlPrefixIn": [
-            "/a/grafana-csp-app/aws",
-            "/a/grafana-csp-app/aws/overview",
-            "/a/grafana-csp-app/aws/configuration"
+          "and": [
+            {
+              "urlPrefixIn": [
+                "/a/grafana-csp-app/aws",
+                "/a/grafana-csp-app/aws/overview",
+                "/a/grafana-csp-app/aws/configuration"
+              ]
+            },
+            {
+              "targetPlatform": "cloud"
+            }
           ]
-        },
-        {
-          "targetPlatform": "cloud"
         }
       ]
     }

--- a/monitor-azure-resources-lj/manifest.json
+++ b/monitor-azure-resources-lj/manifest.json
@@ -10,16 +10,20 @@
   "startingLocation": "/a/grafana-csp-app/azure",
   "targeting": {
     "match": {
-      "and": [
+      "or": [
         {
-          "urlPrefixIn": [
-            "/a/grafana-csp-app/azure",
-            "/a/grafana-csp-app/azure/overview",
-            "/a/grafana-csp-app/azure/configuration"
+          "and": [
+            {
+              "urlPrefixIn": [
+                "/a/grafana-csp-app/azure",
+                "/a/grafana-csp-app/azure/overview",
+                "/a/grafana-csp-app/azure/configuration"
+              ]
+            },
+            {
+              "targetPlatform": "cloud"
+            }
           ]
-        },
-        {
-          "targetPlatform": "cloud"
         }
       ]
     }

--- a/monitor-infrastructure-grot/manifest.json
+++ b/monitor-infrastructure-grot/manifest.json
@@ -10,12 +10,16 @@
   "startingLocation": "/connections/infrastructure",
   "targeting": {
     "match": {
-      "and": [
+      "or": [
         {
-          "urlPrefix": "/connections/infrastructure"
-        },
-        {
-          "targetPlatform": "cloud"
+          "and": [
+            {
+              "urlPrefix": "/connections/infrastructure"
+            },
+            {
+              "targetPlatform": "cloud"
+            }
+          ]
         }
       ]
     }

--- a/mysql-data-source-lj/manifest.json
+++ b/mysql-data-source-lj/manifest.json
@@ -10,29 +10,33 @@
   "startingLocation": "/connections/datasources",
   "targeting": {
     "match": {
-      "and": [
+      "or": [
         {
-          "or": [
+          "and": [
             {
-              "and": [
+              "or": [
                 {
-                  "urlPrefix": "/connections/datasources"
+                  "and": [
+                    {
+                      "urlPrefix": "/connections/datasources"
+                    },
+                    {
+                      "tag": "selected-datasource:mysql"
+                    }
+                  ]
                 },
                 {
-                  "tag": "selected-datasource:mysql"
+                  "urlPrefix": "/connections/datasources/mysql"
+                },
+                {
+                  "urlRegex": "/connections/add-new-connection/?$"
                 }
               ]
             },
             {
-              "urlPrefix": "/connections/datasources/mysql"
-            },
-            {
-              "urlRegex": "/connections/add-new-connection/?$"
+              "targetPlatform": "cloud"
             }
           ]
-        },
-        {
-          "targetPlatform": "cloud"
         }
       ]
     }

--- a/mysql-db-olly-lj/manifest.json
+++ b/mysql-db-olly-lj/manifest.json
@@ -10,15 +10,19 @@
   "startingLocation": "/a/grafana-dbo11y-app",
   "targeting": {
     "match": {
-      "and": [
+      "or": [
         {
-          "urlPrefixIn": [
-            "/a/grafana-dbo11y-app",
-            "/a/grafana-dbo11y-app/configuration"
+          "and": [
+            {
+              "urlPrefixIn": [
+                "/a/grafana-dbo11y-app",
+                "/a/grafana-dbo11y-app/configuration"
+              ]
+            },
+            {
+              "targetPlatform": "cloud"
+            }
           ]
-        },
-        {
-          "targetPlatform": "cloud"
         }
       ]
     }

--- a/mysql-integration-lj/manifest.json
+++ b/mysql-integration-lj/manifest.json
@@ -10,15 +10,16 @@
   "startingLocation": "/connections/add-new-connection/mysql",
   "targeting": {
     "match": {
-      "and": [
+      "or": [
         {
-          "urlPrefixIn": [
-            "/connections/add-new-connection/mysql",
-            "/connections/infrastructure"
+          "and": [
+            {
+              "urlPrefix": "/connections/add-new-connection/mysql"
+            },
+            {
+              "targetPlatform": "cloud"
+            }
           ]
-        },
-        {
-          "targetPlatform": "cloud"
         }
       ]
     }

--- a/otel-fleet-management/manifest.json
+++ b/otel-fleet-management/manifest.json
@@ -10,9 +10,17 @@
   "startingLocation": "/a/grafana-collector-app/fleet-management",
   "targeting": {
     "match": {
-      "and": [
-        { "source": "learn.grafana.net" },
-        { "urlPrefix": "/a/grafana-collector-app" }
+      "or": [
+        {
+          "and": [
+            {
+              "source": "learn.grafana.net"
+            },
+            {
+              "urlPrefix": "/a/grafana-collector-app"
+            }
+          ]
+        }
       ]
     }
   },

--- a/play-5k-run-results/manifest.json
+++ b/play-5k-run-results/manifest.json
@@ -13,9 +13,17 @@
   "startingLocation": "/d/sixn5pn/analyzing-5k-run-results",
   "targeting": {
     "match": {
-      "and": [
-        { "urlPrefix": "/d/sixn5pn/analyzing-5k-run-results" },
-        { "source": "play.grafana.org" }
+      "or": [
+        {
+          "and": [
+            {
+              "urlPrefix": "/d/sixn5pn/analyzing-5k-run-results"
+            },
+            {
+              "source": "play.grafana.org"
+            }
+          ]
+        }
       ]
     }
   },

--- a/play-carbon-intensity/manifest.json
+++ b/play-carbon-intensity/manifest.json
@@ -10,9 +10,17 @@
   "startingLocation": "/d/siw7lpj/uk-carbon-intensity",
   "targeting": {
     "match": {
-      "and": [
-        { "urlPrefix": "/d/siw7lpj/uk-carbon-intensity" },
-        { "source": "play.grafana.org" }
+      "or": [
+        {
+          "and": [
+            {
+              "urlPrefix": "/d/siw7lpj/uk-carbon-intensity"
+            },
+            {
+              "source": "play.grafana.org"
+            }
+          ]
+        }
       ]
     }
   },

--- a/play-cheerlights/manifest.json
+++ b/play-cheerlights/manifest.json
@@ -13,9 +13,17 @@
   "startingLocation": "/d/c1467936-aba3-4550-8694-3fd66198ecc2/cheerlights",
   "targeting": {
     "match": {
-      "and": [
-        { "urlPrefix": "/d/c1467936-aba3-4550-8694-3fd66198ecc2/cheerlights" },
-        { "source": "play.grafana.org" }
+      "or": [
+        {
+          "and": [
+            {
+              "urlPrefix": "/d/c1467936-aba3-4550-8694-3fd66198ecc2/cheerlights"
+            },
+            {
+              "source": "play.grafana.org"
+            }
+          ]
+        }
       ]
     }
   },

--- a/play-chicago-l-trains-tour/manifest.json
+++ b/play-chicago-l-trains-tour/manifest.json
@@ -13,9 +13,17 @@
   "startingLocation": "/d/siwlw7f/chicago-l-trains",
   "targeting": {
     "match": {
-      "and": [
-        { "urlPrefix": "/d/siwlw7f/chicago-l-trains" },
-        { "source": "play.grafana.org" }
+      "or": [
+        {
+          "and": [
+            {
+              "urlPrefix": "/d/siwlw7f/chicago-l-trains"
+            },
+            {
+              "source": "play.grafana.org"
+            }
+          ]
+        }
       ]
     }
   },

--- a/play-eurovision-tour/manifest.json
+++ b/play-eurovision-tour/manifest.json
@@ -13,9 +13,17 @@
   "startingLocation": "/d/eurovision/eurovision-2026",
   "targeting": {
     "match": {
-      "and": [
-        { "urlPrefix": "/d/eurovision/eurovision-2026" },
-        { "source": "play.grafana.org" }
+      "or": [
+        {
+          "and": [
+            {
+              "urlPrefix": "/d/eurovision/eurovision-2026"
+            },
+            {
+              "source": "play.grafana.org"
+            }
+          ]
+        }
       ]
     }
   },

--- a/play-gb-railway-usage/manifest.json
+++ b/play-gb-railway-usage/manifest.json
@@ -13,9 +13,17 @@
   "startingLocation": "/d/sixtbqt/great-britain-railway-station-usage",
   "targeting": {
     "match": {
-      "and": [
-        { "urlPrefix": "/d/sixtbqt/great-britain-railway-station-usage" },
-        { "source": "play.grafana.org" }
+      "or": [
+        {
+          "and": [
+            {
+              "urlPrefix": "/d/sixtbqt/great-britain-railway-station-usage"
+            },
+            {
+              "source": "play.grafana.org"
+            }
+          ]
+        }
       ]
     }
   },

--- a/play-nz-geonet-tour/manifest.json
+++ b/play-nz-geonet-tour/manifest.json
@@ -13,9 +13,17 @@
   "startingLocation": "/d/simgmgk/new-zealand-geonet",
   "targeting": {
     "match": {
-      "and": [
-        { "urlPrefix": "/d/simgmgk/new-zealand-geonet" },
-        { "source": "play.grafana.org" }
+      "or": [
+        {
+          "and": [
+            {
+              "urlPrefix": "/d/simgmgk/new-zealand-geonet"
+            },
+            {
+              "source": "play.grafana.org"
+            }
+          ]
+        }
       ]
     }
   },

--- a/play-traitors-uk-tour/manifest.json
+++ b/play-traitors-uk-tour/manifest.json
@@ -10,9 +10,17 @@
   "startingLocation": "/d/siqtdwm/the-traitors-uk-series-4",
   "targeting": {
     "match": {
-      "and": [
-        { "urlPrefix": "/d/siqtdwm/the-traitors-uk-series-4" },
-        { "source": "play.grafana.org" }
+      "or": [
+        {
+          "and": [
+            {
+              "urlPrefix": "/d/siqtdwm/the-traitors-uk-series-4"
+            },
+            {
+              "source": "play.grafana.org"
+            }
+          ]
+        }
       ]
     }
   },

--- a/postgresql-db-olly-lj/manifest.json
+++ b/postgresql-db-olly-lj/manifest.json
@@ -10,15 +10,19 @@
   "startingLocation": "/a/grafana-dbo11y-app",
   "targeting": {
     "match": {
-      "and": [
+      "or": [
         {
-          "urlPrefixIn": [
-            "/a/grafana-dbo11y-app",
-            "/a/grafana-dbo11y-app/configuration"
+          "and": [
+            {
+              "urlPrefixIn": [
+                "/a/grafana-dbo11y-app",
+                "/a/grafana-dbo11y-app/configuration"
+              ]
+            },
+            {
+              "targetPlatform": "cloud"
+            }
           ]
-        },
-        {
-          "targetPlatform": "cloud"
         }
       ]
     }

--- a/postgresql-integration-lj/manifest.json
+++ b/postgresql-integration-lj/manifest.json
@@ -10,22 +10,23 @@
   "startingLocation": "/connections/add-new-connection/postgres",
   "targeting": {
     "match": {
-      "and": [
+      "or": [
         {
-          "or": [
+          "and": [
             {
-              "urlPrefixIn": [
-                "/connections/add-new-connection/postgres",
-                "/connections/infrastructure"
+              "or": [
+                {
+                  "urlPrefix": "/connections/add-new-connection/postgres"
+                },
+                {
+                  "urlRegex": "/connections/add-new-connection/?$"
+                }
               ]
             },
             {
-              "urlRegex": "/connections/add-new-connection/?$"
+              "targetPlatform": "cloud"
             }
           ]
-        },
-        {
-          "targetPlatform": "cloud"
         }
       ]
     }

--- a/private-data-source-connect-lj/manifest.json
+++ b/private-data-source-connect-lj/manifest.json
@@ -10,9 +10,17 @@
   "startingLocation": "/connections/private-data-source-connections",
   "targeting": {
     "match": {
-      "and": [
-        { "urlPrefix": "/connections/private-data-source-connections" },
-        { "targetPlatform": "cloud" }
+      "or": [
+        {
+          "and": [
+            {
+              "urlPrefix": "/connections/private-data-source-connections"
+            },
+            {
+              "targetPlatform": "cloud"
+            }
+          ]
+        }
       ]
     }
   },

--- a/prom-remote-write-lj/manifest.json
+++ b/prom-remote-write-lj/manifest.json
@@ -10,12 +10,16 @@
   "startingLocation": "/connections/add-new-connection/hmInstancePromId",
   "targeting": {
     "match": {
-      "and": [
+      "or": [
         {
-          "urlPrefix": "/connections/add-new-connection/hmInstancePromId"
-        },
-        {
-          "targetPlatform": "cloud"
+          "and": [
+            {
+              "urlPrefix": "/connections/add-new-connection/hmInstancePromId"
+            },
+            {
+              "targetPlatform": "cloud"
+            }
+          ]
         }
       ]
     }

--- a/prometheus-lj/manifest.json
+++ b/prometheus-lj/manifest.json
@@ -7,29 +7,33 @@
   "testEnvironment": { "tier": "cloud" },
   "targeting": {
     "match": {
-      "and": [
+      "or": [
         {
-          "or": [
+          "and": [
             {
-              "and": [
+              "or": [
                 {
-                  "urlPrefix": "/connections/datasources"
+                  "and": [
+                    {
+                      "urlPrefix": "/connections/datasources"
+                    },
+                    {
+                      "tag": "selected-datasource:prometheus"
+                    }
+                  ]
                 },
                 {
-                  "tag": "selected-datasource:prometheus"
+                  "urlPrefix": "/connections/datasources/prometheus"
+                },
+                {
+                  "urlRegex": "/connections/add-new-connection/?$"
                 }
               ]
             },
             {
-              "urlPrefix": "/connections/datasources/prometheus"
-            },
-            {
-              "urlRegex": "/connections/add-new-connection/?$"
+              "targetPlatform": "cloud"
             }
           ]
-        },
-        {
-          "targetPlatform": "cloud"
         }
       ]
     }

--- a/rca-workbench-investigation-lj/manifest.json
+++ b/rca-workbench-investigation-lj/manifest.json
@@ -9,12 +9,19 @@
   "startingLocation": "/a/grafana-asserts-app/assertions",
   "targeting": {
     "match": {
-      "and": [
+      "or": [
         {
-          "urlPrefixIn": ["/a/grafana-asserts-app/assertions", "/a/grafana-asserts-app/catalog"]
-        },
-        {
-          "targetPlatform": "cloud"
+          "and": [
+            {
+              "urlPrefixIn": [
+                "/a/grafana-asserts-app/assertions",
+                "/a/grafana-asserts-app/catalog"
+              ]
+            },
+            {
+              "targetPlatform": "cloud"
+            }
+          ]
         }
       ]
     }

--- a/read-a-trace-lj/manifest.json
+++ b/read-a-trace-lj/manifest.json
@@ -11,17 +11,21 @@
   "startingLocation": "/explore",
   "targeting": {
     "match": {
-      "and": [
+      "or": [
         {
-          "urlPrefix": "/explore"
-        },
-        {
-          "or": [
+          "and": [
             {
-              "source": "play.grafana.org"
+              "urlPrefix": "/explore"
             },
             {
-              "source": "learn.grafana.net"
+              "or": [
+                {
+                  "source": "play.grafana.org"
+                },
+                {
+                  "source": "learn.grafana.net"
+                }
+              ]
             }
           ]
         }

--- a/reduce-metrics-cardinality/manifest.json
+++ b/reduce-metrics-cardinality/manifest.json
@@ -10,15 +10,19 @@
   "startingLocation": "/a/grafana-adaptive-metrics-app/overview",
   "targeting": {
     "match": {
-      "and": [
+      "or": [
         {
-          "urlPrefixIn": [
-            "/a/grafana-adaptive-metrics-app/overview",
-            "/a/grafana-adaptive-metrics-app/rule-management"
+          "and": [
+            {
+              "urlPrefixIn": [
+                "/a/grafana-adaptive-metrics-app/overview",
+                "/a/grafana-adaptive-metrics-app/rule-management"
+              ]
+            },
+            {
+              "targetPlatform": "cloud"
+            }
           ]
-        },
-        {
-          "targetPlatform": "cloud"
         }
       ]
     }

--- a/run-first-k6-test-lj/analyze-results/manifest.json
+++ b/run-first-k6-test-lj/analyze-results/manifest.json
@@ -10,9 +10,17 @@
   "startingLocation": "/a/k6-app/runs",
   "targeting": {
     "match": {
-      "and": [
-        { "targetPlatform": "cloud" },
-        { "urlPrefix": "/a/k6-app/runs" }
+      "or": [
+        {
+          "and": [
+            {
+              "targetPlatform": "cloud"
+            },
+            {
+              "urlPrefix": "/a/k6-app/runs"
+            }
+          ]
+        }
       ]
     }
   },

--- a/run-first-k6-test-lj/install-k6/manifest.json
+++ b/run-first-k6-test-lj/install-k6/manifest.json
@@ -10,9 +10,17 @@
   "startingLocation": "/testing-and-synthetics",
   "targeting": {
     "match": {
-      "and": [
-        { "targetPlatform": "cloud" },
-        { "urlPrefix": "/testing-and-synthetics" }
+      "or": [
+        {
+          "and": [
+            {
+              "targetPlatform": "cloud"
+            },
+            {
+              "urlPrefix": "/testing-and-synthetics"
+            }
+          ]
+        }
       ]
     }
   },

--- a/run-first-k6-test-lj/manifest.json
+++ b/run-first-k6-test-lj/manifest.json
@@ -10,9 +10,17 @@
   "startingLocation": "/a/k6-app",
   "targeting": {
     "match": {
-      "and": [
-        { "urlPrefix": "/a/k6-app" },
-        { "targetPlatform": "cloud" }
+      "or": [
+        {
+          "and": [
+            {
+              "urlPrefix": "/a/k6-app"
+            },
+            {
+              "targetPlatform": "cloud"
+            }
+          ]
+        }
       ]
     }
   },

--- a/run-first-k6-test-lj/run-locally/manifest.json
+++ b/run-first-k6-test-lj/run-locally/manifest.json
@@ -10,9 +10,17 @@
   "startingLocation": "/testing-and-synthetics",
   "targeting": {
     "match": {
-      "and": [
-        { "targetPlatform": "cloud" },
-        { "urlPrefix": "/testing-and-synthetics" }
+      "or": [
+        {
+          "and": [
+            {
+              "targetPlatform": "cloud"
+            },
+            {
+              "urlPrefix": "/testing-and-synthetics"
+            }
+          ]
+        }
       ]
     }
   },

--- a/run-first-k6-test-lj/send-to-grafana-cloud/manifest.json
+++ b/run-first-k6-test-lj/send-to-grafana-cloud/manifest.json
@@ -10,9 +10,17 @@
   "startingLocation": "/a/k6-app/settings",
   "targeting": {
     "match": {
-      "and": [
-        { "targetPlatform": "cloud" },
-        { "urlPrefix": "/a/k6-app/settings" }
+      "or": [
+        {
+          "and": [
+            {
+              "targetPlatform": "cloud"
+            },
+            {
+              "urlPrefix": "/a/k6-app/settings"
+            }
+          ]
+        }
       ]
     }
   },

--- a/run-first-k6-test-lj/understand-value/manifest.json
+++ b/run-first-k6-test-lj/understand-value/manifest.json
@@ -10,9 +10,17 @@
   "startingLocation": "/testing-and-synthetics",
   "targeting": {
     "match": {
-      "and": [
-        { "targetPlatform": "cloud" },
-        { "urlPrefix": "/testing-and-synthetics" }
+      "or": [
+        {
+          "and": [
+            {
+              "targetPlatform": "cloud"
+            },
+            {
+              "urlPrefix": "/testing-and-synthetics"
+            }
+          ]
+        }
       ]
     }
   },

--- a/run-first-k6-test-lj/write-test-script/manifest.json
+++ b/run-first-k6-test-lj/write-test-script/manifest.json
@@ -10,9 +10,17 @@
   "startingLocation": "/testing-and-synthetics",
   "targeting": {
     "match": {
-      "and": [
-        { "targetPlatform": "cloud" },
-        { "urlPrefix": "/testing-and-synthetics" }
+      "or": [
+        {
+          "and": [
+            {
+              "targetPlatform": "cloud"
+            },
+            {
+              "urlPrefix": "/testing-and-synthetics"
+            }
+          ]
+        }
       ]
     }
   },

--- a/saved-queries-explore/manifest.json
+++ b/saved-queries-explore/manifest.json
@@ -10,12 +10,16 @@
   "startingLocation": "/explore",
   "targeting": {
     "match": {
-      "and": [
+      "or": [
         {
-          "targetPlatform": "cloud"
-        },
-        {
-          "urlPrefix": "/explore"
+          "and": [
+            {
+              "targetPlatform": "cloud"
+            },
+            {
+              "urlPrefix": "/explore"
+            }
+          ]
         }
       ]
     }

--- a/saved-queries-panel-edit/manifest.json
+++ b/saved-queries-panel-edit/manifest.json
@@ -10,17 +10,21 @@
   "startingLocation": "/dashboard/new",
   "targeting": {
     "match": {
-      "and": [
+      "or": [
         {
-          "targetPlatform": "cloud"
-        },
-        {
-          "or": [
+          "and": [
             {
-              "urlPrefix": "/d/"
+              "targetPlatform": "cloud"
             },
             {
-              "urlPrefix": "/dashboard/new"
+              "or": [
+                {
+                  "urlPrefix": "/d/"
+                },
+                {
+                  "urlPrefix": "/dashboard/new"
+                }
+              ]
             }
           ]
         }

--- a/scripts/lint-targeting.py
+++ b/scripts/lint-targeting.py
@@ -1,0 +1,304 @@
+#!/usr/bin/env python3
+"""Lint manifest.json `targeting.match` expressions for over-broad matching.
+
+The grafana-recommender scores a match expression and returns anything with
+accuracy > 0 -- the `matched` boolean is discarded (cmd/recommender/v1recommend.go).
+`and` accuracy is the *fraction* of matched children, so an `and` holding any
+child that is true regardless of the current page (targetPlatform, tag,
+datasource, userRole, cohort) scores > 0 on every page in the tenant and is
+returned everywhere. `or` accuracy is binary, so wrapping the `and` in an `or`
+keeps the expression at 1.0-or-absent.
+
+Results are sorted by accuracy alone, with no tie-break and a 10-item cap, so a
+precise guide cannot outrank a broad one -- it can only tie it. Reducing how many
+guides match a page is the only lever an author has.
+
+Run from the repository root:
+
+    python3 scripts/lint-targeting.py            # lint, exit 1 on findings
+    python3 scripts/lint-targeting.py --report   # per-page contention report
+"""
+
+import json
+import sys
+from collections import Counter
+from pathlib import Path
+
+# Criterion names the engine understands. Anything else is dropped by non-strict
+# json.Unmarshal, leaving `{}` -- which evaluates as matched at accuracy 1.0, so a
+# typo becomes a free always-true child.
+VALID = {
+    "and", "or", "urlRegex", "urlPrefix", "urlPrefixIn",
+    "datasource", "datasourceIn", "allDatasources", "noDatasources",
+    "userRole", "userRoleIn", "tag", "tagIn", "allTags",
+    "cohort", "cohortIn", "targetPlatform", "targetPlatformIn",
+    "source", "sourceIn",
+}
+
+# Order of the `switch` in internal/recommender/rules.go. Only the first matching
+# case in an object is evaluated; sibling keys are silently ignored.
+ORDER = [
+    "and", "or", "urlRegex", "urlPrefix", "urlPrefixIn",
+    "datasource", "datasourceIn", "allDatasources", "noDatasources",
+    "userRole", "userRoleIn", "tag", "tagIn", "allTags",
+    "cohort", "cohortIn", "targetPlatform", "targetPlatformIn", "sourceIn",
+]
+
+URL_KEYS = {"urlPrefix", "urlPrefixIn", "urlRegex"}
+
+# `source`/`sourceIn` are hard pre-filters evaluated before scoring, and bare
+# `source` has no case in the switch at all, so it neither constrains the URL nor
+# costs anything in the score.
+SOURCE_KEYS = {"source", "sourceIn"}
+
+
+def effective_key(node):
+    """The one key the engine will actually evaluate for this object."""
+    for key in ORDER:
+        if key in node and node[key] not in (None, "", [], {}):
+            return key
+    return None
+
+
+def children(node):
+    for combinator in ("and", "or"):
+        for index, child in enumerate(node.get(combinator) or []):
+            yield combinator, index, child
+
+
+def constrains_url(node):
+    if not isinstance(node, dict):
+        return False
+    if any(key in node for key in URL_KEYS):
+        return True
+    return any(constrains_url(child) for _, _, child in children(node))
+
+
+def only_source(node):
+    """True for a subtree that carries nothing but source pre-filters."""
+    if not isinstance(node, dict):
+        return False
+    keys = set(node) - {"and", "or"}
+    if keys and not keys <= SOURCE_KEYS:
+        return False
+    kids = [child for _, _, child in children(node)]
+    if kids:
+        return all(only_source(child) for child in kids)
+    return bool(keys)
+
+
+def lint(package, match):
+    findings = []
+
+    def walk(node, path):
+        if not isinstance(node, dict):
+            return
+
+        for key in node:
+            if key not in VALID:
+                findings.append(
+                    f"{path}: unknown criterion {key!r} -- dropped by the engine, "
+                    f"leaving an always-true child"
+                )
+
+        scored = [key for key in node if key in ORDER]
+        if len(scored) > 1:
+            findings.append(
+                f"{path}: {len(scored)} criteria in one object {scored} -- only "
+                f"{effective_key(node)!r} is evaluated; split into and/or children"
+            )
+
+        if node.get("urlPrefix") == "/":
+            findings.append(f'{path}: urlPrefix "/" matches every page')
+
+        # An `and` whose children are not all page-dependent scores a partial
+        # accuracy everywhere. Wrapping it in `or` restores binary scoring.
+        if node.get("and"):
+            page_dependent = [constrains_url(c) for c in node["and"]]
+            if any(page_dependent) and not all(page_dependent):
+                unconstrained = [
+                    c for c in node["and"]
+                    if not constrains_url(c) and not only_source(c)
+                ]
+                if unconstrained and path == "match":
+                    findings.append(
+                        f"{path}: root `and` mixes URL and non-URL criteria -- scores a "
+                        f"partial accuracy on every page; wrap it in an `or`"
+                    )
+
+        # Every branch of an `or` must constrain the URL, otherwise the
+        # unconstrained branch is an easy-out that matches every page.
+        for index, child in enumerate(node.get("or") or []):
+            if not constrains_url(child) and not only_source(child):
+                findings.append(
+                    f"{path}.or[{index}]: branch has no URL constraint -- matches every page"
+                )
+
+        for combinator, index, child in children(node):
+            walk(child, f"{path}.{combinator}[{index}]")
+
+    walk(match, "match")
+
+    if not constrains_url(match):
+        findings.append("match: no URL constraint anywhere -- the entry is unmatchable")
+
+    return [(package, finding) for finding in findings]
+
+
+def load_manifests(root):
+    manifests = {}
+    for path in sorted(root.glob("**/manifest.json")):
+        if "node_modules" in path.parts:
+            continue
+        try:
+            data = json.loads(path.read_text())
+        except json.JSONDecodeError as exc:
+            print(f"  {path}: invalid JSON -- {exc}", file=sys.stderr)
+            continue
+        match = (data.get("targeting") or {}).get("match")
+        if match:
+            manifests[str(path.parent.relative_to(root))] = match
+    return manifests
+
+
+# --- contention report -------------------------------------------------------
+
+import re  # noqa: E402  (only needed by the report path)
+
+
+def evaluate(node, ctx):
+    """Mirror of MatchExpr.EvalWithCriteria; returns (matched, accuracy)."""
+    if not isinstance(node, dict):
+        return True, 1.0
+    key = effective_key(node)
+    if key == "and":
+        results = [evaluate(c, ctx)[0] for c in node["and"]]
+        total = len(results)
+        return all(results), (sum(results) / total if total else 1.0)
+    if key == "or":
+        matched = any(evaluate(c, ctx)[0] for c in node["or"])
+        return matched, (1.0 if matched else 0.0)
+    if key == "urlRegex":
+        pattern = node["urlRegex"]
+        pattern = pattern if pattern.startswith("^") else "^" + pattern
+        try:
+            ok = bool(re.search(pattern, ctx["path"], re.I))
+        except re.error:
+            ok = False
+        return ok, (1.0 if ok else 0.0)
+    if key == "urlPrefix":
+        ok = ctx["path"].startswith(node["urlPrefix"])
+        return ok, (1.0 if ok else 0.0)
+    if key == "urlPrefixIn":
+        ok = any(ctx["path"].startswith(p) for p in node["urlPrefixIn"])
+        return ok, (1.0 if ok else 0.0)
+    if key == "tag":
+        ok = node["tag"] in ctx["tags"]
+        return ok, (1.0 if ok else 0.0)
+    if key == "targetPlatform":
+        ok = node["targetPlatform"] in ("any", ctx["platform"])
+        return ok, (1.0 if ok else 0.0)
+    if key == "userRole":
+        ok = node["userRole"] == ctx["role"]
+        return ok, (1.0 if ok else 0.0)
+    if key == "datasource":
+        ok = node["datasource"] in ctx["datasources"]
+        return ok, (1.0 if ok else 0.0)
+    # bare `source` and unrecognised leaves: totalCriteria == 0 -> matched at 1.0
+    return True, 1.0
+
+
+def source_patterns(node):
+    found = []
+    if isinstance(node, dict):
+        if "source" in node:
+            found.append(node["source"])
+        if "sourceIn" in node:
+            found.extend(node["sourceIn"])
+        for _, _, child in children(node):
+            found += source_patterns(child)
+    return found
+
+
+# Representative pages, drawn from grafana-pathfinder-app/product-knowledge/app-states.mdc
+PAGES = [
+    ("/dashboards", []),
+    ("/dashboards", ["panel-type:timeseries"]),
+    ("/d/abc123/my-dashboard", []),
+    ("/dashboard/new", []),
+    ("/playlists", []),
+    ("/explore", []),
+    ("/drilldown", []),
+    ("/connections", []),
+    ("/connections/infrastructure", []),
+    ("/connections/add-new-connection", []),
+    ("/connections/add-new-connection/kafka", []),
+    ("/connections/datasources", []),
+    ("/connections/datasources", ["selected-datasource:prometheus"]),
+    ("/alerting/list", []),
+    ("/admin", []),
+    ("/admin/provisioning", []),
+    ("/a/k6-app", []),
+    ("/a/grafana-k8s-app/home", []),
+    ("/a/grafana-irm-app/incidents", []),
+]
+
+MAX_RECOMMENDATIONS = 10  # DefaultMaxRecommendations in cmd/recommender/main.go
+
+
+def report(manifests, host="mystack.grafana.net"):
+    over_cap = 0
+    appearances = Counter()
+    print(f"{'page':<46}{'context tags':<32}{'shown':>6}")
+    print("-" * 86)
+    for path, tags in PAGES:
+        ctx = {
+            "path": path, "platform": "cloud", "role": "Editor",
+            "datasources": ["prometheus", "loki"], "tags": tags,
+        }
+        shown = []
+        for package, match in manifests.items():
+            patterns = source_patterns(match)
+            if patterns and not any(re.search(p, host, re.I) for p in patterns):
+                continue
+            if evaluate(match, ctx)[1] > 0:
+                shown.append(package)
+                appearances[package] += 1
+        flag = "  <== OVER CAP" if len(shown) > MAX_RECOMMENDATIONS else ""
+        if len(shown) > MAX_RECOMMENDATIONS:
+            over_cap += 1
+        print(f"{path:<46}{','.join(tags) or '-':<32}{len(shown):>6}{flag}")
+    print(f"\npages over the {MAX_RECOMMENDATIONS}-slot cap: {over_cap}")
+    print(f"\nguides matching the most of these {len(PAGES)} pages:")
+    for package, count in appearances.most_common(10):
+        print(f"   {count:>3}  {package}")
+    return over_cap
+
+
+def main():
+    root = Path.cwd()
+    manifests = load_manifests(root)
+    if not manifests:
+        print("No manifests with targeting found. Run from the repository root.", file=sys.stderr)
+        return 2
+
+    if "--report" in sys.argv:
+        over_cap = report(manifests)
+        return 1 if over_cap else 0
+
+    findings = []
+    for package, match in manifests.items():
+        findings += lint(package, match)
+
+    print(f"Linted {len(manifests)} manifests with targeting.")
+    if findings:
+        print(f"\n{len(findings)} finding(s):\n")
+        for package, finding in findings:
+            print(f"  {package}\n      {finding}")
+        return 1
+    print("No findings.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/semantic-layer-tutorial/manifest.json
+++ b/semantic-layer-tutorial/manifest.json
@@ -10,12 +10,22 @@
   "startingLocation": "/d/cubeds-ecom-full-data-model/grafana-for-bi3a-semantic-layer-demo",
   "targeting": {
     "match": {
-      "and": [
-        { "source": "play.grafana.org" },
+      "or": [
         {
-          "or": [
-            { "urlPrefix": "/d/cubeds-ecom-full-data-model" },
-            { "urlPrefix": "/d/territory-navigator" }
+          "and": [
+            {
+              "source": "play.grafana.org"
+            },
+            {
+              "or": [
+                {
+                  "urlPrefix": "/d/cubeds-ecom-full-data-model"
+                },
+                {
+                  "urlPrefix": "/d/territory-navigator"
+                }
+              ]
+            }
           ]
         }
       ]

--- a/send-logs-alloy-loki-lj/manifest.json
+++ b/send-logs-alloy-loki-lj/manifest.json
@@ -7,12 +7,16 @@
   "startingLocation": "/a/grafana-collector-app",
   "targeting": {
     "match": {
-      "and": [
+      "or": [
         {
-          "urlPrefix": "/a/grafana-collector-app"
-        },
-        {
-          "targetPlatform": "cloud"
+          "and": [
+            {
+              "urlPrefix": "/a/grafana-collector-app"
+            },
+            {
+              "targetPlatform": "cloud"
+            }
+          ]
         }
       ]
     }

--- a/send-traces-alloy-lp/manifest.json
+++ b/send-traces-alloy-lp/manifest.json
@@ -7,15 +7,22 @@
     "name": "grafana-docs",
     "team": "Grafana Documentation"
   },
-  "startingLocation": "/",
+  "startingLocation": "/connections/add-new-connection/htInstanceId",
   "targeting": {
     "match": {
-      "and": [
+      "or": [
         {
-          "urlPrefix": "/"
-        },
-        {
-          "targetPlatform": "cloud"
+          "and": [
+            {
+              "urlPrefixIn": [
+                "/connections/add-new-connection/htInstanceId",
+                "/connections/add-new-connection/collector-open-telemetry"
+              ]
+            },
+            {
+              "targetPlatform": "cloud"
+            }
+          ]
         }
       ]
     }

--- a/slo-quickstart/manifest.json
+++ b/slo-quickstart/manifest.json
@@ -9,10 +9,18 @@
   },
   "targeting": {
     "match": {
-        "and": [
-          { "urlPrefix": "/a/grafana-slo-app" },
-          { "targetPlatform": "cloud" }
-        ]
+      "or": [
+        {
+          "and": [
+            {
+              "urlPrefix": "/a/grafana-slo-app"
+            },
+            {
+              "targetPlatform": "cloud"
+            }
+          ]
+        }
+      ]
     }
   },
   "testEnvironment": {

--- a/sm-dns-check-tutorial/manifest.json
+++ b/sm-dns-check-tutorial/manifest.json
@@ -10,12 +10,16 @@
   "startingLocation": "/a/grafana-synthetic-monitoring-app",
   "targeting": {
     "match": {
-      "and": [
+      "or": [
         {
-          "targetPlatform": "cloud"
-        },
-        {
-          "urlPrefix": "/a/grafana-synthetic-monitoring-app"
+          "and": [
+            {
+              "targetPlatform": "cloud"
+            },
+            {
+              "urlPrefix": "/a/grafana-synthetic-monitoring-app"
+            }
+          ]
         }
       ]
     }

--- a/sm-ping-check-tutorial/manifest.json
+++ b/sm-ping-check-tutorial/manifest.json
@@ -10,12 +10,16 @@
   "startingLocation": "/a/grafana-synthetic-monitoring-app",
   "targeting": {
     "match": {
-      "and": [
+      "or": [
         {
-          "targetPlatform": "cloud"
-        },
-        {
-          "urlPrefix": "/a/grafana-synthetic-monitoring-app"
+          "and": [
+            {
+              "targetPlatform": "cloud"
+            },
+            {
+              "urlPrefix": "/a/grafana-synthetic-monitoring-app"
+            }
+          ]
         }
       ]
     }

--- a/sm-scripted-check-tutorial/manifest.json
+++ b/sm-scripted-check-tutorial/manifest.json
@@ -10,12 +10,16 @@
   "startingLocation": "/a/grafana-synthetic-monitoring-app",
   "targeting": {
     "match": {
-      "and": [
+      "or": [
         {
-          "targetPlatform": "cloud"
-        },
-        {
-          "urlPrefix": "/a/grafana-synthetic-monitoring-app"
+          "and": [
+            {
+              "targetPlatform": "cloud"
+            },
+            {
+              "urlPrefix": "/a/grafana-synthetic-monitoring-app"
+            }
+          ]
         }
       ]
     }

--- a/sm-setting-up-your-first-check/manifest.json
+++ b/sm-setting-up-your-first-check/manifest.json
@@ -10,9 +10,17 @@
   "startingLocation": "/a/grafana-synthetic-monitoring-app",
   "targeting": {
     "match": {
-      "and": [
-        { "targetPlatform": "cloud" },
-        { "urlPrefix": "/a/grafana-synthetic-monitoring-app" }
+      "or": [
+        {
+          "and": [
+            {
+              "targetPlatform": "cloud"
+            },
+            {
+              "urlPrefix": "/a/grafana-synthetic-monitoring-app"
+            }
+          ]
+        }
       ]
     }
   },

--- a/sm-tcp-check-tutorial/manifest.json
+++ b/sm-tcp-check-tutorial/manifest.json
@@ -10,12 +10,16 @@
   "startingLocation": "/a/grafana-synthetic-monitoring-app",
   "targeting": {
     "match": {
-      "and": [
+      "or": [
         {
-          "targetPlatform": "cloud"
-        },
-        {
-          "urlPrefix": "/a/grafana-synthetic-monitoring-app"
+          "and": [
+            {
+              "targetPlatform": "cloud"
+            },
+            {
+              "urlPrefix": "/a/grafana-synthetic-monitoring-app"
+            }
+          ]
         }
       ]
     }

--- a/tempo-data-source-lj/manifest.json
+++ b/tempo-data-source-lj/manifest.json
@@ -10,29 +10,33 @@
   "startingLocation": "/connections/datasources",
   "targeting": {
     "match": {
-      "and": [
+      "or": [
         {
-          "or": [
+          "and": [
             {
-              "and": [
+              "or": [
                 {
-                  "urlPrefix": "/connections/datasources"
+                  "and": [
+                    {
+                      "urlPrefix": "/connections/datasources"
+                    },
+                    {
+                      "tag": "selected-datasource:tempo"
+                    }
+                  ]
                 },
                 {
-                  "tag": "selected-datasource:tempo"
+                  "urlPrefix": "/connections/datasources/tempo"
+                },
+                {
+                  "urlRegex": "/connections/add-new-connection/?$"
                 }
               ]
             },
             {
-              "urlPrefix": "/connections/datasources/tempo"
-            },
-            {
-              "urlRegex": "/connections/add-new-connection/?$"
+              "targetPlatform": "cloud"
             }
           ]
-        },
-        {
-          "targetPlatform": "cloud"
         }
       ]
     }

--- a/test-sm-overview-tutorial/manifest.json
+++ b/test-sm-overview-tutorial/manifest.json
@@ -10,13 +10,19 @@
   "startingLocation": "/testing-and-synthetics",
   "targeting": {
     "match": {
-      "and": [
-        { "targetPlatform": "cloud" },
+      "or": [
         {
-          "urlPrefixIn": [
-            "/testing-and-synthetics",
-            "/a/k6-app",
-            "/a/grafana-synthetic-monitoring-app"
+          "and": [
+            {
+              "targetPlatform": "cloud"
+            },
+            {
+              "urlPrefixIn": [
+                "/testing-and-synthetics",
+                "/a/k6-app",
+                "/a/grafana-synthetic-monitoring-app"
+              ]
+            }
           ]
         }
       ]

--- a/tour-of-visualizations/manifest.json
+++ b/tour-of-visualizations/manifest.json
@@ -7,12 +7,16 @@
   "startingLocation": "/d/ma79mqp/visualization-examples",
   "targeting": {
     "match": {
-      "and": [
+      "or": [
         {
-          "urlPrefix": "/d/ma79mqp/visualization-examples"
-        },
-        {
-          "source": "play.grafana.org"
+          "and": [
+            {
+              "urlPrefix": "/d/ma79mqp/visualization-examples"
+            },
+            {
+              "source": "play.grafana.org"
+            }
+          ]
         }
       ]
     }

--- a/transform-data/manifest.json
+++ b/transform-data/manifest.json
@@ -7,9 +7,17 @@
   "startingLocation": "/d/",
   "targeting": {
     "match": {
-      "and": [
-        { "urlPrefix": "/d/" },
-        { "source": ".*\\.grafana\\.net" }
+      "or": [
+        {
+          "and": [
+            {
+              "urlPrefix": "/d/"
+            },
+            {
+              "source": ".*\\.grafana\\.net"
+            }
+          ]
+        }
       ]
     }
   },

--- a/understanding-the-four-golden-signals-of-observability/manifest.json
+++ b/understanding-the-four-golden-signals-of-observability/manifest.json
@@ -10,13 +10,19 @@
   "startingLocation": "/a/grafana-setupguide-app/home",
   "targeting": {
     "match": {
-      "and": [
-        { "targetPlatform": "cloud" },
+      "or": [
         {
-          "urlPrefixIn": [
-            "/a/grafana-setupguide-app/home",
-            "/explore",
-            "/drilldown"
+          "and": [
+            {
+              "targetPlatform": "cloud"
+            },
+            {
+              "urlPrefixIn": [
+                "/a/grafana-setupguide-app/home",
+                "/explore",
+                "/drilldown"
+              ]
+            }
           ]
         }
       ]

--- a/visualization-logs-lp/manifest.json
+++ b/visualization-logs-lp/manifest.json
@@ -13,15 +13,15 @@
       "or": [
         {
           "and": [
-            { "urlPrefix": "/dashboards" },
-            { "targetPlatform": "cloud" }
-          ]
-        },
-        {
-          "and": [
-            { "urlPrefix": "/dashboards" },
-            { "tag": "panel-type:logs" },
-            { "targetPlatform": "cloud" }
+            {
+              "urlPrefix": "/dashboards"
+            },
+            {
+              "tag": "panel-type:logs"
+            },
+            {
+              "targetPlatform": "cloud"
+            }
           ]
         }
       ]

--- a/visualization-metrics-lj/manifest.json
+++ b/visualization-metrics-lj/manifest.json
@@ -13,15 +13,15 @@
       "or": [
         {
           "and": [
-            { "urlPrefix": "/dashboards" },
-            { "targetPlatform": "cloud" }
-          ]
-        },
-        {
-          "and": [
-            { "urlPrefix": "/dashboards" },
-            { "tag": "panel-type:timeseries" },
-            { "targetPlatform": "cloud" }
+            {
+              "urlPrefix": "/dashboards"
+            },
+            {
+              "tag": "panel-type:timeseries"
+            },
+            {
+              "targetPlatform": "cloud"
+            }
           ]
         }
       ]

--- a/visualization-traces-lj/manifest.json
+++ b/visualization-traces-lj/manifest.json
@@ -13,22 +13,28 @@
       "or": [
         {
           "and": [
-            { "urlPrefix": "/dashboards" },
-            { "targetPlatform": "cloud" }
+            {
+              "urlPrefix": "/dashboards"
+            },
+            {
+              "tag": "panel-type:table"
+            },
+            {
+              "targetPlatform": "cloud"
+            }
           ]
         },
         {
           "and": [
-            { "urlPrefix": "/dashboards" },
-            { "tag": "panel-type:table" },
-            { "targetPlatform": "cloud" }
-          ]
-        },
-        {
-          "and": [
-            { "urlPrefix": "/dashboards" },
-            { "tag": "panel-type:traces" },
-            { "targetPlatform": "cloud" }
+            {
+              "urlPrefix": "/dashboards"
+            },
+            {
+              "tag": "panel-type:traces"
+            },
+            {
+              "targetPlatform": "cloud"
+            }
           ]
         }
       ]

--- a/welcome-frontend-observability/manifest.json
+++ b/welcome-frontend-observability/manifest.json
@@ -11,12 +11,16 @@
   "startingLocation": "/a/grafana-kowalski-app",
   "targeting": {
     "match": {
-      "and": [
+      "or": [
         {
-          "targetPlatform": "cloud"
-        },
-        {
-          "urlPrefix": "/a/grafana-kowalski-app"
+          "and": [
+            {
+              "targetPlatform": "cloud"
+            },
+            {
+              "urlPrefix": "/a/grafana-kowalski-app"
+            }
+          ]
         }
       ]
     }

--- a/welcome-to-play/datasource-page/manifest.json
+++ b/welcome-to-play/datasource-page/manifest.json
@@ -10,9 +10,17 @@
   "startingLocation": "/d/mamnq22/data-source-examples",
   "targeting": {
     "match": {
-      "and": [
-        { "urlPrefix": "/d/mamnq22/data-source-examples" },
-        { "source": "play.grafana.org" }
+      "or": [
+        {
+          "and": [
+            {
+              "urlPrefix": "/d/mamnq22/data-source-examples"
+            },
+            {
+              "source": "play.grafana.org"
+            }
+          ]
+        }
       ]
     }
   },

--- a/welcome-to-play/main-page/manifest.json
+++ b/welcome-to-play/main-page/manifest.json
@@ -10,9 +10,17 @@
   "startingLocation": "/d/to6j8mh/grafana-play-home",
   "targeting": {
     "match": {
-      "and": [
-        { "urlPrefix": "/d/to6j8mh/grafana-play-home" },
-        { "source": "play.grafana.org" }
+      "or": [
+        {
+          "and": [
+            {
+              "urlPrefix": "/d/to6j8mh/grafana-play-home"
+            },
+            {
+              "source": "play.grafana.org"
+            }
+          ]
+        }
       ]
     }
   },

--- a/welcome-to-play/visualization-page/manifest.json
+++ b/welcome-to-play/visualization-page/manifest.json
@@ -10,9 +10,17 @@
   "startingLocation": "/d/ma79mqp/visualization-examples",
   "targeting": {
     "match": {
-      "and": [
-        { "urlPrefix": "/d/ma79mqp/visualization-examples" },
-        { "source": "play.grafana.org" }
+      "or": [
+        {
+          "and": [
+            {
+              "urlPrefix": "/d/ma79mqp/visualization-examples"
+            },
+            {
+              "source": "play.grafana.org"
+            }
+          ]
+        }
       ]
     }
   },


### PR DESCRIPTION
## Why

Recommendations were crowding common pages and pushing relevant guides out of the visible slots. Reading [`grafana-recommender`](https://github.com/grafana/grafana-recommender) shows the cause is **how a match expression is scored**, not how results are ranked:

1. **Inclusion is `accuracy > 0`, not `matched`.** `cmd/recommender/v1recommend.go:362` discards the `matched` boolean (`_`) and gates only on accuracy — a guide that did *not* match is still returned if any one criterion hits.
2. **`and` scores fractionally; `or` scores binary** (`internal/recommender/rules.go:209-250`). So `{"and":[{"urlPrefix":"/explore"},{"targetPlatform":"cloud"}]}` scores **0.5 on every page of a Cloud stack**, because the platform child is true regardless of the page. **82 manifests used exactly that shape.**
3. **No specificity reward, no tie-break, 10 slots.** Every criterion weighs 1, max is 1.0, sorting is accuracy-only, and `sort.Slice` is unstable over randomised map iteration. **A precise guide cannot outrank a broad one — only tie it.** The only lever is making fewer guides match.

Measured on a Cloud stack before this change: **83–90 packages returned on every page**, with 10–19 tied at the maximum competing for 10 slots. On `/a/grafana-irm-app/incidents`, 8 of the 10 were the learning paths matching `urlPrefix: "/"`.

## What changed

| | |
|---|---|
| **Retarget the 8 `urlPrefix: "/"` paths** | They matched every page in the product. Each now targets the page it actually starts from, with `startingLocation` fixed to match (it was also `"/"`, against `docs/manifest-reference.md`). |
| **Or-wrap root-level `and` blocks** | Makes scoring binary — 1.0 on the intended pages, absent elsewhere. Required *alongside* the above: freeing the top slots without it just promotes ~70 arbitrary 0.5-scored guides into them. The shape already existed in `git-sync-dashboards-lj` and `interactive-dashboards-lj`; now applied evenly. |
| **Curate catalog pages** | `/connections/infrastructure` listed all 11 integration guides; each now targets its own tile. The bare `/connections/add-new-connection` arm matched every tile beneath it — replaced with an anchored regex for the catalog index. |
| **Drop self-defeating `or` arms** | In `visualization-logs-lp`, `visualization-metrics-lj`, `visualization-traces-lj`, `elasticsearch-logs-lj` a bare URL arm sat beside a tag-narrowed copy of itself and always won, making the tag dead weight. |
| **Fix a dead rule** | `github-data-source-lj` targeted `/add-new-connection`; the real route is `/connections/add-new-connection/github`, so it could never match. |

Of 118 changed manifests, **92 are or-wrap only with URLs unchanged** and 26 have genuinely retargeted URLs. No field other than `targeting` and `startingLocation` changed anywhere — verified programmatically.

## Result

Per-page contention, Cloud stack (`scripts/lint-targeting.py --report`):

| Page | Before | After |
|---|---|---|
| `/a/grafana-irm-app/incidents` | 83 | **2** |
| `/connections/datasources` + prometheus | 83 | **1** |
| `/alerting/list` | 83 | **5** |
| `/explore` | 83 | **5** |
| `/dashboards` | 90 | **4** |
| `/d/<uid>/<slug>` | 84 | **4** |

No page in the sampled set exceeds the 10-slot cap, and no guide matches more than 3 of 19 representative pages.

## Verification

- **All 666 packages pass** `pathfinder-cli validate` (recursive per-package loop, not just the depth-1 `--packages` form).
- **Every URL verified against a live Grafana Cloud stack** — all 8 integration tile slugs, the `/connections/datasources/<pluginId>` route shape, `/admin/provisioning`, `/a/k6-app`, `/a/grafana-k8s-app`. This also turned up the real homes for Beyla, GitHub and Infinity, and confirmed every existing `selected-datasource:*` tag against real datasource type IDs.
- `scripts/lint-targeting.py` reports no findings.
- `index.json` untouched; no `stats` stamped.

## Also added

`scripts/lint-targeting.py` catches all of the above shapes: `urlPrefix: "/"`, partial-scoring root `and` blocks, `or` branches with no URL constraint, unknown criterion names (silently dropped by the engine, leaving an **always-true** child — a typo widens a match), and multiple criteria in one object (evaluation is a `switch`, so only the first is read).

Docs now cover the scoring rules, the three predicates already in use but undocumented (`tag`, `urlRegex`, `userRole`), and that the plugin's own matcher understands only `urlPrefix`/`urlPrefixIn`/`targetPlatform`/`and`/`or` and drops an entry entirely if anything else appears.

## Follow-ups, not in this PR

- **`assistant-self-hosted` has no clean fix.** It is `targetPlatform: "oss"` but uses `urlRegex: "^/?$"` for the home page, and the plugin's OSS matcher fails closed on the whole entry — so it is dropped by the very matcher that serves OSS. The home page cannot be expressed in the supported subset (`urlPrefix: "/"` matches everything). Left intact so the server path keeps working; needs an exact-match predicate upstream.
- **`/a/k6-app` shows 8** — all genuinely k6, but they all target the app root, so it is one guide away from the cap. Sub-route targeting would split them.
- **`/connections` and `/connections/datasources` now show 0** with no datasource selected. Nothing relevant was lost (the guides previously there were mis-targeted), but both are decent PLG surfaces if someone wants an overview guide on them.
- The CLI's own remediation advice suggests `--target-url-prefix "/"`, which is the anti-pattern this PR removes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)