### PR TITLE
Fix alerting-query-language install-datasources health failure

### DIFF
--- a/alerting-query-language-lj/install-datasources/content.json
+++ b/alerting-query-language-lj/install-datasources/content.json
@@ -35,14 +35,20 @@
         {
           "type": "guided",
           "content": "Click **Install the Quick Pizza SRE demo**. This deploys the tutorial data sources and refreshes the page.",
-          "completeEarly": true,
           "steps": [
             {
-              "action": "highlight",
+              "action": "button",
               "reftarget": "button[data-testid='install-quickpizza']",
-              "lazyRender": true
+              "lazyRender": true,
+              "requirements": ["exists-reftarget"]
             }
           ]
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "After install, Grafana refreshes the page and the tutorial Prometheus data source **grafanacloud-play-prom** becomes available.",
+          "requirements": ["has-datasource:grafanacloud-play-prom"]
         }
       ]
     },


### PR DESCRIPTION
Fixes the `alerting-query-language-lj` health failure where `build-query` blocked on step 1 because `grafanacloud-play-prom` was not installed. The install milestone now clicks **Install the Quick Pizza SRE demo** and waits for `has-datasource:grafanacloud-play-prom` before advancing.

Related to grafana/interactive-tutorials#552

Made with [Cursor](https://cursor.com)