### PR TITLE
Give the Connections hub and data source list their own recommendations

### DIFF
--- a/connect-prometheus-metrics/manifest.json
+++ b/connect-prometheus-metrics/manifest.json
@@ -3,7 +3,47 @@
   "type": "guide",
   "description": "Hands-on guide: Learn how to connect Prometheus metrics to Grafana Cloud using the Connections catalog and Hosted Prometheus.",
   "category": "general",
-  "author": { "team": "interactive-learning", "name": "tacole02" },
+  "author": {
+    "team": "interactive-learning",
+    "name": "tacole02"
+  },
+  "startingLocation": "/connections",
+  "targeting": {
+    "match": {
+      "or": [
+        {
+          "and": [
+            {
+              "urlRegex": "^/connections/?$"
+            },
+            {
+              "targetPlatform": "cloud"
+            }
+          ]
+        },
+        {
+          "and": [
+            {
+              "urlRegex": "^/connections/datasources/?$"
+            },
+            {
+              "targetPlatform": "cloud"
+            }
+          ]
+        },
+        {
+          "and": [
+            {
+              "urlPrefix": "/connections/add-new-connection/hmInstancePromId"
+            },
+            {
+              "targetPlatform": "cloud"
+            }
+          ]
+        }
+      ]
+    }
+  },
   "testEnvironment": {
     "tier": "cloud"
   },

--- a/explore-getting-started/manifest.json
+++ b/explore-getting-started/manifest.json
@@ -21,6 +21,16 @@
               "urlPrefix": "/explore"
             }
           ]
+        },
+        {
+          "and": [
+            {
+              "targetPlatform": "cloud"
+            },
+            {
+              "urlRegex": "^/connections/datasources/?$"
+            }
+          ]
         }
       ]
     }

--- a/monitor-infrastructure-grot/manifest.json
+++ b/monitor-infrastructure-grot/manifest.json
@@ -20,6 +20,16 @@
               "targetPlatform": "cloud"
             }
           ]
+        },
+        {
+          "and": [
+            {
+              "urlRegex": "^/connections/?$"
+            },
+            {
+              "targetPlatform": "cloud"
+            }
+          ]
         }
       ]
     }

--- a/private-data-source-connect-lj/manifest.json
+++ b/private-data-source-connect-lj/manifest.json
@@ -20,6 +20,16 @@
               "targetPlatform": "cloud"
             }
           ]
+        },
+        {
+          "and": [
+            {
+              "urlRegex": "^/connections/?$"
+            },
+            {
+              "targetPlatform": "cloud"
+            }
+          ]
         }
       ]
     }


### PR DESCRIPTION
Follow-up to #550.

## Why

After #550 narrowed targeting, `/connections` and `/connections/datasources` had **no interactive guides at all** — only docs pages, most at 0.5 partial accuracy (the same scoring bug, in the recommender's own embedded state rules). Both are high-intent surfaces, so they're worth populating deliberately rather than by accident of a broad prefix.

## Why `urlRegex` and not `urlPrefix`

`/connections` is a prefix of `/connections/datasources`, `/connections/add-new-connection` and `/connections/infrastructure`. A prefix match would put these guides back on every page beneath them — exactly what `infinity-json-lj` and `beyla-tempo-lj` were doing before #550.

Anchored `urlRegex` (`^/connections/?$`, `^/connections/datasources/?$`) matches the hub and the list page *only*. This is the pattern six manifests already use for the add-new-connection catalog index.

## What each page gets

**`/connections`** is an orientation hub — "Welcome to Connections", with cards for Data sources, Integrations, and Private data source connect. So it gets the guides that help someone *choose*:

| Guide | Rationale |
|---|---|
| `connect-prometheus-metrics` | **Had no `targeting` at all**, so it was unrecommendable — despite being explicitly about finding your way around the Connections catalog. Also now targets the Hosted Prometheus tile, its real configuration surface. |
| `private-data-source-connect-lj` | PDC is a card on the hub and easy to miss. Keeps its own page as primary. |
| `monitor-infrastructure-grot` | Integrations is a card on the hub. Keeps `/connections/infrastructure` as primary. |

**`/connections/datasources`** is "view and manage", with *Add new data source*, plus *Build a dashboard* and *Explore* on every row:

| Guide | Rationale |
|---|---|
| `connect-prometheus-metrics` | The add-a-source path. |
| `explore-getting-started` | The Explore action each row already offers. |

## No leakage

Simulated per page against the real engine semantics:

| Page | Guides |
|---|---|
| `/connections`, `/connections/` | **3** (the hub set) |
| `/connections/datasources`, `/connections/datasources/` | **2** |
| `/connections/datasources/prometheus` | 1 — unchanged |
| `/connections/datasources/edit/<uid>` | 1 — unchanged |
| `/connections/add-new-connection/kafka` | 1 — unchanged |
| `/connections/infrastructure` | 1 — unchanged |
| `/connections/private-data-source-connections` | 1 — unchanged |
| `/connections/add-new-connection/hmInstancePromId` | 2 — both hosted-Prometheus guides |

Page structure and every URL verified against a live Grafana Cloud stack.

## Verification

- `scripts/lint-targeting.py` — no findings across 130 manifests.
- All **667** packages pass `pathfinder-cli validate` (recursive per-package loop).
- Diff touches only `targeting` and `startingLocation` — verified programmatically; no other field changed in any of the 4 manifests.

## Note

Both regexes are dropped by the plugin's own five-predicate matcher. All four guides are `targetPlatform: cloud`, so they were never eligible on the OSS local path anyway — consistent with the constraint documented in #550.

I kept this deliberately tight (3 and 2) rather than filling the 10 slots, since over-filling is what #550 fixed. Easy to add more if you want a fuller set — the remaining untargeted guides are `logql-101`, `adaptive-logs-recommendations`, `deploy-alert-terraform-lj`, `semantic-layer-data-model-config`, `windows-integration-lp` and the three `rca-demo*` variants, each of which needs a home somewhere other than Connections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)