### PR TITLE
Add PostgreSQL data source learning path

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -79,6 +79,7 @@
 /adaptive-logs-lj/                                        @chri2547
 /play-carbon-intensity/                                   @simonprickett
 /play-traitors-uk-tour/                                   @simonprickett
+/postgresql-data-source-lj/                               @lwandz13
 /postgresql-integration-lj/                               @chri2547
 /prom-remote-write-lj/                                    @knylander-grafana
 /prometheus-lj/                                           @knylander-grafana

--- a/postgresql-data-source-lj/add-data-source/content.json
+++ b/postgresql-data-source-lj/add-data-source/content.json
@@ -51,14 +51,13 @@
         },
         {
           "type": "interactive",
-          "action": "formfill",
-          "reftarget": "input[placeholder='Name']",
-          "targetvalue": "Production PostgreSQL Database",
+          "action": "highlight",
+          "reftarget": "[data-testid='data-testid Editable title edit button']",
           "doIt": false,
           "requirements": [
             "exists-reftarget"
           ],
-          "content": "In the **Name** field, enter a descriptive name for your PostgreSQL data source.\n\nFor example, enter `Production PostgreSQL Database`.\n\n**Did you know?** The name of the data source is displayed on dashboard panels, so it's important to choose a meaningful name."
+          "content": "To give your data source a descriptive name, click the **edit title** (pencil) icon next to the name at the top of the page, then enter a name such as `Production PostgreSQL Database`.\n\n**Did you know?** The name of the data source is displayed on dashboard panels, so it's important to choose a meaningful name."
         }
       ]
     },

--- a/postgresql-data-source-lj/add-data-source/content.json
+++ b/postgresql-data-source-lj/add-data-source/content.json
@@ -1,0 +1,74 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "postgresql-data-source-add",
+  "title": "Add the PostgreSQL data source",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "Grafana ships with the PostgreSQL data source preinstalled in Grafana Cloud, so you don't need to install a plugin. In this milestone, you add the PostgreSQL data source and give it a descriptive name.\n\nLet's walk through the steps together."
+    },
+    {
+      "type": "section",
+      "autoCollapse": false,
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "a[href='/connections/datasources']",
+          "requirements": [
+            "navmenu-open",
+            "exists-reftarget"
+          ],
+          "content": "In the navigation menu, click **Connections > Data sources**."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='data-testid data-source-add-button']",
+          "requirements": [
+            "exists-reftarget"
+          ],
+          "content": "Click **Add new data source**."
+        },
+        {
+          "type": "interactive",
+          "action": "formfill",
+          "reftarget": "input[placeholder='Filter by name or type']",
+          "targetvalue": "PostgreSQL",
+          "requirements": [
+            "exists-reftarget"
+          ],
+          "content": "In the **Search** field, enter `PostgreSQL`."
+        },
+        {
+          "type": "interactive",
+          "action": "button",
+          "reftarget": "PostgreSQL",
+          "requirements": [
+            "exists-reftarget"
+          ],
+          "content": "From the search results, click **PostgreSQL**."
+        },
+        {
+          "type": "interactive",
+          "action": "formfill",
+          "reftarget": "input[placeholder='Name']",
+          "targetvalue": "Production PostgreSQL Database",
+          "doIt": false,
+          "requirements": [
+            "exists-reftarget"
+          ],
+          "content": "In the **Name** field, enter a descriptive name for your PostgreSQL data source.\n\nFor example, enter `Production PostgreSQL Database`.\n\n**Did you know?** The name of the data source is displayed on dashboard panels, so it's important to choose a meaningful name."
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "In the next milestone, you'll configure the connection details and authentication credentials for your PostgreSQL server."
+    },
+    {
+      "type": "markdown",
+      "content": "---\n\n### More to explore (optional)\n\n- [Add the PostgreSQL data source](https://grafana.com/docs/grafana/latest/datasources/postgres/configure/#add-the-postgresql-data-source)\n- [Data source plugins for Grafana](https://grafana.com/grafana/plugins/data-source-plugins/)"
+    }
+  ]
+}

