### PR TITLE
Fix guide navigation blocked by collapsed sidebar sections

### DIFF
--- a/github-data-source-lj/install-github-plugin/content.json
+++ b/github-data-source-lj/install-github-plugin/content.json
@@ -38,12 +38,10 @@
       "blocks": [
         {
           "type": "interactive",
-          "action": "highlight",
-          "reftarget": "a[data-testid='data-testid Nav menu item'][href='/plugins']",
-          "content": "Navigate to **Administration > Plugins and data > Plugins**.",
-          "requirements": [
-            "navmenu-open"
-          ]
+          "action": "navigate",
+          "reftarget": "/plugins",
+          "content": "Open **Administration > Plugins and data > Plugins**.",
+          "verify": "on-page:/plugins"
         },
         {
           "type": "interactive",
@@ -61,8 +59,10 @@
           "action": "highlight",
           "reftarget": "a[href='/plugins/grafana-github-datasource']",
           "requirements": [
+            "on-page:/plugins",
             "exists-reftarget"
           ],
+          "verify": "on-page:/plugins/grafana-github-datasource",
           "content": "Locate the **GitHub** data source plugin and click on it to view the plugin details."
         },
         {
@@ -78,12 +78,10 @@
         },
         {
           "type": "interactive",
-          "action": "highlight",
-          "reftarget": "a[href='/connections/datasources']",
-          "content": "Navigate to **Connections > Data sources**.",
-          "requirements": [
-            "navmenu-open"
-          ]
+          "action": "navigate",
+          "reftarget": "/connections/datasources",
+          "content": "Open **Connections > Data sources**.",
+          "verify": "on-page:/connections/datasources"
         },
         {
           "type": "interactive",
@@ -93,6 +91,7 @@
             "on-page:/connections/datasources",
             "exists-reftarget"
           ],
+          "verify": "on-page:/connections/datasources/new",
           "content": "Click **Add new data source** in the upper right of the page."
         },
         {
@@ -111,8 +110,10 @@
           "action": "button",
           "reftarget": "GitHub",
           "requirements": [
+            "on-page:/connections/datasources/new",
             "exists-reftarget"
           ],
+          "verify": "on-page:/connections/datasources/edit",
           "content": "Click **GitHub** to select the GitHub data source and begin configuration."
         }
       ]

