### PR TITLE
Make drilldown-logs optional service filters skippable

### DIFF
--- a/drilldown-logs-lj/view-logs/content.json
+++ b/drilldown-logs-lj/view-logs/content.json
@@ -29,7 +29,8 @@
           "requirements": [
             "exists-reftarget"
           ],
-          "doIt": false
+          "doIt": false,
+          "skippable": true
         },
         {
           "type": "interactive",
@@ -39,7 +40,8 @@
           "requirements": [
             "exists-reftarget"
           ],
-          "doIt": false
+          "doIt": false,
+          "skippable": true
         },
         {
           "type": "conditional",


### PR DESCRIPTION
Fixes the `drilldown-logs-lj` health failure on View service logs where `exists-reftarget` blocked on the service search input when it was not visible. Marks the conditional data source and service search steps as `skippable: true` so they do not fail the path when those controls are absent or hidden.

Related to grafana/interactive-tutorials#552

Made with [Cursor](https://cursor.com)