### PR TITLE
Fix target UI guide selectors

### DIFF
--- a/adaptive-logs-recommendations/content.json
+++ b/adaptive-logs-recommendations/content.json
@@ -92,7 +92,7 @@
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "label[aria-label^='Show early detection patterns']",
+          "reftarget": "[data-testid='early-detection-patterns-toggle']",
           "content": "Enable **Show early detection patterns** to see newly detected log patterns sooner. Use this when you want to react quickly to new ingest spikes or noisy logs before Adaptive Logs has enough data to generate a recommendation.",
           "requirements": [
             "exists-reftarget"

--- a/adaptive-metrics-recommendations/content.json
+++ b/adaptive-metrics-recommendations/content.json
@@ -28,8 +28,8 @@
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "a[data-testid='data-testid Tab Rules']",
-          "content": "Open the **Rules** tab to review recommendations for aggregations and series reductions. This is where you’ll spend most of your time reviewing, filtering, and deciding which changes to apply.",
+          "reftarget": "a[data-testid='data-testid Tab Metrics']",
+          "content": "Open the **Metrics** tab to review recommendations for aggregations and series reductions. This is where you’ll spend most of your time reviewing, filtering, and deciding which changes to apply.",
           "requirements": [
             "exists-reftarget"
           ]

--- a/billing-usage-lj/navigate-to-billing-dashboard/content.json
+++ b/billing-usage-lj/navigate-to-billing-dashboard/content.json
@@ -25,7 +25,7 @@
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "button[data-testid='data-testid Tab Usage']",
+          "reftarget": "button[data-testid='tab-usage']",
           "content": "The **Usage** tab is where you track current spend and per-product usage.",
           "requirements": [
             "exists-reftarget",
@@ -36,8 +36,8 @@
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "h2:contains('Cost and Usage Overview')",
-          "content": "The **Cost and Usage Overview** summarizes your spend balance and contract burndown for the current period.",
+          "reftarget": "h1:contains('Cost and Usage Overview')",
+          "content": "The **Cost and Usage Overview** summarizes billable usage cost, plan cost, and overages.",
           "requirements": [
             "exists-reftarget",
             "on-page:/a/grafana-cmab-app/usage"
@@ -47,8 +47,8 @@
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "[data-testid='data-testid Panel header Contract Burndown']",
-          "content": "The **Contract Burndown** chart compares your committed spend against your cumulative usage cost over time.",
+          "reftarget": "h3:contains('Monthly Usage')",
+          "content": "The **Monthly Usage** chart shows monthly cost and Adaptive Telemetry savings for the selected period.",
           "requirements": [
             "exists-reftarget",
             "on-page:/a/grafana-cmab-app/usage"
@@ -77,7 +77,7 @@
     },
     {
       "type": "markdown",
-      "content": "## Find your way around\n\nThe app organizes billing and usage information into tabs:\n\n- **Usage**: Your current spend balance, contract burndown, and a per-product breakdown of usage and cost.\n- **Cardinality**: Tools to analyze metrics cardinality, a common driver of metrics cost.\n- **Attributions**: Usage and cost broken down by your configured cost attribution labels, so you can assign spend to teams or services.\n- **Usage Alerts**: Create and manage alerts that notify you when usage or cost approaches a threshold.\n- **Invoices**: View and download your monthly invoices.\n\nThe roles you have determine which tabs you can see. For example, viewing usage requires the **Billing and usage reader** role."
+      "content": "## Find your way around\n\nThe app organizes billing and usage information into tabs:\n\n- **Usage**: Your current billable usage cost, monthly usage, and per-product breakdown of usage and cost.\n- **Cardinality**: Tools to analyze metrics cardinality, a common driver of metrics cost.\n- **Attributions**: Usage and cost broken down by your configured cost attribution labels, so you can assign spend to teams or services.\n- **Usage Alerts**: Create and manage alerts that notify you when usage or cost approaches a threshold.\n- **Invoices**: View and download your monthly invoices.\n\nThe roles you have determine which tabs you can see. For example, viewing usage requires the **Billing and usage reader** role."
     },
     {
       "type": "markdown",

--- a/cloudwatch-data-source-lj/add-data-source/content.json
+++ b/cloudwatch-data-source-lj/add-data-source/content.json
@@ -37,6 +37,7 @@
           "action": "button",
           "reftarget": "CloudWatch",
           "requirements": ["on-page:/connections/datasources/new", "exists-reftarget"],
+          "verify": "on-page:/connections/datasources/edit",
           "content": "Click **CloudWatch**.\n\nGrafana creates the data source and opens its **Settings** tab, where you'll configure the connection."
         }
       ]

--- a/create-availability-slo-lj/create-availability-slo/content.json
+++ b/create-availability-slo-lj/create-availability-slo/content.json
@@ -24,7 +24,7 @@
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "a[data-testid=\"data-testid Nav menu item\"][href=\"/a/grafana-slo-app/home/insights\"]",
+          "reftarget": "a[href=\"/a/grafana-slo-app/home/insights\"]",
           "requirements": ["navmenu-open"],
           "content": "Click **SLO**."
         },

--- a/drilldown-metrics-lj/search-metrics/content.json
+++ b/drilldown-metrics-lj/search-metrics/content.json
@@ -33,8 +33,8 @@
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "input[placeholder='Filter by label values']",
-          "content": "Use one of the following methods to reduce the number of metrics you see:\n\n- Select a filter in the **Filter by label values** field.\n- Enter a search expression in the **Search metrics** field and press **Enter**.\n\nFor example, enter `cpu`. The metrics that match the search or filter expression appear.",
+          "reftarget": "input[placeholder='+ label = value']",
+          "content": "Use one of the following methods to reduce the number of metrics you see:\n\n- Select a filter in the **+ label = value** field.\n- Enter a search expression in the **Search metrics** field and press **Enter**.\n\nFor example, enter `cpu`. The metrics that match the search or filter expression appear.",
           "requirements": ["exists-reftarget"],
           "doIt": false
         }