--- a/postgresql-data-source-lj/add-data-source/content.json
+++ b/postgresql-data-source-lj/add-data-source/content.json
@@ -5,7 +5,7 @@
   "blocks": [
     {
       "type": "markdown",
-      "content": "Grafana ships with the PostgreSQL data source preinstalled in Grafana Cloud, so you don't need to install a plugin. In this milestone, you add the PostgreSQL data source and give it a descriptive name.\n\nLet's walk through the steps together."
+      "content": "PostgreSQL is a built-in core data source in Grafana, so you don't need to install a plugin. In this milestone, you add the PostgreSQL data source and give it a descriptive name.\n\nLet's walk through the steps together."
     },
     {
       "type": "section",

--- a/postgresql-data-source-lj/add-data-source/manifest.json
+++ b/postgresql-data-source-lj/add-data-source/manifest.json
@@ -5,7 +5,7 @@
   "category": "data-availability",
   "author": {
     "team": "Grafana Documentation",
-    "name": "Larissa Wandzura"
+    "name": "lwandz13"
   },
   "testEnvironment": {
     "tier": "cloud"

--- a/postgresql-data-source-lj/add-data-source/manifest.json
+++ b/postgresql-data-source-lj/add-data-source/manifest.json
@@ -1,0 +1,17 @@
+{
+  "id": "postgresql-data-source-add",
+  "type": "guide",
+  "description": "Learn how to navigate Grafana Cloud and add the PostgreSQL data source.",
+  "category": "data-availability",
+  "author": {
+    "team": "Grafana Documentation",
+    "name": "Larissa Wandzura"
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": ["postgresql-data-source-prepare"],
+  "recommends": ["postgresql-data-source-configure"],
+  "suggests": [],
+  "provides": []
+}

--- a/postgresql-data-source-lj/add-data-source/website.yaml
+++ b/postgresql-data-source-lj/add-data-source/website.yaml
@@ -1,0 +1,20 @@
+menuTitle: Add PostgreSQL data source
+weight: 200
+step: 3
+layout: single-journey
+cta:
+  type: continue
+keywords:
+- PostgreSQL
+- data source
+- add
+- configure
+side_journeys:
+  title: More to explore (optional)
+  heading: 'At this point in your journey, you can explore the following paths:'
+  items:
+  - title: Add the PostgreSQL data source
+    link: /docs/grafana/latest/datasources/postgres/configure/#add-the-postgresql-data-source
+  - title: Data source plugins for Grafana
+    link: https://grafana.com/grafana/plugins/data-source-plugins/
+description: Learn how to navigate Grafana Cloud and add the PostgreSQL data source.

--- a/postgresql-data-source-lj/configure-datasource/content.json
+++ b/postgresql-data-source-lj/configure-datasource/content.json
@@ -1,0 +1,79 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "postgresql-data-source-configure",
+  "title": "Configure PostgreSQL data source connection details",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "In this milestone, you configure the connection details and authentication credentials so that Grafana Cloud can connect to your PostgreSQL database.\n\nThis includes the host and port, the database name, the user name and password, and the TLS/SSL mode."
+    },
+    {
+      "type": "section",
+      "autoCollapse": false,
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "formfill",
+          "reftarget": "input[name='host']",
+          "targetvalue": "localhost:5432",
+          "doIt": false,
+          "requirements": [
+            "exists-reftarget"
+          ],
+          "content": "In the **Host URL** field under the **Connection** section, enter the hostname or IP address and port of your PostgreSQL server.\n\nFor example, enter `localhost:5432` or `postgres.example.com:5432`. The default PostgreSQL port is `5432`."
+        },
+        {
+          "type": "interactive",
+          "action": "formfill",
+          "reftarget": "input[id='connection-database']",
+          "targetvalue": "grafana",
+          "doIt": false,
+          "requirements": [
+            "exists-reftarget"
+          ],
+          "content": "In the **Database name** field, enter the name of your PostgreSQL database.\n\nFor example, enter `grafana`. This database is used as the default for queries in the query editor."
+        },
+        {
+          "type": "interactive",
+          "action": "formfill",
+          "reftarget": "input[placeholder='Username']",
+          "targetvalue": "grafanareader",
+          "doIt": false,
+          "requirements": [
+            "exists-reftarget"
+          ],
+          "content": "In the **Username** field under the **Authentication** section, enter the name of the PostgreSQL user you created.\n\nFor example, enter `grafanareader`."
+        },
+        {
+          "type": "interactive",
+          "action": "formfill",
+          "reftarget": "input[placeholder='Password']",
+          "doIt": false,
+          "requirements": [
+            "exists-reftarget"
+          ],
+          "content": "In the **Password** field, enter the password for the PostgreSQL user you created."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "input[id='connection-sslmode']",
+          "doIt": false,
+          "skippable": true,
+          "requirements": [
+            "exists-reftarget"
+          ],
+          "content": "In the **TLS/SSL Mode** field, select the mode that matches your database.\n\nFor cloud-hosted databases such as Amazon RDS, Azure Database for PostgreSQL, and Google Cloud SQL, `require` is the recommended minimum. Use `verify-full` for the most secure option, or `disable` only for local development on a trusted network."
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "In the next milestone, you'll select the private data source connect (PDC) agent and test the connection."
+    },
+    {
+      "type": "markdown",
+      "content": "---\n\n### More to explore (optional)\n\n- [PostgreSQL configuration options](https://grafana.com/docs/grafana/latest/datasources/postgres/configure/#postgresql-configuration-options)\n- [TLS/SSL mode reference](https://grafana.com/docs/grafana/latest/datasources/postgres/configure/#tlsssl-mode-reference)\n- [Private data source connect (PDC)](https://grafana.com/docs/grafana-cloud/connect-externally-hosted/private-data-source-connect/)"
+    }
+  ]
+}

--- a/postgresql-data-source-lj/configure-datasource/content.json
+++ b/postgresql-data-source-lj/configure-datasource/content.json
@@ -25,7 +25,7 @@
         {
           "type": "interactive",
           "action": "formfill",
-          "reftarget": "input[id='connection-database']",
+          "reftarget": "input[name='database']",
           "targetvalue": "grafana",
           "doIt": false,
           "requirements": [
@@ -53,19 +53,12 @@
             "exists-reftarget"
           ],
           "content": "In the **Password** field, enter the password for the PostgreSQL user you created."
-        },
-        {
-          "type": "interactive",
-          "action": "highlight",
-          "reftarget": "input[id='connection-sslmode']",
-          "doIt": false,
-          "skippable": true,
-          "requirements": [
-            "exists-reftarget"
-          ],
-          "content": "In the **TLS/SSL Mode** field, select the mode that matches your database.\n\nFor cloud-hosted databases such as Amazon RDS, Azure Database for PostgreSQL, and Google Cloud SQL, `require` is the recommended minimum. Use `verify-full` for the most secure option, or `disable` only for local development on a trusted network."
         }
       ]
