### PR TITLE
Bump pinned Pathfinder CLI to acbf39b4 so completion stats reach repository.json

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -59,7 +59,13 @@ jobs:
           # Pin: bumped from 342121e6 now the upstream lockfile is back in sync (npm ci passes).
           # This pin must include grafana-pathfinder-app#1661, which added `build-stats`;
           # the old pin predates it and has no such command.
-          ref: 4d697f8088262ec41b735a8ed0cc0ab2390b483f
+          # Bumped again from 4d697f80: that pin's `build-repository` dropped the `stats` key
+          # the build-stats step above had just written, so the stamping was inert. This pin is
+          # grafana-pathfinder-app#1662, which forwards unknown top-level manifest keys into
+          # repository.json — the smallest move that makes the stats reach the CDN. Deliberately
+          # stops short of #1710 (CLI command binding); it rides along on #1684, which adds the
+          # `callout` block type, counted as one non-container block like `markdown`.
+          ref: acbf39b4fbad1459a807754e2d54488e3d58df3e
           path: pathfinder-app
           persist-credentials: false
 
@@ -144,7 +150,13 @@ jobs:
           # Pin: bumped from 342121e6 now the upstream lockfile is back in sync (npm ci passes).
           # This pin must include grafana-pathfinder-app#1661, which added `build-stats`;
           # the old pin predates it and has no such command.
-          ref: 4d697f8088262ec41b735a8ed0cc0ab2390b483f
+          # Bumped again from 4d697f80: that pin's `build-repository` dropped the `stats` key
+          # the build-stats step above had just written, so the stamping was inert. This pin is
+          # grafana-pathfinder-app#1662, which forwards unknown top-level manifest keys into
+          # repository.json — the smallest move that makes the stats reach the CDN. Deliberately
+          # stops short of #1710 (CLI command binding); it rides along on #1684, which adds the
+          # `callout` block type, counted as one non-container block like `markdown`.
+          ref: acbf39b4fbad1459a807754e2d54488e3d58df3e
           path: pathfinder-app
           persist-credentials: false
 

--- a/.github/workflows/validate-json.yml
+++ b/.github/workflows/validate-json.yml
@@ -70,7 +70,10 @@ jobs:
         # The old pin predated the input block's dataCheck* fields and rejected them as unknown.
         # Bumped again from 2262da89: this pin must include grafana-pathfinder-app#1661,
         # which added `build-stats`; 2262da89 predates it and has no such command.
-        ref: 4d697f8088262ec41b735a8ed0cc0ab2390b483f
+        # Bumped again from 4d697f80 to keep this validator on the same CLI as deploy.yml, whose
+        # `build-repository` needed grafana-pathfinder-app#1662 to forward the `stats` key at all.
+        # Carries #1684's new `callout` block type, so a guide using one validates here.
+        ref: acbf39b4fbad1459a807754e2d54488e3d58df3e
         path: pathfinder-app
         persist-credentials: false
 


### PR DESCRIPTION
Moves the pinned `grafana-pathfinder-app` CLI from `4d697f80` to `acbf39b4` in all three places (`deploy.yml` ×2, `validate-json.yml`).

## Why

The pipeline already runs `build-stats` to stamp every manifest with its completion stats, then `build-repository` to denormalise them into `repository.json`. At `4d697f80`, `build-repository` did not forward the `stats` key, so the numbers were computed and dropped. This pin is [grafana-pathfinder-app#1662](https://github.com/grafana/grafana-pathfinder-app/pull/1662), which forwards unknown top-level manifest keys through.

## Which commit

`acbf39b4` is #1662 itself — a five-commit window, the smallest move that does the job. It stops short of #1710 (CLI command binding), which is 18 commits further on. Verified against a real checkout at the candidate:

- `npm ci` passes (the lockfile desync that rejected an earlier candidate is not present here).
- `npm run build:cli` succeeds; `build-stats` and `build-repository` both exist and run.
- `engines.node` is `>=24`, unchanged from the old pin, so the explicit Node 24 pin in `deploy.yml` still satisfies it.

## What rides along

Four commits besides #1662: a react-router-dom security bump (#1680), a completion-records 404 fix (#1660), an e2e retry-budget change (#1688), and **#1684, which adds a new `callout` block type**.

Since these stats count blocks, `callout` was checked specifically. It is a leaf block (`title` + markdown `content`, no child array) and appears in neither `TRANSPARENT_CONTAINER_BLOCK_TYPES` nor `OPAQUE_PARENT_BLOCK_TYPES`, so the counting rule gives it **exactly one position in the denominator**, like `markdown`/`image`/`video`. Confirmed empirically — two otherwise identical fixture packages, one with a callout and one without, stamped `blockCount` 4 and 3. Not double counted, not skipped, and it does not raise `completableBlockCount`, matching its presentational declaration. No guide in this repo uses one yet.

## Evidence

Run from the repository root at the new pin, exactly as CI invokes them:

```
build-stats     → ✅ 667 manifest(s) updated, 0 already up to date   (exit 0)
build-repository → ✅ Wrote repository.json (667 packages)            (exit 0)
```

`build-stats` exits clean over the whole tree — it aborts the entire run on an unresolvable, duplicated or double-parented milestone, so this is the evidence the new pin does not break the deploy path. 667 packages, up from the 665 last recorded.

`repository.json` now carries stats: **667 of 667 entries** have a `stats` object (e.g. `{"version":1,"blockCount":85,"sectionCount":9,"completableBlockCount":16,"finalCompletablePosition":67}`), and `build-repository` logs `forwarding 1 extension field(s): stats` per package. The same command built at the old pin over the same tree produced **0 of 667**.

No stamped manifests or generated index are committed; the working tree was restored after the runs.

## Noted, not changed

`validate-json.yml` reads Node from `node-version-file: pathfinder-app/package.json`, where `engines.node` is the open-ended `>=24`, while `deploy.yml` pins `24` explicitly with a comment explaining why. That divergence predates this PR and is unaffected by it.