--- a/explore-cardinality/content.json
+++ b/explore-cardinality/content.json
@@ -31,7 +31,7 @@
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "button[data-testid='data-testid Tab Cardinality']",
+          "reftarget": "button[data-testid='tab-cardinality']",
           "content": "Select the **Cardinality** tab.",
           "requirements": [
             "exists-reftarget",

--- a/monitor-aws-resources-lj/connect-aws-account/content.json
+++ b/monitor-aws-resources-lj/connect-aws-account/content.json
@@ -19,7 +19,7 @@
           "targetvalue": "aws-ec2-account",
           "content": "In the **Account name** field, enter a unique name that contains only alphanumeric characters, dashes, and underscores, for example `aws-ec2-account`.",
           "doIt": false,
-          "requirements": ["exists-reftarget", "on-page:/a/grafana-csp-app/aws/configuration"]
+          "requirements": ["exists-reftarget", "on-page:/a/grafana-csp-app/aws/configuration/accounts/create"]
         },
         {
           "type": "interactive",

--- a/monitor-aws-resources-lj/connect-aws-account/manifest.json
+++ b/monitor-aws-resources-lj/connect-aws-account/manifest.json
@@ -7,7 +7,7 @@
     "name": "Jack Baldry",
     "team": "Grafana Documentation"
   },
-  "startingLocation": "/a/grafana-csp-app/aws/configuration",
+  "startingLocation": "/a/grafana-csp-app/aws/configuration/accounts/create",
   "testEnvironment": {
     "tier": "cloud"
   },

--- a/monitor-azure-resources-lj/configure-metrics/content.json
+++ b/monitor-azure-resources-lj/configure-metrics/content.json
@@ -19,7 +19,7 @@
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "div[role='button']:contains('Autodiscovery')",
+          "reftarget": "button:contains('Autodiscovery')",
           "content": "Scroll to the **Configure metrics** section and select **Autodiscovery**.",
           "requirements": ["exists-reftarget", "on-page:/a/grafana-csp-app/azure/configuration/azure-metrics-serverless/create"]
         },