+    },
+    {
+      "type": "markdown",
+      "content": "Next, set the **TLS/SSL Mode** to match your database. For cloud-hosted databases such as Amazon RDS, Azure Database for PostgreSQL, and Google Cloud SQL, `require` is the recommended minimum. Use `verify-full` for the most secure option, or `disable` only for local development on a trusted network."
     },
     {
       "type": "markdown",

--- a/postgresql-data-source-lj/configure-datasource/manifest.json
+++ b/postgresql-data-source-lj/configure-datasource/manifest.json
@@ -5,7 +5,7 @@
   "category": "data-availability",
   "author": {
     "team": "Grafana Documentation",
-    "name": "Larissa Wandzura"
+    "name": "lwandz13"
   },
   "testEnvironment": {
     "tier": "cloud"

--- a/postgresql-data-source-lj/configure-datasource/manifest.json
+++ b/postgresql-data-source-lj/configure-datasource/manifest.json
@@ -1,0 +1,17 @@
+{
+  "id": "postgresql-data-source-configure",
+  "type": "guide",
+  "description": "Learn how to enter the connection details, credentials, and TLS/SSL mode for the PostgreSQL data source.",
+  "category": "data-availability",
+  "author": {
+    "team": "Grafana Documentation",
+    "name": "Larissa Wandzura"
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": ["postgresql-data-source-add"],
+  "recommends": ["postgresql-data-source-test"],
+  "suggests": [],
+  "provides": []
+}

--- a/postgresql-data-source-lj/configure-datasource/website.yaml
+++ b/postgresql-data-source-lj/configure-datasource/website.yaml
@@ -1,0 +1,21 @@
+menuTitle: Configure connection details
+weight: 300
+step: 4
+layout: single-journey
+cta:
+  type: continue
+keywords:
+- PostgreSQL
+- data source
+- connection
+- TLS
+- SSL
+side_journeys:
+  title: More to explore (optional)
+  heading: 'At this point in your journey, you can explore the following paths:'
+  items:
+  - title: PostgreSQL configuration options
+    link: /docs/grafana/latest/datasources/postgres/configure/#postgresql-configuration-options
+  - title: TLS/SSL mode reference
+    link: /docs/grafana/latest/datasources/postgres/configure/#tlsssl-mode-reference
+description: Learn how to enter the connection details, credentials, and TLS/SSL mode for the PostgreSQL data source.

--- a/postgresql-data-source-lj/content.json
+++ b/postgresql-data-source-lj/content.json
@@ -1,0 +1,22 @@
+{
+  "id": "postgresql-data-source-lj",
+  "title": "Connect to a PostgreSQL data source in Grafana Cloud",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "Welcome to the Grafana learning path that provides best practices for configuring a PostgreSQL data source.\n\nPostgreSQL is one of the world's most popular open source relational databases. The PostgreSQL data source lets you query and visualize data from any PostgreSQL-compatible database directly within Grafana, so you can build dashboards from database metrics, application data, and business intelligence insights. It also works with managed services such as Amazon RDS, Amazon Aurora, Azure Database for PostgreSQL, and Google Cloud SQL.\n\nThis path teaches you how to configure the data source that enables you to query, visualize, and create dashboards with data from your PostgreSQL database."
+    },
+    {
+      "type": "markdown",
+      "content": "## Here's what to expect\n\nWhen you complete this path, you'll be able to:\n\n- Create a dedicated read-only Grafana user in your PostgreSQL database\n- Add the PostgreSQL data source in Grafana Cloud\n- Enter the connection details, credentials, and TLS/SSL mode for your PostgreSQL server\n- Select a private data source connect (PDC) agent and test the database connection\n- Verify that your PostgreSQL data appears in Grafana Cloud with a test query"
+    },
+    {
+      "type": "markdown",
+      "content": "## Before you begin\n\nBefore you connect to a PostgreSQL data source, ensure you have:\n\n- A PostgreSQL server (version 9.0 or newer) that's up and running.\n- Access to a PostgreSQL database with data you want to visualize.\n- Connection details including host, port, database name, username, and password.\n- The `Organization administrator` role in Grafana to configure the data source.\n- Network access for the PostgreSQL server (the default port is `5432`).\n- Your TLS/SSL certificates and client keys ready, if you connect with TLS/SSL.\n- [Created a private connection to a data source](https://grafana.com/docs/learning-paths/private-data-source-connect/) with the PDC agent running, if your database is on a private network."
+    },
+    {
+      "type": "markdown",
+      "content": "## Troubleshooting\n\nIf you get stuck, we've got your back! Where appropriate, troubleshooting information is just a click away.\n\n## More to explore\n\nWe understand you might want to explore other capabilities not strictly on this path. We'll provide you opportunities where it makes sense."
+    }
+  ]
+}

--- a/postgresql-data-source-lj/content.json
+++ b/postgresql-data-source-lj/content.json
@@ -8,7 +8,7 @@
     },
     {
       "type": "markdown",
-      "content": "## Here's what to expect\n\nWhen you complete this path, you'll be able to:\n\n- Create a dedicated read-only Grafana user in your PostgreSQL database\n- Add the PostgreSQL data source in Grafana Cloud\n- Enter the connection details, credentials, and TLS/SSL mode for your PostgreSQL server\n- Select a private data source connect (PDC) agent and test the database connection\n- Verify that your PostgreSQL data appears in Grafana Cloud with a test query"
+      "content": "## Here's what to expect\n\nWhen you complete this path, you'll be able to:\n\n- Create a dedicated read-only Grafana user in your PostgreSQL database\n- Add the PostgreSQL data source in Grafana Cloud\n- Enter the connection details and credentials, and choose a TLS/SSL mode, for your PostgreSQL server\n- Select a private data source connect (PDC) agent and test the database connection\n- Verify that your PostgreSQL data appears in Grafana Cloud with a test query"
     },
     {
       "type": "markdown",

--- a/postgresql-data-source-lj/end-journey/content.json
+++ b/postgresql-data-source-lj/end-journey/content.json
@@ -1,0 +1,15 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "postgresql-data-source-end",
+  "title": "Destination reached!",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "Congratulations on completing this path! Job well done!\n\nWe hope you've enjoyed traveling with us as you:\n\n- Created a dedicated read-only Grafana user in your PostgreSQL database\n- Added the PostgreSQL data source in Grafana Cloud\n- Configured connection details including host, port, database name, and credentials\n- Set the TLS/SSL mode for a secure connection\n- Tested the database connection through PDC to your Grafana Cloud instance\n- Verified PostgreSQL data access through Grafana's Explore feature"
+    },
+    {
+      "type": "markdown",
+      "content": "---\n\n### Related paths\n\nConsider taking the following paths after you complete this path:\n\n- [Create a private connection to a data source](https://grafana.com/docs/learning-paths/private-data-source-connect/)\n- [Monitor PostgreSQL with Grafana Alloy](https://grafana.com/docs/learning-paths/postgresql-integration/)\n- [Set up Database Observability for PostgreSQL](https://grafana.com/docs/learning-paths/postgresql-db-olly/)"
+    }
+  ]
+}