--- a/haproxy-load-balancer-lj/select-platform/content.json
+++ b/haproxy-load-balancer-lj/select-platform/content.json
@@ -13,29 +13,33 @@
       "blocks": [
         {
           "type": "interactive",
-          "action": "highlight",
-          "reftarget": "a[data-testid='data-testid Nav menu item'][href='/connections/add-new-connection']",
-          "content": "Click **Connections > Add new connection** in the left-side menu.",
-          "requirements": ["navmenu-open"]
+          "action": "navigate",
+          "reftarget": "/connections/add-new-connection",
+          "verify": "on-page:/connections/add-new-connection",
+          "content": "Open **Connections > Add new connection**."
         },
         {
           "type": "interactive",
           "action": "formfill",
           "reftarget": "input[data-testid='search-input-input']",
           "content": "Filter the connections by typing `HAProxy` in the search.",
-          "targetvalue": "HAProxy"
+          "targetvalue": "HAProxy",
+          "requirements": ["on-page:/connections/add-new-connection", "exists-reftarget"]
         },
         {
           "type": "interactive",
           "action": "highlight",
           "reftarget": "a[href='/connections/add-new-connection/haproxy']",
-          "content": "Click the **HAProxy** tile."
+          "content": "Click the **HAProxy** tile.",
+          "verify": "on-page:/connections/add-new-connection/haproxy",
+          "requirements": ["on-page:/connections/add-new-connection", "exists-reftarget"]
         },
         {
           "type": "interactive",
           "action": "highlight",
           "reftarget": "div[data-testid='collector-os-selection'] input",
           "content": "Select the **operating system** that matches your HAProxy server.",
+          "requirements": ["on-page:/connections/add-new-connection/haproxy", "exists-reftarget"],
           "doIt": false
         },
         {
@@ -43,6 +47,7 @@
           "action": "highlight",
           "reftarget": "div[data-testid='collector-arch-selection'] input",
           "content": "Select the **architecture** that matches your system (Amd64 for x86_64, Arm64 for aarch64).",
+          "requirements": ["on-page:/connections/add-new-connection/haproxy", "exists-reftarget"],
           "doIt": false
         },
         {

--- a/iis-web-server-lj/select-integration/content.json
+++ b/iis-web-server-lj/select-integration/content.json
@@ -12,25 +12,26 @@
       "autoCollapse": false,
       "blocks": [
         {
-          "type": "multistep",
-          "content": "Navigate to **Connections > Add new connection**.",
-          "requirements": ["navmenu-open"],
-          "steps": [
-            { "action": "highlight", "reftarget": "a[data-testid='data-testid Nav menu item'][href='/connections']" },
-            { "action": "highlight", "reftarget": "a[data-testid='data-testid Nav menu item'][href='/connections/add-new-connection']" }
-          ]
+          "type": "interactive",
+          "action": "navigate",
+          "reftarget": "/connections/add-new-connection",
+          "content": "Open **Connections > Add new connection**.",
+          "verify": "on-page:/connections/add-new-connection"
         },
         {
           "type": "interactive",
           "action": "formfill",
           "reftarget": "[aria-label='Search connections by name']",
           "targetvalue": "IIS",
+          "requirements": ["on-page:/connections/add-new-connection", "exists-reftarget"],
           "content": "In the search box, type **IIS** to filter the integrations."
         },
         {
           "type": "interactive",
           "action": "highlight",
           "reftarget": "a[href='/connections/add-new-connection/microsoft-iis']",
+          "requirements": ["on-page:/connections/add-new-connection", "exists-reftarget"],
+          "verify": "on-page:/connections/add-new-connection/microsoft-iis",
           "content": "Click the **Microsoft IIS** tile to select the integration."
         }
       ]

--- a/infinity-csv-lj/add-data-source/content.json
+++ b/infinity-csv-lj/add-data-source/content.json
@@ -16,24 +16,18 @@
       "autoCollapse": false,
       "blocks": [
         {
-          "type": "multistep",
-          "content": "In Grafana Cloud, click **Connections > Data sources**.",
-          "requirements": ["navmenu-open"],
-          "steps": [
-            {
-              "action": "highlight",
-              "reftarget": "a[data-testid='data-testid Nav menu item'][href='/connections']"
-            },
-            {
-              "action": "highlight",
-              "reftarget": "a[data-testid='data-testid Nav menu item'][href='/connections/datasources']"
-            }
-          ]
+          "type": "interactive",
+          "action": "navigate",
+          "reftarget": "/connections/datasources",
+          "content": "In Grafana Cloud, open **Connections > Data sources**.",
+          "verify": "on-page:/connections/datasources"
         },
         {
           "type": "interactive",
           "action": "highlight",
           "reftarget": "[data-testid='data-testid data-source-add-button']",
+          "requirements": ["on-page:/connections/datasources", "exists-reftarget"],
+          "verify": "on-page:/connections/datasources/new",
           "content": "Click **Add new data source**."
         },
         {
@@ -41,20 +35,23 @@
           "action": "formfill",
           "reftarget": "[placeholder='Filter by name or type']",
           "targetvalue": "Infinity",
+          "requirements": ["on-page:/connections/datasources/new", "exists-reftarget"],
           "content": "In the **Search** field, enter `Infinity`."
         },
         {
           "type": "interactive",
-          "action": "highlight",
-          "reftarget": "button[aria-label='Add new data source Infinity']",
+          "action": "button",
+          "reftarget": "Infinity",
+          "requirements": ["on-page:/connections/datasources/new", "exists-reftarget"],
+          "verify": "on-page:/connections/datasources/edit",
           "content": "From the search results, click the **Infinity** tile."
         },
         {
           "type": "interactive",
-          "action": "formfill",
-          "reftarget": "[data-testid='data-testid Data source settings page name input field']",
-          "targetvalue": "My Infinity Data Source",
-          "content": "Enter a name for the data source.",
+          "action": "highlight",
+          "reftarget": "button[aria-label='Edit title']",
+          "content": "To rename the data source, click the edit icon next to the data source name, then enter a meaningful name.",
+          "requirements": ["on-page:/connections/datasources/edit", "exists-reftarget"],
           "doIt": false
         }
       ]

--- a/linux-server-integration-lj/select-platform/content.json
+++ b/linux-server-integration-lj/select-platform/content.json
@@ -30,25 +30,32 @@
       "blocks": [
         {
           "type": "interactive",
-          "action": "highlight",
-          "reftarget": "a[data-testid='data-testid Nav menu item'][href='/connections/add-new-connection']",
-          "content": "Click **Connections > Add new connection** in the left-side menu.",
-          "requirements": [
-            "navmenu-open"
-          ]
+          "action": "navigate",
+          "reftarget": "/connections/add-new-connection",
+          "verify": "on-page:/connections/add-new-connection",
+          "content": "Open **Connections > Add new connection**."
         },
         {
           "type": "interactive",
           "action": "formfill",
           "reftarget": "input[data-testid='search-input-input']",
           "content": "Filter the connections by typing `Linux Server` in the search.",
-          "targetvalue": "Linux Server"
+          "targetvalue": "Linux Server",
+          "requirements": [
+            "on-page:/connections/add-new-connection",
+            "exists-reftarget"
+          ]
         },
         {
           "type": "interactive",
           "action": "highlight",
           "reftarget": "a[href='/connections/add-new-connection/linux-node']",
-          "content": "Click the **Linux Server** tile."
+          "content": "Click the **Linux Server** tile.",
+          "verify": "on-page:/connections/add-new-connection/linux-node",
+          "requirements": [
+            "on-page:/connections/add-new-connection",
+            "exists-reftarget"
+          ]
         },
         {
           "type": "markdown",
@@ -60,6 +67,7 @@
           "reftarget": "div[data-testid='collector-os-selection'] input",
           "content": "Select the **operating system** that matches your Linux distribution.",
           "requirements": [
+            "on-page:/connections/add-new-connection/linux-node",
             "exists-reftarget"
           ],
           "doIt": false
@@ -70,6 +78,7 @@
           "reftarget": "div[data-testid='collector-arch-selection'] input",
           "content": "Select the **architecture** that matches your system (Amd64 for x86_64, Arm64 for aarch64).",
           "requirements": [
+            "on-page:/connections/add-new-connection/linux-node",
             "exists-reftarget"
           ],
           "doIt": false

--- a/macos-integration-lj/select-architecture/content.json
+++ b/macos-integration-lj/select-architecture/content.json
@@ -13,23 +13,26 @@
       "blocks": [
         {
           "type": "interactive",
-          "action": "highlight",
-          "reftarget": "a[data-testid='data-testid Nav menu item'][href='/connections/add-new-connection']",
-          "content": "Click **Connections > Add new connection** in the left-side menu.",
-          "requirements": ["navmenu-open"]
+          "action": "navigate",
+          "reftarget": "/connections/add-new-connection",
+          "verify": "on-page:/connections/add-new-connection",
+          "content": "Open **Connections > Add new connection**."
         },
         {
           "type": "interactive",
           "action": "formfill",
           "reftarget": "input[data-testid='search-input-input']",
           "content": "Filter the connections by typing `macOS` in the search.",
-          "targetvalue": "macOS"
+          "targetvalue": "macOS",
+          "requirements": ["on-page:/connections/add-new-connection", "exists-reftarget"]
         },
         {
           "type": "interactive",
           "action": "highlight",
           "reftarget": "a[href='/connections/add-new-connection/macos-node']",
-          "content": "Click the **macOS** tile."
+          "content": "Click the **macOS** tile.",
+          "verify": "on-page:/connections/add-new-connection/macos-node",
+          "requirements": ["on-page:/connections/add-new-connection", "exists-reftarget"]
         },
         {
           "type": "markdown",
@@ -40,7 +43,7 @@
           "action": "highlight",
           "reftarget": "div[data-testid='collector-arch-selection'] input",
           "content": "Select the **architecture** that matches your Mac.\n\nIf you are unsure of your Mac's architecture, open Terminal and run `uname -m`. If it returns `x86_64`, you have an Intel Mac: select **Amd64**. If it returns `arm64`, select **Arm64**.",
-          "requirements": ["exists-reftarget"],
+          "requirements": ["on-page:/connections/add-new-connection/macos-node", "exists-reftarget"],
           "doIt": false
         },
         {
@@ -48,7 +51,7 @@
           "action": "highlight",
           "reftarget": "div[data-testid='collector-installation-method'] input",
           "content": "Select the **Homebrew** installation method.",
-          "requirements": ["exists-reftarget"],
+          "requirements": ["on-page:/connections/add-new-connection/macos-node", "exists-reftarget"],
           "doIt": false
         }
       ]

--- a/mongodb-integration-lj/select-platform/content.json
+++ b/mongodb-integration-lj/select-platform/content.json
@@ -20,13 +20,20 @@
         },
         {
           "type": "markdown",
-          "content": "On the Grafana Cloud home page, open the navigation menu on the left side of the screen and click **Connections > Add new connection**."
+          "content": "On the Grafana Cloud home page, open **Connections > Add new connection**."
+        },
+        {
+          "type": "interactive",
+          "action": "navigate",
+          "reftarget": "/connections/add-new-connection",
+          "verify": "on-page:/connections/add-new-connection",
+          "content": "Open **Connections > Add new connection**."
         },
         {
           "type": "interactive",
           "action": "formfill",
           "reftarget": "input[data-testid='search-input-input']",
-          "requirements": ["exists-reftarget"],
+          "requirements": ["on-page:/connections/add-new-connection", "exists-reftarget"],
           "content": "Search for `MongoDB` in the connections catalog.",
           "targetvalue": "MongoDB"
         },
@@ -34,7 +41,8 @@
           "type": "interactive",
           "action": "highlight",
           "reftarget": "a[href='/connections/add-new-connection/mongodb']",
-          "requirements": ["exists-reftarget"],
+          "requirements": ["on-page:/connections/add-new-connection", "exists-reftarget"],
+          "verify": "on-page:/connections/add-new-connection/mongodb",
           "content": "Click the **MongoDB** tile to open the integration setup page."
         },
         {

--- a/mysql-integration-lj/select-platform/content.json
+++ b/mysql-integration-lj/select-platform/content.json
@@ -13,10 +13,10 @@
       "blocks": [
         {
           "type": "interactive",
-          "action": "highlight",
-          "reftarget": "a[data-testid='data-testid Nav menu item'][href='/connections/add-new-connection']",
-          "content": "Click **Connections > Add new connection** in the left-side menu.",
-          "requirements": ["navmenu-open"]
+          "action": "navigate",
+          "reftarget": "/connections/add-new-connection",
+          "verify": "on-page:/connections/add-new-connection",
+          "content": "Open **Connections > Add new connection**."
         },
         {
           "type": "interactive",
@@ -24,14 +24,15 @@
           "reftarget": "input[data-testid='search-input-input']",
           "content": "Filter the connections by typing `MySQL` in the search.",
           "targetvalue": "MySQL",
-          "requirements": ["exists-reftarget"]
+          "requirements": ["on-page:/connections/add-new-connection", "exists-reftarget"]
         },
         {
           "type": "interactive",
           "action": "highlight",
           "reftarget": "a[href='/connections/add-new-connection/mysql']",
           "content": "Click the **MySQL** tile to open the setup page.",
-          "requirements": ["exists-reftarget"]
+          "verify": "on-page:/connections/add-new-connection/mysql",
+          "requirements": ["on-page:/connections/add-new-connection", "exists-reftarget"]
         },
         {
           "type": "markdown",
@@ -42,7 +43,7 @@
           "action": "highlight",
           "reftarget": "div[data-testid='collector-os-selection'] input",
           "content": "Select the **operating system** that matches your platform.",
-          "requirements": ["exists-reftarget"],
+          "requirements": ["on-page:/connections/add-new-connection/mysql", "exists-reftarget"],
           "doIt": false
         },
         {
@@ -50,7 +51,7 @@
           "action": "highlight",
           "reftarget": "div[data-testid='collector-arch-selection'] input",
           "content": "Select the **architecture** that matches your system (Amd64 for x86_64, Arm64 for aarch64).\n\nIf you are unsure of the architecture, run `uname -m` in your terminal. If it returns `x86_64`, select **Amd64**. If it returns `aarch64`, select **Arm64**.",
-          "requirements": ["exists-reftarget"],
+          "requirements": ["on-page:/connections/add-new-connection/mysql", "exists-reftarget"],
           "doIt": false
         }
       ]

--- a/postgresql-db-olly-lj/verify-telemetry/content.json
+++ b/postgresql-db-olly-lj/verify-telemetry/content.json
@@ -17,25 +17,10 @@
         },
         {
           "type": "interactive",
-          "action": "highlight",
-          "reftarget": "button[aria-label*='section: Observability']",
-          "content": "Expand **Observability** in the navigation menu.",
-          "requirements": ["navmenu-open"],
-          "doIt": false
-        },
-        {
-          "type": "interactive",
-          "action": "highlight",
-          "reftarget": "a[data-testid='data-testid Nav menu item'][href='/a/grafana-dbo11y-app/']",
-          "content": "Click **Database**.",
-          "requirements": ["navmenu-open"]
-        },
-        {
-          "type": "interactive",
-          "action": "highlight",
-          "reftarget": "a[data-testid='data-testid Nav menu item'][href='/a/grafana-dbo11y-app/configuration']",
-          "content": "Click **Configuration** in the Database Observability navigation.",
-          "requirements": ["on-page:/a/grafana-dbo11y-app"]
+          "action": "navigate",
+          "reftarget": "/a/grafana-dbo11y-app/configuration",
+          "content": "Open **Database > Configuration**.",
+          "verify": "on-page:/a/grafana-dbo11y-app/configuration"
         },
         {
           "type": "markdown",

--- a/postgresql-integration-lj/select-platform/content.json
+++ b/postgresql-integration-lj/select-platform/content.json
@@ -17,23 +17,26 @@
       "blocks": [
         {
           "type": "interactive",
-          "action": "highlight",
-          "reftarget": "a[data-testid='data-testid Nav menu item'][href='/connections/add-new-connection']",
-          "content": "Click **Connections > Add new connection** in the left-side menu.",
-          "requirements": ["navmenu-open"]
+          "action": "navigate",
+          "reftarget": "/connections/add-new-connection",
+          "verify": "on-page:/connections/add-new-connection",
+          "content": "Open **Connections > Add new connection**."
         },
         {
           "type": "interactive",
           "action": "formfill",
           "reftarget": "input[data-testid='search-input-input']",
           "targetvalue": "PostgreSQL",
-          "content": "Filter the connections by typing `PostgreSQL` in the search."
+          "content": "Filter the connections by typing `PostgreSQL` in the search.",
+          "requirements": ["on-page:/connections/add-new-connection", "exists-reftarget"]
         },
         {
           "type": "interactive",
           "action": "highlight",
           "reftarget": "a[href='/connections/add-new-connection/postgres']",
-          "content": "Click the **PostgreSQL** tile to open the setup page."
+          "content": "Click the **PostgreSQL** tile to open the setup page.",
+          "verify": "on-page:/connections/add-new-connection/postgres",
+          "requirements": ["on-page:/connections/add-new-connection", "exists-reftarget"]
         },
         {
           "type": "markdown",
@@ -44,6 +47,7 @@
           "action": "highlight",
           "reftarget": "div[data-testid='collector-os-selection']",
           "content": "Select the **operating system** that matches your platform.",
+          "requirements": ["on-page:/connections/add-new-connection/postgres", "exists-reftarget"],
           "doIt": false
         },
         {
@@ -51,6 +55,7 @@
           "action": "highlight",
           "reftarget": "div[data-testid='collector-arch-selection']",
           "content": "Select the **architecture** that matches your system (Amd64 for x86_64, Arm64 for aarch64).\n\nIf you are unsure of the architecture of a Linux machine, run `uname -m` in your terminal. If it returns `x86_64`, select **Amd64**. If it returns `aarch64`, select **Arm64**. If the command returns anything else, your system isn't supported by Grafana Alloy; you need to use a 64-bit x86 or ARM system.",
+          "requirements": ["on-page:/connections/add-new-connection/postgres", "exists-reftarget"],
           "doIt": false
         },
         {

--- a/run-first-k6-test-lj/analyze-results/content.json
+++ b/run-first-k6-test-lj/analyze-results/content.json
@@ -12,14 +12,12 @@
       "title": "Explore test results",
       "blocks": [
         {
-          "type": "multistep",
+          "type": "interactive",
+          "action": "navigate",
+          "reftarget": "/a/k6-app",
           "content": "In the main menu, navigate to **Testing & synthetics > Performance**.",
-          "requirements": ["navmenu-open"],
-          "skippable": true,
-          "steps": [
-            { "action": "highlight", "reftarget": "a[data-testid='data-testid Nav menu item'][href='/testing-and-synthetics']" },
-            { "action": "highlight", "reftarget": "a[data-testid='data-testid Nav menu item'][href='/a/k6-app']" }
-          ]
+          "verify": "on-page:/a/k6-app",
+          "skippable": true
         },
         {
           "type": "markdown",
@@ -38,16 +36,12 @@
           "content": "Scroll down to the **Cloud Insights** section.\n\nCloud Insights analyzes your test script and results, then generates scores and recommendations across categories such as best practice, reliability, and system performance."
         },
         {
-          "type": "interactive",
-          "action": "highlight",
-          "reftarget": "a[data-testid='data-testid Tab HTTP']",
-          "content": "Select the **HTTP** tab to explore detailed request metrics for each endpoint, including count, response times (min, average, p95, p99, max), and status codes."
+          "type": "markdown",
+          "content": "After you open a test run, select the **HTTP** tab to review detailed request metrics for each endpoint."
         },
         {
-          "type": "interactive",
-          "action": "highlight",
-          "reftarget": "a[data-testid='data-testid Tab THRESHOLDS']",
-          "content": "Select the **Thresholds** tab to review the default and custom thresholds for your test.\n\nGrafana Cloud k6 automatically applies thresholds like `http_req_failed` and `http_req_duration`."
+          "type": "markdown",
+          "content": "Select the **Thresholds** tab to review the default and custom thresholds for your test, such as `http_req_failed` and `http_req_duration`."
         }
       ]
     },

--- a/tempo-data-source-lj/add-data-source/content.json
+++ b/tempo-data-source-lj/add-data-source/content.json
@@ -13,15 +13,17 @@
       "blocks": [
         {
           "type": "interactive",
-          "action": "highlight",
-          "reftarget": "a[href='/connections/datasources']",
-          "requirements": ["navmenu-open"],
+          "action": "navigate",
+          "reftarget": "/connections/datasources",
+          "verify": "on-page:/connections/datasources",
           "content": "In the navigation menu, click **Connections > Data sources**."
         },
         {
           "type": "interactive",
           "action": "highlight",
           "reftarget": "[data-testid='data-testid data-source-add-button']",
+          "requirements": ["on-page:/connections/datasources", "exists-reftarget"],
+          "verify": "on-page:/connections/datasources/new",
           "content": "Click **Add new data source**."
         },
         {
@@ -29,18 +31,22 @@
           "action": "formfill",
           "reftarget": "input[placeholder='Filter by name or type']",
           "targetvalue": "Tempo",
+          "requirements": ["on-page:/connections/datasources/new", "exists-reftarget"],
           "content": "In the **Filter by name or type** field, enter `Tempo`."
         },
         {
           "type": "interactive",
           "action": "button",
           "reftarget": "Tempo",
+          "requirements": ["on-page:/connections/datasources/new", "exists-reftarget"],
+          "verify": "on-page:/connections/datasources/edit",
           "content": "From the search results, click **Tempo**."
         },
         {
           "type": "interactive",
           "action": "highlight",
           "reftarget": "button[aria-label='Edit title']",
+          "requirements": ["on-page:/connections/datasources/edit", "exists-reftarget"],
           "content": "At the top of the page, next to the data source name, click the edit (pencil) icon and enter a descriptive name for your Tempo data source.\n\nFor example, enter `Production Tempo`.\n\n**Did you know?** The name of the data source is displayed on dashboard panels and in the data source picker in Explore, so it's important to choose a meaningful name."
         }
       ]

--- a/windows-integration-lp/select-platform/content.json
+++ b/windows-integration-lp/select-platform/content.json
@@ -13,12 +13,10 @@
       "blocks": [
         {
           "type": "interactive",
-          "action": "highlight",
-          "reftarget": "a[data-testid='data-testid Nav menu item'][href='/connections/add-new-connection']",
-          "content": "Navigate to **Connections > Add new connection**.",
-          "requirements": [
-            "navmenu-open"
-          ]
+          "action": "navigate",
+          "reftarget": "/connections/add-new-connection",
+          "content": "Open **Connections > Add new connection**.",
+          "verify": "on-page:/connections/add-new-connection"
         },
         {
           "type": "interactive",
@@ -27,6 +25,7 @@
           "targetvalue": "Windows",
           "content": "In the search box, type **Windows** to filter the integrations.",
           "requirements": [
+            "on-page:/connections/add-new-connection",
             "exists-reftarget"
           ]
         },
@@ -36,8 +35,10 @@
           "reftarget": "a[href=\"/connections/add-new-connection/windows-exporter\"]",
           "content": "Click the **Windows** tile to select the integration.",
           "requirements": [
+            "on-page:/connections/add-new-connection",
             "exists-reftarget"
-          ]
+          ],
+          "verify": "on-page:/connections/add-new-connection/windows-exporter"
         }
       ]
     },


### PR DESCRIPTION
## Summary
- Replace hidden sidebar child-link highlights with direct navigation steps.
- Add page guards before selector-specific guide steps.
- Convert k6 result tab selector steps to markdown because the tabs appear only after a test run is open.
- A couple of ancillary changes to heal `infinity-csv-lj/add-data-source` (data source tile selector, title edit control).

## Why
Recent e2e test runs showed repeated failures on fresh stacks for this group of guides related to sidebar nav item interactivity. The guides expected child sidebar links to be visible, but those sidebar sections start collapsed. Direct navigation removes that state dependency.

The changes here should heal these guides fully, except for `github-data-source-lj/install-github-plugin` and `postgresql-db-olly-lj/verify-telemetry`. The GitHub data source flow appears to have changed a bit in Grafana, and I'm not sure how to update. The postgresql-db-olly guide appears to assume that Alloy is already installed on the stack, and it may need a `depends` entry declared in its manifest. Both cases are outside the scope of the changes here.
