### PR TITLE
Fix billing-usage Product Breakdown selector

### DIFF
--- a/billing-usage-lj/identify-cost-sources/content.json
+++ b/billing-usage-lj/identify-cost-sources/content.json
@@ -25,7 +25,7 @@
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "h2:contains('Product Breakdown')",
+          "reftarget": "h1:contains('Product Breakdown')",
           "content": "Scroll to the **Product Breakdown** section. It lists each billable product, such as Metrics, Logs, Traces, Profiles, and k6, with its current usage and cost. Compare the costs to find which products consume most of your budget. You can also compare the selected period against an earlier one to see how each product's spend is trending.",
           "requirements": [
             "exists-reftarget",


### PR DESCRIPTION
Fixes the `billing-usage-lj` health failure on Identify the source of billable activity where `exists-reftarget` could not find Product Breakdown. The Usage page renders that heading as an `h1`, not an `h2`.

Related to grafana/interactive-tutorials#552

Made with [Cursor](https://cursor.com)