--- a/postgresql-data-source-lj/end-journey/content.json
+++ b/postgresql-data-source-lj/end-journey/content.json
@@ -5,7 +5,7 @@
   "blocks": [
     {
       "type": "markdown",
-      "content": "Congratulations on completing this path! Job well done!\n\nWe hope you've enjoyed traveling with us as you:\n\n- Created a dedicated read-only Grafana user in your PostgreSQL database\n- Added the PostgreSQL data source in Grafana Cloud\n- Configured connection details including host, port, database name, and credentials\n- Set the TLS/SSL mode for a secure connection\n- Tested the database connection through PDC to your Grafana Cloud instance\n- Verified PostgreSQL data access through Grafana's Explore feature"
+      "content": "Congratulations on completing this path! Job well done!\n\nWe hope you've enjoyed traveling with us as you:\n\n- Created a dedicated read-only Grafana user in your PostgreSQL database\n- Added the PostgreSQL data source in Grafana Cloud\n- Configured connection details including host, port, database name, and credentials\n- Reviewed the TLS/SSL mode options for a secure connection\n- Tested the database connection through PDC to your Grafana Cloud instance\n- Verified PostgreSQL data access through Grafana's Explore feature"
     },
     {
       "type": "markdown",

--- a/postgresql-data-source-lj/end-journey/manifest.json
+++ b/postgresql-data-source-lj/end-journey/manifest.json
@@ -5,7 +5,7 @@
   "category": "data-availability",
   "author": {
     "team": "Grafana Documentation",
-    "name": "Larissa Wandzura"
+    "name": "lwandz13"
   },
   "testEnvironment": {
     "tier": "cloud"

--- a/postgresql-data-source-lj/end-journey/manifest.json
+++ b/postgresql-data-source-lj/end-journey/manifest.json
@@ -1,0 +1,17 @@
+{
+  "id": "postgresql-data-source-end",
+  "type": "guide",
+  "description": "Recap of what you accomplished connecting the PostgreSQL data source, with related paths to explore next.",
+  "category": "data-availability",
+  "author": {
+    "team": "Grafana Documentation",
+    "name": "Larissa Wandzura"
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": ["postgresql-data-source-verify"],
+  "recommends": [],
+  "suggests": [],
+  "provides": []
+}

--- a/postgresql-data-source-lj/end-journey/website.yaml
+++ b/postgresql-data-source-lj/end-journey/website.yaml
@@ -1,0 +1,12 @@
+menuTitle: Destination reached!
+weight: 600
+step: 7
+layout: single-journey
+cta:
+  type: conclusion
+keywords:
+- PostgreSQL
+- data source
+- completion
+- next steps
+description: Congratulations on completing the PostgreSQL data source learning path!

--- a/postgresql-data-source-lj/manifest.json
+++ b/postgresql-data-source-lj/manifest.json
@@ -5,7 +5,7 @@
   "category": "data-availability",
   "author": {
     "team": "Grafana Documentation",
-    "name": "Larissa Wandzura"
+    "name": "lwandz13"
   },
   "startingLocation": "/connections/datasources",
   "targeting": {

--- a/postgresql-data-source-lj/manifest.json
+++ b/postgresql-data-source-lj/manifest.json
@@ -1,0 +1,59 @@
+{
+  "id": "postgresql-data-source-lj",
+  "type": "path",
+  "description": "How to configure the PostgreSQL data source.",
+  "category": "data-availability",
+  "author": {
+    "team": "Grafana Documentation",
+    "name": "Larissa Wandzura"
+  },
+  "startingLocation": "/connections/datasources",
+  "targeting": {
+    "match": {
+      "or": [
+        {
+          "and": [
+            {
+              "or": [
+                {
+                  "and": [
+                    {
+                      "urlPrefix": "/connections/datasources"
+                    },
+                    {
+                      "tag": "selected-datasource:postgres"
+                    }
+                  ]
+                },
+                {
+                  "urlPrefix": "/connections/datasources/postgres"
+                },
+                {
+                  "urlRegex": "/connections/add-new-connection/?$"
+                }
+              ]
+            },
+            {
+              "targetPlatform": "cloud"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "milestones": [
+    "postgresql-data-source-prepare",
+    "postgresql-data-source-add",
+    "postgresql-data-source-configure",
+    "postgresql-data-source-test",
+    "postgresql-data-source-verify",
+    "postgresql-data-source-end"
+  ],
+  "depends": [],
+  "recommends": [],
+  "suggests": [],
+  "provides": []
+}

--- a/postgresql-data-source-lj/prepare-configuration/content.json
+++ b/postgresql-data-source-lj/prepare-configuration/content.json
@@ -1,0 +1,45 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "postgresql-data-source-prepare",
+  "title": "Prepare PostgreSQL database configuration",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "In this milestone, you prepare the PostgreSQL configuration required for monitoring. This includes creating a dedicated read-only user for Grafana and gathering the connection details you'll need later.\n\nGrafana doesn't validate the safety of queries, so a user with broad privileges could run harmful SQL such as `DROP TABLE`. Creating a dedicated user with only `SELECT` permissions on the schemas and tables you need follows security best practices and limits risk.\n\n**Prerequisites**:\n\n- Check that your PostgreSQL server is up and running.\n- Make sure your firewall allows connections to the PostgreSQL server (the default port is `5432`).\n\nTo prepare your PostgreSQL database configuration, complete the following steps:"
+    },
+    {
+      "type": "section",
+      "autoCollapse": false,
+      "blocks": [
+        {
+          "type": "markdown",
+          "content": "Connect to your PostgreSQL server as an administrative user:\n\n```bash\npsql -U postgres -h localhost\n```"
+        },
+        {
+          "type": "markdown",
+          "content": "Create a dedicated read-only user for Grafana:\n\n```sql\nCREATE USER grafanareader WITH PASSWORD 'password';\n```"
+        },
+        {
+          "type": "markdown",
+          "content": "Grant the user access to the schema and read access to the tables you want to visualize. Replace `schema` and `table` with your own names:\n\n```sql\nGRANT USAGE ON SCHEMA schema TO grafanareader;\nGRANT SELECT ON schema.table TO grafanareader;\n```"
+        },
+        {
+          "type": "markdown",
+          "content": "Exit the PostgreSQL client:\n\n```sql\n\\q\n```"
+        },
+        {
+          "type": "markdown",
+          "content": "Test the new user's connection:\n\n```bash\npsql -U grafanareader -h localhost -d your_database -c \"SELECT version();\"\n```"
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "In the next milestone, you'll add the PostgreSQL data source to your Grafana Cloud instance."
+    },
+    {
+      "type": "markdown",
+      "content": "---\n\n### More to explore (optional)\n\n- [Configure the PostgreSQL data source](https://grafana.com/docs/grafana/latest/datasources/postgres/configure/)\n- [Data source plugins for Grafana](https://grafana.com/grafana/plugins/data-source-plugins/)"
+    }
+  ]
+}

--- a/postgresql-data-source-lj/prepare-configuration/manifest.json
+++ b/postgresql-data-source-lj/prepare-configuration/manifest.json
@@ -5,7 +5,7 @@
   "category": "data-availability",
   "author": {
     "team": "Grafana Documentation",
-    "name": "Larissa Wandzura"
+    "name": "lwandz13"
   },
   "testEnvironment": {
     "tier": "cloud"

--- a/postgresql-data-source-lj/prepare-configuration/manifest.json
+++ b/postgresql-data-source-lj/prepare-configuration/manifest.json
@@ -1,0 +1,17 @@
+{
+  "id": "postgresql-data-source-prepare",
+  "type": "guide",
+  "description": "Learn how to create a read-only user in PostgreSQL and prepare the database connection details.",
+  "category": "data-availability",
+  "author": {
+    "team": "Grafana Documentation",
+    "name": "Larissa Wandzura"
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": [],
+  "recommends": ["postgresql-data-source-add"],
+  "suggests": [],
+  "provides": []
+}

--- a/postgresql-data-source-lj/prepare-configuration/website.yaml
+++ b/postgresql-data-source-lj/prepare-configuration/website.yaml
@@ -1,0 +1,20 @@
+menuTitle: Prepare configuration
+weight: 100
+step: 2
+layout: single-journey
+cta:
+  type: continue
+keywords:
+- PostgreSQL
+- data source
+- user
+- permissions
+side_journeys:
+  title: More to explore (optional)
+  heading: 'At this point in your journey, you can explore the following paths:'
+  items:
+  - title: Configure the PostgreSQL data source
+    link: /docs/grafana/latest/datasources/postgres/configure/
+  - title: Data source plugins for Grafana
+    link: https://grafana.com/grafana/plugins/data-source-plugins/
+description: Learn how to create a read-only user in PostgreSQL and prepare the database connection details.

--- a/postgresql-data-source-lj/test-connection/content.json
+++ b/postgresql-data-source-lj/test-connection/content.json
@@ -1,0 +1,53 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "postgresql-data-source-test",
+  "title": "Select PDC and test connection",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "The private data source connect (PDC) feature lets you establish a secure connection between Grafana Cloud and a PostgreSQL database on a private network.\n\nGrafana Cloud can't reach databases on `localhost`, `127.0.0.1`, or private IP ranges (`10.x`, `172.16.x`, `192.168.x`) directly. If your database isn't publicly accessible, PDC creates a secure tunnel so the connection can succeed."
+    },
+    {
+      "type": "markdown",
+      "content": "**Recommendation:** We recommend that you create a private connection whenever you connect Grafana Cloud to an external data source."
+    },
+    {
+      "type": "section",
+      "autoCollapse": false,
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "input[aria-label='Private data source connect']",
+          "doIt": false,
+          "skippable": true,
+          "requirements": [
+            "exists-reftarget"
+          ],
+          "content": "In the **Private data source connect** field, select the name of a PDC agent.\n\n**Note:** For the test connection to succeed, you must select a PDC agent that's running. Skip this step if your database is publicly accessible."
+        },
+        {
+          "type": "interactive",
+          "action": "button",
+          "reftarget": "Save & test",
+          "requirements": [
+            "exists-reftarget"
+          ],
+          "content": "Click **Save & test**.\n\nWhen successful, you'll see the message: `Database Connection OK`. Grafana also auto-detects your PostgreSQL server version on save."
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "In the next milestone, you'll verify that your PostgreSQL data appears correctly in Grafana Cloud."
+    },
+    {
+      "type": "markdown",
+      "content": "---\n\n### Troubleshooting\n\nExplore the following troubleshooting topics if you need help:\n\n- [Failed to connect to PostgreSQL](https://grafana.com/docs/grafana/latest/datasources/postgres/troubleshooting/#failed-to-connect-to-postgresql)\n- [Grafana Cloud can't reach a private database](https://grafana.com/docs/grafana/latest/datasources/postgres/troubleshooting/#grafana-cloud-cant-reach-a-private-database)\n- [Password authentication failed](https://grafana.com/docs/grafana/latest/datasources/postgres/troubleshooting/#password-authentication-failed)"
+    },
+    {
+      "type": "markdown",
+      "content": "---\n\n### More to explore (optional)\n\n- [TLS and certificate errors](https://grafana.com/docs/grafana/latest/datasources/postgres/troubleshooting/#tls-and-certificate-errors)\n- [Grafana alerting with PostgreSQL data](https://grafana.com/docs/grafana/latest/datasources/postgres/alerting/)"
+    }
+  ]
+}

--- a/postgresql-data-source-lj/test-connection/content.json
+++ b/postgresql-data-source-lj/test-connection/content.json
@@ -18,7 +18,7 @@
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "input[aria-label='Private data source connect']",
+          "reftarget": "[data-testid='pdc-network-select-input']",
           "doIt": false,
           "skippable": true,
           "requirements": [

--- a/postgresql-data-source-lj/test-connection/content.json
+++ b/postgresql-data-source-lj/test-connection/content.json
@@ -9,7 +9,7 @@
     },
     {
       "type": "markdown",
-      "content": "**Recommendation:** We recommend that you create a private connection whenever you connect Grafana Cloud to an external data source."
+      "content": "**Recommendation:** If your PostgreSQL database isn't publicly accessible, use PDC to establish a secure connection. If your database is publicly reachable, you can skip the PDC selection in the next step."
     },
     {
       "type": "section",

--- a/postgresql-data-source-lj/test-connection/manifest.json
+++ b/postgresql-data-source-lj/test-connection/manifest.json
@@ -5,7 +5,7 @@
   "category": "data-availability",
   "author": {
     "team": "Grafana Documentation",
-    "name": "Larissa Wandzura"
+    "name": "lwandz13"
   },
   "testEnvironment": {
     "tier": "cloud"

--- a/postgresql-data-source-lj/test-connection/manifest.json
+++ b/postgresql-data-source-lj/test-connection/manifest.json
@@ -1,0 +1,17 @@
+{
+  "id": "postgresql-data-source-test",
+  "type": "guide",
+  "description": "Learn how to select a private data source connection and test the PostgreSQL database connection.",
+  "category": "data-availability",
+  "author": {
+    "team": "Grafana Documentation",
+    "name": "Larissa Wandzura"
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": ["postgresql-data-source-configure"],
+  "recommends": ["postgresql-data-source-verify"],
+  "suggests": [],
+  "provides": []
+}

--- a/postgresql-data-source-lj/test-connection/website.yaml
+++ b/postgresql-data-source-lj/test-connection/website.yaml
@@ -1,0 +1,20 @@
+menuTitle: Select PDC and test connection
+weight: 400
+step: 5
+layout: single-journey
+cta:
+  type: success
+keywords:
+- PostgreSQL
+- test connection
+- validate
+- troubleshoot
+side_journeys:
+  title: More to explore (optional)
+  heading: 'At this point in your journey, you can explore the following paths:'
+  items:
+  - title: Troubleshoot PostgreSQL data source issues
+    link: /docs/grafana/latest/datasources/postgres/troubleshooting/
+  - title: Private data source connect (PDC)
+    link: /docs/grafana-cloud/connect-externally-hosted/private-data-source-connect/
+description: Learn how to select a private data source connection and test the PostgreSQL database connection.

--- a/postgresql-data-source-lj/verify-postgres-data/content.json
+++ b/postgresql-data-source-lj/verify-postgres-data/content.json
@@ -1,0 +1,71 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "postgresql-data-source-verify",
+  "title": "Verify PostgreSQL data query in Grafana",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "In this milestone, you verify that your PostgreSQL data source works correctly by running a test query in Grafana's Explore feature."
+    },
+    {
+      "type": "section",
+      "autoCollapse": false,
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "a[href='/explore']",
+          "requirements": [
+            "navmenu-open",
+            "exists-reftarget"
+          ],
+          "content": "In the Grafana Cloud navigation menu, click **Explore**."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='data-testid Select a data source']",
+          "doIt": false,
+          "requirements": [
+            "on-page:/explore",
+            "exists-reftarget"
+          ],
+          "content": "From the data source dropdown at the top-left, select your PostgreSQL data source.\n\nFor example, select **Production PostgreSQL Database**."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='query-editor-rows']",
+          "doIt": false,
+          "requirements": [
+            "on-page:/explore",
+            "exists-reftarget"
+          ],
+          "content": "Switch to **Code** mode and enter a simple SQL query to test your connection.\n\nFor example, enter:\n\n```sql\nSELECT datname, numbackends FROM pg_stat_database LIMIT 5\n```\n\n**Tip:** You can use any valid SQL query that your PostgreSQL user has permission to run."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "button[aria-label='Run query']",
+          "requirements": [
+            "on-page:/explore",
+            "exists-reftarget"
+          ],
+          "content": "Click **Run query** to execute the query.\n\nYou should see the results in the table below the query editor. For more results, change the `LIMIT` from `5` to `10`.\n\n**Did you know?** Grafana's Explore feature is perfect for testing queries and exploring your data before you build dashboards."
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "## Verify successful data access\n\nAfter running your test query, you should see:\n\n- Query results displayed in the Explore interface\n- No connection errors or timeouts\n- Data that matches what you expect from your PostgreSQL database\n- The ability to run different SQL queries successfully"
+    },
+    {
+      "type": "markdown",
+      "content": "**Congratulations!** You've successfully connected your PostgreSQL database to Grafana Cloud."
+    },
+    {
+      "type": "markdown",
+      "content": "---\n\n### More to explore (optional)\n\n- [PostgreSQL query editor](https://grafana.com/docs/grafana/latest/datasources/postgres/query-editor/)\n- [Building dashboards with PostgreSQL data](https://grafana.com/docs/grafana/latest/dashboards/)\n- [Creating alerts with PostgreSQL queries](https://grafana.com/docs/grafana/latest/datasources/postgres/alerting/)"
+    }
+  ]
+}

--- a/postgresql-data-source-lj/verify-postgres-data/content.json
+++ b/postgresql-data-source-lj/verify-postgres-data/content.json
@@ -41,7 +41,7 @@
             "on-page:/explore",
             "exists-reftarget"
           ],
-          "content": "Switch to **Code** mode and enter a simple SQL query to test your connection.\n\nFor example, enter:\n\n```sql\nSELECT datname, numbackends FROM pg_stat_database LIMIT 5\n```\n\n**Tip:** You can use any valid SQL query that your PostgreSQL user has permission to run."
+          "content": "In the query editor, enter a simple SQL query to test your connection.\n\nFor example, enter:\n\n```sql\nSELECT datname, numbackends FROM pg_stat_database LIMIT 5\n```\n\n**Tip:** If the editor is in **Builder** mode, switch to **Code** mode first. You can use any valid SQL query that your PostgreSQL user has permission to run."
         },
         {
           "type": "interactive",

--- a/postgresql-data-source-lj/verify-postgres-data/manifest.json
+++ b/postgresql-data-source-lj/verify-postgres-data/manifest.json
@@ -1,0 +1,17 @@
+{
+  "id": "postgresql-data-source-verify",
+  "type": "guide",
+  "description": "Learn how to verify PostgreSQL data by running a test query in Grafana Explore.",
+  "category": "data-availability",
+  "author": {
+    "team": "Grafana Documentation",
+    "name": "Larissa Wandzura"
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": ["postgresql-data-source-test"],
+  "recommends": ["postgresql-data-source-end"],
+  "suggests": [],
+  "provides": []
+}

--- a/postgresql-data-source-lj/verify-postgres-data/manifest.json
+++ b/postgresql-data-source-lj/verify-postgres-data/manifest.json
@@ -5,7 +5,7 @@
   "category": "data-availability",
   "author": {
     "team": "Grafana Documentation",
-    "name": "Larissa Wandzura"
+    "name": "lwandz13"
   },
   "testEnvironment": {
     "tier": "cloud"

--- a/postgresql-data-source-lj/verify-postgres-data/website.yaml
+++ b/postgresql-data-source-lj/verify-postgres-data/website.yaml
@@ -1,0 +1,20 @@
+menuTitle: Verify PostgreSQL data
+weight: 500
+step: 6
+layout: single-journey
+cta:
+  type: success
+keywords:
+- PostgreSQL
+- data source
+- Explore
+- query
+side_journeys:
+  title: More to explore (optional)
+  heading: 'At this point in your journey, you can explore the following paths:'
+  items:
+  - title: PostgreSQL query editor
+    link: /docs/grafana/latest/datasources/postgres/query-editor/
+  - title: Building dashboards with PostgreSQL data
+    link: /docs/grafana/latest/dashboards/
+description: Learn how to verify PostgreSQL data by running a test query in Grafana Explore.

--- a/postgresql-data-source-lj/website.yaml
+++ b/postgresql-data-source-lj/website.yaml
@@ -1,0 +1,33 @@
+menuTitle: Connect to a PostgreSQL data source
+weight: 360
+journey:
+  group: data-availability
+  skill: Beginner
+  source: Docs & blog posts
+  logo:
+    src: /static/img/logos/postgresql_elephant_icon.svg
+    background: '#0068FF'
+    width: 46
+    height: 55
+step: 1
+layout: single-journey
+cascade:
+  layout: single-journey
+cta:
+  type: start
+  title: Are you ready?
+  cta_text: Let's go!
+keywords:
+- PostgreSQL
+- data source
+- Grafana Cloud
+- database monitoring
+- SQL queries
+related_journeys:
+  title: Related paths
+  heading: Consider taking the following paths before you start this path.
+  items:
+  - title: Create a private connection to a data source
+    link: /docs/learning-paths/private-data-source-connect/
+description: Welcome to the Grafana learning path that shows you how to connect Grafana Cloud to an existing PostgreSQL database and query your data.
+show_play: false


### PR DESCRIPTION
## What

Adds a new interactive learning path package **`postgresql-data-source-lj`** for connecting the PostgreSQL data source in Grafana Cloud.

Six milestones (modeled on `mysql-data-source-lj`):

1. **prepare-configuration** — create a read-only `grafanareader` user, `GRANT SELECT` (markdown)
2. **add-data-source** — Connections → Add new data source → search **PostgreSQL** → name it
3. **configure-datasource** — Host URL (`:5432`), Database name, Username, Password, TLS/SSL Mode
4. **test-connection** — select PDC → **Save & test**
5. **verify-postgres-data** — Explore → run a test SQL query
6. **end-journey** — recap + related paths

Content sourced from the canonical PostgreSQL data source docs (overview, configure, query-editor, troubleshooting). Also adds a CODEOWNERS entry.

## Selectors needing verification

These were reused from the working MySQL path or are PostgreSQL-form guesses; verifying via the PR tester / Block Editor:

- `configure-datasource`: `input[id='connection-database']` (Database name)
- `configure-datasource`: `input[id='connection-sslmode']` (TLS/SSL Mode)
- `test-connection`: `input[aria-label='Private data source connect']`

## Testing

- [x] Block Editor smoke test each milestone (Show me / Do it)

<!-- vale = NO -->

Made with [Cursor](https://cursor.com)