--- a/sm-dns-check-tutorial/content.json
+++ b/sm-dns-check-tutorial/content.json
@@ -40,6 +40,29 @@
           ]
         },
         {
+          "type": "conditional",
+          "conditions": [
+            "exists-reftarget"
+          ],
+          "reftarget": "button[data-testid='app-init init-button']",
+          "whenTrue": [
+            {
+              "type": "interactive",
+              "action": "highlight",
+              "reftarget": "button[data-testid='app-init init-button']",
+              "content": "Click **Get started** to initialize Synthetic Monitoring.",
+              "requirements": [
+                "exists-reftarget"
+              ]
+            },
+            {
+              "type": "markdown",
+              "content": "Wait until the Synthetic Monitoring home page shows **Create new check**."
+            }
+          ],
+          "whenFalse": []
+        },
+        {
           "type": "interactive",
           "action": "highlight",
           "reftarget": "a[data-testid='action create check']",

--- a/sm-scripted-check-tutorial/content.json
+++ b/sm-scripted-check-tutorial/content.json
@@ -19,6 +19,29 @@
           "verify": "on-page:/a/grafana-synthetic-monitoring-app/home"
         },
         {
+          "type": "conditional",
+          "conditions": [
+            "exists-reftarget"
+          ],
+          "reftarget": "button[data-testid='app-init init-button']",
+          "whenTrue": [
+            {
+              "type": "interactive",
+              "action": "highlight",
+              "reftarget": "button[data-testid='app-init init-button']",
+              "content": "Click **Get started** to initialize Synthetic Monitoring.",
+              "requirements": [
+                "exists-reftarget"
+              ]
+            },
+            {
+              "type": "markdown",
+              "content": "Wait until the Synthetic Monitoring home page shows **Create new check**."
+            }
+          ],
+          "whenFalse": []
+        },
+        {
           "type": "interactive",
           "action": "highlight",
           "reftarget": "a[data-testid='action create check']",

--- a/sm-tcp-check-tutorial/content.json
+++ b/sm-tcp-check-tutorial/content.json
@@ -40,6 +40,29 @@
           ]
         },
         {
+          "type": "conditional",
+          "conditions": [
+            "exists-reftarget"
+          ],
+          "reftarget": "button[data-testid='app-init init-button']",
+          "whenTrue": [
+            {
+              "type": "interactive",
+              "action": "highlight",
+              "reftarget": "button[data-testid='app-init init-button']",
+              "content": "Click **Get started** to initialize Synthetic Monitoring.",
+              "requirements": [
+                "exists-reftarget"
+              ]
+            },
+            {
+              "type": "markdown",
+              "content": "Wait until the Synthetic Monitoring home page shows **Create new check**."
+            }
+          ],
+          "whenFalse": []
+        },
+        {
           "type": "interactive",
           "action": "highlight",
           "reftarget": "a[data-testid='action create check']",

--- a/transform-data/content.json
+++ b/transform-data/content.json
@@ -61,7 +61,7 @@
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "button[data-testid='data-testid Tab All visualizations']",
+          "reftarget": "button[data-testid='data-testid Tab Visualizations']",
           "content": "Click **All visualizations** to display the full list of visualization types."
         },
         {

--- a/visualization-traces-lj/add-visualization/content.json
+++ b/visualization-traces-lj/add-visualization/content.json
@@ -42,12 +42,30 @@
           ]
         },
         {
-          "type": "markdown",
-          "content": "In the **Add** drawer, click the **Panel** card to add a new visualization to your dashboard.\n\nA new panel is added to your dashboard."
+          "type": "multistep",
+          "content": "Click **Skip to dashboard**, open the **Add** drawer, and click **Panel**.",
+          "requirements": ["on-page:/dashboard/new"],
+          "steps": [
+            {
+              "action": "highlight",
+              "reftarget": "button:text('Skip to dashboard')"
+            },
+            {
+              "action": "highlight",
+              "reftarget": "button[data-testid='data-testid Dashboard Sidebar new button']"
+            },
+            {
+              "action": "highlight",
+              "reftarget": "div[data-testid='data-testid sidebar add new panel']"
+            }
+          ]
         },
         {
-          "type": "markdown",
-          "content": "On the new panel, enter a panel title and description, and click **Configure** to open the Edit panel view."
+          "type": "interactive",
+          "action": "button",
+          "reftarget": "Configure",
+          "content": "On the new panel, click **Configure** to open the Edit panel view.",
+          "requirements": ["exists-reftarget", "on-page:/dashboard/new"]
         },
         {
           "type": "interactive",
@@ -64,7 +82,7 @@
           "steps": [
             {
               "action": "highlight",
-              "reftarget": "[data-testid='data-testid Tab All visualizations']"
+              "reftarget": "[data-testid='data-testid Tab Visualizations']"
             },
             {
               "action": "highlight",


### PR DESCRIPTION
## Summary
- Update guide selectors for current Target UI states in Drilldown, Synthetic Monitoring, Cost Management, dashboard, Adaptive, CSP, SLO, and data-source flows.
- Add Synthetic Monitoring onboarding handling before `Create new check` steps.
- Add page verification or current selectors where artifact evidence showed a guide-content-only fix was safe.

## Why
Recent e2e guide failure artifacts showed that several guides reached the correct page, but the page used newer selectors, showed onboarding, or needed an intermediate UI step before the target existed. These changes fix the guide-content cases that were safe to correct from screenshots and DOM snapshots.

## Validation
- JSON parse check passed for 15 changed JSON files.
- `node /Users/leslieheinzen/Source/grafana-pathfinder-app/dist/cli/cli/index.js validate --strict <file>` passed for 14 changed `content.json` files.
- `git --no-pager diff --check` passed.

## Out of scope
- RCA / Asserts demo setup and Knowledge Graph data.
- Drilldown Logs and Traces seeded telemetry data.
- Fleet collector inventory and attributes.
- Semantic Layer seeded Cube data source.
- Usage Alerts builder flow after `Create alert`.
- Git Sync seeded GitHub App credentials.
- Infrastructure alerting valid draft rule state.
