### PR TITLE
Add Google Sheets data source learning path

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -75,6 +75,7 @@
 /mysql-integration-lj/                                    @chri2547
 /influxdb-data-source-lj/                                 @chri2547
 /tempo-data-source-lj/                                    @lwandz13
+/google-sheets-data-source-lj/                            @lwandz13
 /create-availability-slo-lj/                              @chri2547
 /adaptive-logs-lj/                                        @chri2547
 /play-carbon-intensity/                                   @simonprickett

--- a/google-sheets-data-source-lj/advantages/content.json
+++ b/google-sheets-data-source-lj/advantages/content.json
@@ -1,0 +1,27 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "google-sheets-data-source-advantages",
+  "title": "Advantages of the Google Sheets data source",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "The Google Sheets data source plugin brings spreadsheet data directly into your Grafana environment. This integration eliminates the need to export, copy, or re-key data to visualize what your team already maintains in a spreadsheet."
+    },
+    {
+      "type": "markdown",
+      "content": "Because the plugin reads through the Google Sheets API, your panels reflect the current state of the spreadsheet each time they refresh. It operates in read-only mode, so Grafana never writes to or modifies your data."
+    },
+    {
+      "type": "markdown",
+      "content": "With the Google Sheets data source, you can:\n\n- Query spreadsheets by ID and range, and cache responses to stay within API quotas\n- Build dashboards that combine spreadsheet data with metrics, logs, and traces\n- Use template variables in the spreadsheet ID or range for dynamic dashboards\n- Add annotations from a sheet to overlay events on your panels\n- Create alert rules from Google Sheets queries\n- Explore spreadsheet data ad hoc without building a dashboard first"
+    },
+    {
+      "type": "markdown",
+      "content": "The plugin supports both public spreadsheets (using an API key) and private spreadsheets (using a Google service account). This learning path uses API key authentication with a publicly shared spreadsheet, which is the fastest way to get started in Grafana Cloud."
+    },
+    {
+      "type": "markdown",
+      "content": "In the next milestone, you'll install and add the Google Sheets data source in your Grafana Cloud instance."
+    }
+  ]
+}

--- a/google-sheets-data-source-lj/advantages/content.json
+++ b/google-sheets-data-source-lj/advantages/content.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "1.0.0",
+  "schemaVersion": "1.1.0",
   "id": "google-sheets-data-source-advantages",
   "title": "Advantages of the Google Sheets data source",
   "blocks": [
@@ -9,7 +9,7 @@
     },
     {
       "type": "markdown",
-      "content": "Because the plugin reads through the Google Sheets API, your panels reflect the current state of the spreadsheet each time they refresh. It operates in read-only mode, so Grafana never writes to or modifies your data."
+      "content": "Because the plugin reads through the Google Sheets API, each time your panels refresh they read the latest spreadsheet data or a cached response. It operates in read-only mode, so Grafana never writes to or modifies your data."
     },
     {
       "type": "markdown",

--- a/google-sheets-data-source-lj/advantages/manifest.json
+++ b/google-sheets-data-source-lj/advantages/manifest.json
@@ -1,0 +1,17 @@
+{
+  "id": "google-sheets-data-source-advantages",
+  "type": "guide",
+  "description": "Learn the advantages of using the Google Sheets data source to visualize spreadsheet data in Grafana.",
+  "category": "data-availability",
+  "author": {
+    "name": "lwandz13",
+    "team": "Grafana Documentation"
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": ["google-sheets-data-source-business-value"],
+  "recommends": ["google-sheets-data-source-install"],
+  "suggests": [],
+  "provides": []
+}

--- a/google-sheets-data-source-lj/advantages/website.yaml
+++ b/google-sheets-data-source-lj/advantages/website.yaml
@@ -1,0 +1,12 @@
+menuTitle: Advantages of the data source
+weight: 200
+step: 3
+layout: single-journey
+cta:
+  type: continue
+keywords:
+- Google Sheets
+- data source
+- spreadsheet
+- data visualization
+description: Learn the advantages of using the Google Sheets data source to visualize spreadsheet data in Grafana.

--- a/google-sheets-data-source-lj/business-value/content.json
+++ b/google-sheets-data-source-lj/business-value/content.json
@@ -1,0 +1,50 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "google-sheets-data-source-business-value",
+  "title": "The case for observability",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "Not all of the data that matters to your team lives in a metrics database. Budgets, inventory counts, project trackers, on-call rotations, survey results, and countless other business signals often live in a Google spreadsheet that someone updates by hand."
+    },
+    {
+      "type": "markdown",
+      "content": "Consider the following:\n\n- A finance team tracks monthly spend in a shared sheet, but nobody sees it next to the infrastructure costs it drives.\n- An operations team maintains a maintenance schedule in a spreadsheet, disconnected from the systems it affects.\n- A support team logs customer escalations in a sheet that never appears alongside application performance data."
+    },
+    {
+      "type": "markdown",
+      "content": "When this data stays trapped in a spreadsheet, it can't be correlated with the rest of your observability signals. You end up switching tabs, copying values, and making decisions from a fragmented picture."
+    },
+    {
+      "type": "markdown",
+      "content": "## Enter...observability"
+    },
+    {
+      "type": "conditional",
+      "conditions": [
+        "renderer:website"
+      ],
+      "whenTrue": [
+        {
+          "type": "video",
+          "src": "https://www.youtube.com/embed/TQur9GJHIIQ",
+          "provider": "youtube",
+          "title": "What is observability?"
+        }
+      ],
+      "whenFalse": []
+    },
+    {
+      "type": "markdown",
+      "content": "Observability is the process of making a system's internal state more transparent. Systems are made observable by the data they produce, which in turn helps you to determine if your infrastructure or application is healthy and functioning normally."
+    },
+    {
+      "type": "markdown",
+      "content": "Bringing spreadsheet data into Grafana extends that transparency to the business context around your systems. By reading Google Sheets directly, you can place hand-maintained data next to metrics, logs, and traces in a single dashboard, and ask questions across all of it at once."
+    },
+    {
+      "type": "markdown",
+      "content": "---\n\n### More to explore (optional)\n\n- [What is observability?](https://grafana.com/docs/grafana-cloud/introduction/what-is-observability/)"
+    }
+  ]
+}

--- a/google-sheets-data-source-lj/business-value/content.json
+++ b/google-sheets-data-source-lj/business-value/content.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "1.0.0",
+  "schemaVersion": "1.1.0",
   "id": "google-sheets-data-source-business-value",
   "title": "The case for observability",
   "blocks": [

--- a/google-sheets-data-source-lj/business-value/manifest.json
+++ b/google-sheets-data-source-lj/business-value/manifest.json
@@ -1,0 +1,17 @@
+{
+  "id": "google-sheets-data-source-business-value",
+  "type": "guide",
+  "description": "Understand why bringing spreadsheet data into an observability platform gives teams a more complete picture.",
+  "category": "data-availability",
+  "author": {
+    "name": "lwandz13",
+    "team": "Grafana Documentation"
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": [],
+  "recommends": ["google-sheets-data-source-advantages"],
+  "suggests": [],
+  "provides": []
+}

--- a/google-sheets-data-source-lj/business-value/website.yaml
+++ b/google-sheets-data-source-lj/business-value/website.yaml
@@ -1,0 +1,18 @@
+menuTitle: The case for observability
+weight: 100
+step: 2
+layout: single-journey
+cta:
+  type: continue
+keywords:
+- observability
+- spreadsheet data
+- business metrics
+- data visualization
+side_journeys:
+  title: More to explore (optional)
+  heading: 'At this point in your journey, you can explore the following paths:'
+  items:
+  - title: What is observability?
+    link: /docs/grafana-cloud/introduction/what-is-observability/
+description: Understand why bringing spreadsheet data into an observability platform gives teams a more complete picture.

--- a/google-sheets-data-source-lj/config-datasource/content.json
+++ b/google-sheets-data-source-lj/config-datasource/content.json
@@ -20,14 +20,8 @@
       "autoCollapse": false,
       "blocks": [
         {
-          "type": "interactive",
-          "action": "formfill",
-          "reftarget": "[data-testid='data-testid Data source settings page name input field']",
-          "doIt": false,
-          "requirements": [
-            "exists-reftarget"
-          ],
-          "content": "In the **Name** field, enter a descriptive name for your data source.\n\nFor example, enter `My Google Sheets` or `Team Budget Sheet`.\n\n> **Did you know?** The name of the data source appears on dashboard panels, so it's important to choose a meaningful name. If there are multiple data sources for a dashboard panel, the default toggle determines which data source appears by default."
+          "type": "markdown",
+          "content": "Your data source is created with the default name **grafana-googlesheets-datasource**, shown as the editable title at the top of the page. To rename it, click the **pencil (Edit title)** icon next to the title and enter a descriptive name, for example `My Google Sheets` or `Team Budget Sheet`.\n\n> **Did you know?** The name of the data source appears on dashboard panels, so it's important to choose a meaningful name. If there are multiple data sources for a dashboard panel, the default toggle determines which data source appears by default."
         },
         {
           "type": "markdown",
@@ -43,6 +37,7 @@
           "reftarget": "input[placeholder='Enter API key']",
           "doIt": false,
           "requirements": [
+            "on-page:/connections/datasources/edit",
             "exists-reftarget"
           ],
           "content": "In the **API Key** field, paste the Google API key you created earlier.\n\n**Tip:** Ensure you paste the complete key without any extra spaces or characters."
@@ -57,6 +52,7 @@
           "reftarget": "Save & test",
           "doIt": false,
           "requirements": [
+            "on-page:/connections/datasources/edit",
             "exists-reftarget"
           ],
           "content": "Click **Save & test** to save the configuration and test the connection.\n\nA successful connection displays the message \"Success\"."

--- a/google-sheets-data-source-lj/config-datasource/content.json
+++ b/google-sheets-data-source-lj/config-datasource/content.json
@@ -37,7 +37,6 @@
           "reftarget": "input[placeholder='Enter API key']",
           "doIt": false,
           "requirements": [
-            "on-page:/connections/datasources/edit",
             "exists-reftarget"
           ],
           "content": "In the **API Key** field, paste the Google API key you created earlier.\n\n**Tip:** Ensure you paste the complete key without any extra spaces or characters."
@@ -52,7 +51,6 @@
           "reftarget": "Save & test",
           "doIt": false,
           "requirements": [
-            "on-page:/connections/datasources/edit",
             "exists-reftarget"
           ],
           "content": "Click **Save & test** to save the configuration and test the connection.\n\nA successful connection displays the message \"Success\"."

--- a/google-sheets-data-source-lj/config-datasource/content.json
+++ b/google-sheets-data-source-lj/config-datasource/content.json
@@ -13,6 +13,10 @@
     },
     {
       "type": "markdown",
+      "content": "**Before you start:** These steps take place on the **Google Sheets data source configuration page** (its URL looks like `/connections/datasources/edit/<uid>`). If you completed the previous milestone, you're already there.\n\nIf not, open the configuration page now:\n\n- Go to **Connections > Add new connection**, search for and select **Google Sheets**, then click **Add new data source**. This creates a data source instance and opens its configuration page.\n- Or, to edit an existing one, go to **Connections > Data sources** and select your Google Sheets data source.\n\nDon't confuse this with the plugin **overview** page or the **Choose a data source type** list \u2014 the **Name**, **Authentication type**, and **API Key** fields only appear on the configuration page of an actual data source instance."
+    },
+    {
+      "type": "markdown",
       "content": "To configure authentication and verify the connection, complete the following steps:"
     },
     {

--- a/google-sheets-data-source-lj/config-datasource/content.json
+++ b/google-sheets-data-source-lj/config-datasource/content.json
@@ -1,0 +1,75 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "google-sheets-data-source-config",
+  "title": "Configure the Google Sheets data source",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "In this milestone, you configure your Google Sheets data source with the API key you created and verify that the connection works correctly. This step establishes the authenticated connection between Grafana and the Google Sheets API."
+    },
+    {
+      "type": "markdown",
+      "content": "Choosing the right authentication type ensures the data source can read the spreadsheets you need. The connection test validates that your API key is accepted and that the Google Sheets API is reachable."
+    },
+    {
+      "type": "markdown",
+      "content": "To configure authentication and verify the connection, complete the following steps:"
+    },
+    {
+      "type": "section",
+      "autoCollapse": false,
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "formfill",
+          "reftarget": "[data-testid='data-testid Data source settings page name input field']",
+          "doIt": false,
+          "requirements": [
+            "exists-reftarget"
+          ],
+          "content": "In the **Name** field, enter a descriptive name for your data source.\n\nFor example, enter `My Google Sheets` or `Team Budget Sheet`.\n\n> **Did you know?** The name of the data source appears on dashboard panels, so it's important to choose a meaningful name. If there are multiple data sources for a dashboard panel, the default toggle determines which data source appears by default."
+        },
+        {
+          "type": "markdown",
+          "content": "Optionally, enable the **Default** toggle if you want this to be your default data source when creating new panels."
+        },
+        {
+          "type": "markdown",
+          "content": "For **Authentication type**, select **API Key**.\n\nThe default is **Google JWT File**, which is used for private spreadsheets. Because this path uses a publicly shared spreadsheet, select **API Key** instead. You can expand **Configure Google Sheets Authentication** on the page for step-by-step guidance in the UI."
+        },
+        {
+          "type": "interactive",
+          "action": "formfill",
+          "reftarget": "input[placeholder='Enter API key']",
+          "doIt": false,
+          "requirements": [
+            "exists-reftarget"
+          ],
+          "content": "In the **API Key** field, paste the Google API key you created earlier.\n\n**Tip:** Ensure you paste the complete key without any extra spaces or characters."
+        },
+        {
+          "type": "markdown",
+          "content": "Optionally, set a **Default Spreadsheet ID** to pre-fill new queries with a spreadsheet you use often. You can enter an ID, paste a spreadsheet URL, or leave it empty and set the ID per query."
+        },
+        {
+          "type": "interactive",
+          "action": "button",
+          "reftarget": "Save & test",
+          "doIt": false,
+          "requirements": [
+            "exists-reftarget"
+          ],
+          "content": "Click **Save & test** to save the configuration and test the connection.\n\nA successful connection displays the message \"Success\"."
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "Your Google Sheets data source is configured and connected. You can now query publicly shared spreadsheets from dashboard panels and Explore.\n\n**Try it:** To test without your own spreadsheet, use Grafana's [public demonstration spreadsheet](https://docs.google.com/spreadsheets/d/1TZlZX67Y0s4CvRro_3pCYqRCKuXer81oFp_xcsjPpe8/edit?usp=sharing). Add a visualization, select your Google Sheets data source, and paste the spreadsheet ID `1TZlZX67Y0s4CvRro_3pCYqRCKuXer81oFp_xcsjPpe8`. Leave **Range** empty to use the first sheet."
+    },
+    {
+      "type": "markdown",
+      "content": "---\n\n### Troubleshooting\n\nExplore the following resources if you need help:\n\n- [Troubleshoot the Google Sheets data source](https://grafana.com/docs/plugins/grafana-googlesheets-datasource/latest/troubleshooting/)\n- [Configure the Google Sheets data source](https://grafana.com/docs/plugins/grafana-googlesheets-datasource/latest/configure/)"
+    }
+  ]
+}

--- a/google-sheets-data-source-lj/config-datasource/content.json
+++ b/google-sheets-data-source-lj/config-datasource/content.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "1.0.0",
+  "schemaVersion": "1.1.0",
   "id": "google-sheets-data-source-config",
   "title": "Configure the Google Sheets data source",
   "blocks": [
@@ -25,15 +25,20 @@
       "blocks": [
         {
           "type": "markdown",
-          "content": "Your data source is created with the default name **grafana-googlesheets-datasource**, shown as the editable title at the top of the page. To rename it, click the **pencil (Edit title)** icon next to the title and enter a descriptive name, for example `My Google Sheets` or `Team Budget Sheet`.\n\n> **Did you know?** The name of the data source appears on dashboard panels, so it's important to choose a meaningful name. If there are multiple data sources for a dashboard panel, the default toggle determines which data source appears by default."
+          "content": "Your data source is created with the default name **grafana-googlesheets-datasource**, shown as the editable title at the top of the page. To rename it, click the **pencil (Edit title)** icon next to the title and enter a descriptive name, for example `My Google Sheets` or `Team Budget Sheet`.\n\n> **Did you know?** The name of the data source appears on dashboard panels, so it's important to choose a meaningful name."
         },
         {
           "type": "markdown",
           "content": "Optionally, enable the **Default** toggle if you want this to be your default data source when creating new panels."
         },
         {
-          "type": "markdown",
-          "content": "For **Authentication type**, select **API Key**.\n\nThe default is **Google JWT File**, which is used for private spreadsheets. Because this path uses a publicly shared spreadsheet, select **API Key** instead. You can expand **Configure Google Sheets Authentication** on the page for step-by-step guidance in the UI."
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='data-testid radio-button-option key']",
+          "requirements": [
+            "exists-reftarget"
+          ],
+          "content": "For **Authentication type**, select **API Key**.\n\nThe default is **Google JWT File**, which is used for private spreadsheets. Because this path uses a publicly shared spreadsheet, select **API Key** instead. The **API Key** field only appears after you make this selection."
         },
         {
           "type": "interactive",

--- a/google-sheets-data-source-lj/config-datasource/manifest.json
+++ b/google-sheets-data-source-lj/config-datasource/manifest.json
@@ -1,0 +1,17 @@
+{
+  "id": "google-sheets-data-source-config",
+  "type": "guide",
+  "description": "Learn how to configure the Google Sheets data source with an API key and verify the connection.",
+  "category": "data-availability",
+  "author": {
+    "name": "lwandz13",
+    "team": "Grafana Documentation"
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": ["google-sheets-data-source-create-api-key"],
+  "recommends": ["google-sheets-data-source-end-journey"],
+  "suggests": [],
+  "provides": []
+}

--- a/google-sheets-data-source-lj/config-datasource/website.yaml
+++ b/google-sheets-data-source-lj/config-datasource/website.yaml
@@ -1,0 +1,13 @@
+menuTitle: Configure the data source
+weight: 500
+step: 6
+layout: single-journey
+cta:
+  type: continue
+keywords:
+- Google Sheets
+- configuration
+- API key
+- authentication
+- Save and test
+description: Learn how to configure the Google Sheets data source with an API key and verify the connection.

--- a/google-sheets-data-source-lj/content.json
+++ b/google-sheets-data-source-lj/content.json
@@ -1,0 +1,10 @@
+{
+  "id": "google-sheets-data-source-lj",
+  "title": "Connect to a Google Sheets data source in Grafana Cloud",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "Welcome to the Grafana learning path that provides best practices for setting up a Google Sheets data source.\n\nThe Google Sheets data source lets you visualize your Google spreadsheets in Grafana. It uses the Google Sheets API to read data that you can view in dashboard panels or Explore, so business data that already lives in a spreadsheet becomes a first-class source alongside your metrics, logs, and traces.\n\n## Here's what to expect\n\nWhen you complete this journey, you'll be able to:\n\n- Understand the value of visualizing spreadsheet data through observability\n- Learn the advantages of using the Google Sheets data source\n- Install and add the Google Sheets data source in Grafana Cloud\n- Create a Google API key for spreadsheet access\n- Configure the Google Sheets data source and verify the connection\n\n## Before you begin\n\nBefore you connect to a Google Sheets data source, ensure that you have:\n\n- A Google account with access to the spreadsheets you want to visualize.\n- A Google Cloud project where you can enable APIs and create credentials.\n- The Organization administrator role in your Grafana Cloud instance to install and add a data source.\n- Basic familiarity with Grafana navigation and dashboard creation.\n\n## Troubleshooting\n\nIf you get stuck, we've got your back! Where appropriate, troubleshooting information is just a click away.\n\n## More to explore\n\nWe understand you might want to explore other capabilities not strictly on this path. We'll provide you opportunities where it makes sense."
+    }
+  ]
+}

--- a/google-sheets-data-source-lj/create-api-key/content.json
+++ b/google-sheets-data-source-lj/create-api-key/content.json
@@ -1,0 +1,49 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "google-sheets-data-source-create-api-key",
+  "title": "Create a Google API key",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "In this milestone, you create a Google API key that lets your Google Sheets data source read publicly shared spreadsheets. The API key is the simplest way to authenticate and is a good fit for getting started in Grafana Cloud."
+    },
+    {
+      "type": "markdown",
+      "content": "With API key authentication, the spreadsheets you query must be publicly viewable, for example shared as **Anyone with the link**. If you need to read private spreadsheets, use Google service account (JWT) authentication instead. See [Configure the Google Sheets data source](https://grafana.com/docs/plugins/grafana-googlesheets-datasource/latest/configure/) for the service account steps."
+    },
+    {
+      "type": "markdown",
+      "content": "Before you create the key, the Google Sheets API must be enabled in your Google Cloud project. To create an API key, complete the following steps:"
+    },
+    {
+      "type": "section",
+      "autoCollapse": false,
+      "blocks": [
+        {
+          "type": "markdown",
+          "content": "Sign in to the [Google Cloud Console](https://console.cloud.google.com/) and select the project you want to use, or create a new project."
+        },
+        {
+          "type": "markdown",
+          "content": "Open the [Google Sheets API page](https://console.cloud.google.com/apis/library/sheets.googleapis.com) and click **Enable**."
+        },
+        {
+          "type": "markdown",
+          "content": "Open the [Credentials page](https://console.cloud.google.com/apis/credentials) in the Google Cloud Console."
+        },
+        {
+          "type": "markdown",
+          "content": "Click **Create credentials**, and then select **API key**."
+        },
+        {
+          "type": "markdown",
+          "content": "Copy the generated API key and store it securely for the next milestone.\n\n**Caution:** Treat your API key like a password. Store it securely and never commit it to version control or share it publicly. Consider restricting the key to the Google Sheets API in the Google Cloud Console."
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "You now have a Google API key that can authenticate your Google Sheets data source against publicly shared spreadsheets. Keep it handy for the next milestone, where you'll paste it into the data source configuration."
+    }
+  ]
+}

--- a/google-sheets-data-source-lj/create-api-key/content.json
+++ b/google-sheets-data-source-lj/create-api-key/content.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "1.0.0",
+  "schemaVersion": "1.1.0",
   "id": "google-sheets-data-source-create-api-key",
   "title": "Create a Google API key",
   "blocks": [

--- a/google-sheets-data-source-lj/create-api-key/manifest.json
+++ b/google-sheets-data-source-lj/create-api-key/manifest.json
@@ -1,0 +1,17 @@
+{
+  "id": "google-sheets-data-source-create-api-key",
+  "type": "guide",
+  "description": "Learn how to create a Google API key for authenticating your Google Sheets data source against public spreadsheets.",
+  "category": "data-availability",
+  "author": {
+    "name": "lwandz13",
+    "team": "Grafana Documentation"
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": ["google-sheets-data-source-install"],
+  "recommends": ["google-sheets-data-source-config"],
+  "suggests": [],
+  "provides": []
+}

--- a/google-sheets-data-source-lj/create-api-key/website.yaml
+++ b/google-sheets-data-source-lj/create-api-key/website.yaml
@@ -1,0 +1,12 @@
+menuTitle: Create a Google API key
+weight: 400
+step: 5
+layout: single-journey
+cta:
+  type: continue
+keywords:
+- Google API key
+- authentication
+- Google Cloud
+- Google Sheets API
+description: Learn how to create a Google API key for authenticating your Google Sheets data source against public spreadsheets.

--- a/google-sheets-data-source-lj/end-journey/content.json
+++ b/google-sheets-data-source-lj/end-journey/content.json
@@ -1,0 +1,19 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "google-sheets-data-source-end-journey",
+  "title": "Destination reached!",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "Congratulations on completing this journey! Job well done!"
+    },
+    {
+      "type": "markdown",
+      "content": "We hope you've enjoyed traveling with us as you:\n\n- Learned about the value of visualizing spreadsheet data through observability\n- Learned about the advantages of using the Google Sheets data source\n- Installed and added the Google Sheets data source in Grafana Cloud\n- Created a Google API key for spreadsheet access\n- Configured the Google Sheets data source and verified the connection"
+    },
+    {
+      "type": "markdown",
+      "content": "---\n\n### More to explore\n\n- [Quick start: create a sample dashboard](https://grafana.com/docs/plugins/grafana-googlesheets-datasource/latest/#quick-start-create-a-sample-dashboard) — build a panel from the public demo spreadsheet\n- [Query editor](https://grafana.com/docs/plugins/grafana-googlesheets-datasource/latest/query-editor/) — query spreadsheet data and build panels\n- [Template variables](https://grafana.com/docs/plugins/grafana-googlesheets-datasource/latest/template-variables/) — create dynamic dashboards\n- [Alerting](https://grafana.com/docs/plugins/grafana-googlesheets-datasource/latest/alerting/) — create alert rules from Google Sheets queries\n- [Configure a service account (JWT)](https://grafana.com/docs/plugins/grafana-googlesheets-datasource/latest/configure/#authenticate-with-a-service-account-jwt) — read private spreadsheets"
+    }
+  ]
+}

--- a/google-sheets-data-source-lj/end-journey/content.json
+++ b/google-sheets-data-source-lj/end-journey/content.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "1.0.0",
+  "schemaVersion": "1.1.0",
   "id": "google-sheets-data-source-end-journey",
   "title": "Destination reached!",
   "blocks": [

--- a/google-sheets-data-source-lj/end-journey/manifest.json
+++ b/google-sheets-data-source-lj/end-journey/manifest.json
@@ -1,0 +1,17 @@
+{
+  "id": "google-sheets-data-source-end-journey",
+  "type": "guide",
+  "description": "Congratulations on completing the Google Sheets data source learning path and connecting your spreadsheet data to Grafana Cloud.",
+  "category": "data-availability",
+  "author": {
+    "name": "lwandz13",
+    "team": "Grafana Documentation"
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": ["google-sheets-data-source-config"],
+  "recommends": [],
+  "suggests": [],
+  "provides": []
+}

--- a/google-sheets-data-source-lj/end-journey/website.yaml
+++ b/google-sheets-data-source-lj/end-journey/website.yaml
@@ -1,0 +1,12 @@
+menuTitle: Destination reached!
+weight: 600
+step: 7
+layout: single-journey
+cta:
+  type: conclusion
+keywords:
+- Google Sheets
+- journey completion
+- spreadsheet dashboards
+- data visualization
+description: Congratulations on completing the Google Sheets data source learning path and connecting your spreadsheet data to Grafana Cloud.

--- a/google-sheets-data-source-lj/install-plugin/content.json
+++ b/google-sheets-data-source-lj/install-plugin/content.json
@@ -90,8 +90,8 @@
         },
         {
           "type": "interactive",
-          "action": "button",
-          "reftarget": "Google Sheets",
+          "action": "highlight",
+          "reftarget": "[data-testid='data-testid Add new data source Google Sheets']",
           "requirements": [
             "on-page:/connections/datasources/new",
             "exists-reftarget"

--- a/google-sheets-data-source-lj/install-plugin/content.json
+++ b/google-sheets-data-source-lj/install-plugin/content.json
@@ -1,0 +1,109 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "google-sheets-data-source-install",
+  "title": "Install and add the Google Sheets data source",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "The Google Sheets data source is not installed by default. In this milestone, you search for the data source in the plugin catalog and install it in your Grafana Cloud instance."
+    },
+    {
+      "type": "markdown",
+      "content": "The Google Sheets data source is available in the Grafana plugin catalog and can be installed directly from the Grafana Cloud interface. Once installed, it provides the components needed to connect to the Google Sheets API and read your spreadsheet data."
+    },
+    {
+      "type": "markdown",
+      "content": "To install the Google Sheets data source, complete the following steps:"
+    },
+    {
+      "type": "section",
+      "autoCollapse": false,
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "navigate",
+          "reftarget": "/plugins",
+          "content": "Open **Administration > Plugins and data > Plugins**.",
+          "verify": "on-page:/plugins"
+        },
+        {
+          "type": "interactive",
+          "action": "formfill",
+          "reftarget": "input[placeholder='Search Grafana plugins']",
+          "targetvalue": "Google Sheets",
+          "requirements": [
+            "on-page:/plugins",
+            "exists-reftarget"
+          ],
+          "content": "In the **Search** field, enter `Google Sheets` to filter the available plugins."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "a[href='/plugins/grafana-googlesheets-datasource']",
+          "requirements": [
+            "on-page:/plugins",
+            "exists-reftarget"
+          ],
+          "verify": "on-page:/plugins/grafana-googlesheets-datasource",
+          "content": "Locate the **Google Sheets** data source plugin and click it to view the plugin details."
+        },
+        {
+          "type": "interactive",
+          "action": "button",
+          "reftarget": "Install",
+          "doIt": false,
+          "requirements": [
+            "on-page:/plugins/grafana-googlesheets-datasource",
+            "exists-reftarget"
+          ],
+          "content": "Click **Install** to add the Google Sheets data source to your Grafana Cloud instance.\n\nWait for the installation to complete. The status changes from \"Installing\" to \"Installed\"."
+        },
+        {
+          "type": "interactive",
+          "action": "navigate",
+          "reftarget": "/connections/datasources",
+          "content": "Open **Connections > Data sources**.",
+          "verify": "on-page:/connections/datasources"
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='data-testid data-source-add-button']",
+          "requirements": [
+            "on-page:/connections/datasources",
+            "exists-reftarget"
+          ],
+          "verify": "on-page:/connections/datasources/new",
+          "content": "Click **Add new data source** in the upper right of the page."
+        },
+        {
+          "type": "interactive",
+          "action": "formfill",
+          "reftarget": "input[placeholder='Filter by name or type']",
+          "targetvalue": "Google Sheets",
+          "requirements": [
+            "on-page:/connections/datasources/new",
+            "exists-reftarget"
+          ],
+          "content": "In the search field, enter `Google Sheets` to filter the available data source types."
+        },
+        {
+          "type": "interactive",
+          "action": "button",
+          "reftarget": "Google Sheets",
+          "requirements": [
+            "on-page:/connections/datasources/new",
+            "exists-reftarget"
+          ],
+          "verify": "on-page:/connections/datasources/edit",
+          "content": "Click **Google Sheets** to select the data source and begin configuration."
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "The Google Sheets data source is now installed and added to your Grafana Cloud instance. In the next milestone, you'll create a Google API key so the data source can read your spreadsheet."
+    }
+  ]
+}

--- a/google-sheets-data-source-lj/install-plugin/content.json
+++ b/google-sheets-data-source-lj/install-plugin/content.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "1.0.0",
+  "schemaVersion": "1.1.0",
   "id": "google-sheets-data-source-install",
   "title": "Install and add the Google Sheets data source",
   "blocks": [
@@ -90,8 +90,8 @@
         },
         {
           "type": "interactive",
-          "action": "highlight",
-          "reftarget": "[data-testid='data-testid Add new data source Google Sheets']",
+          "action": "button",
+          "reftarget": "Google Sheets",
           "requirements": [
             "on-page:/connections/datasources/new",
             "exists-reftarget"

--- a/google-sheets-data-source-lj/install-plugin/manifest.json
+++ b/google-sheets-data-source-lj/install-plugin/manifest.json
@@ -1,0 +1,17 @@
+{
+  "id": "google-sheets-data-source-install",
+  "type": "guide",
+  "description": "Learn how to install and add the Google Sheets data source in your Grafana Cloud instance.",
+  "category": "data-availability",
+  "author": {
+    "name": "lwandz13",
+    "team": "Grafana Documentation"
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": ["google-sheets-data-source-advantages"],
+  "recommends": ["google-sheets-data-source-create-api-key"],
+  "suggests": [],
+  "provides": []
+}

--- a/google-sheets-data-source-lj/install-plugin/manifest.json
+++ b/google-sheets-data-source-lj/install-plugin/manifest.json
@@ -10,7 +10,7 @@
   "testEnvironment": {
     "tier": "cloud"
   },
-  "depends": ["google-sheets-data-source-advantages"],
+  "depends": [],
   "recommends": ["google-sheets-data-source-create-api-key"],
   "suggests": [],
   "provides": []

--- a/google-sheets-data-source-lj/install-plugin/website.yaml
+++ b/google-sheets-data-source-lj/install-plugin/website.yaml
@@ -1,0 +1,13 @@
+menuTitle: Install the data source
+weight: 300
+step: 4
+layout: single-journey
+cta:
+  type: continue
+keywords:
+- Google Sheets
+- plugin
+- install
+- data source
+- Grafana Cloud
+description: Learn how to install and add the Google Sheets data source in your Grafana Cloud instance.

--- a/google-sheets-data-source-lj/manifest.json
+++ b/google-sheets-data-source-lj/manifest.json
@@ -1,0 +1,35 @@
+{
+  "id": "google-sheets-data-source-lj",
+  "type": "path",
+  "description": "A learning path that shows you how to connect and visualize Google Sheets data in Grafana Cloud.",
+  "category": "data-availability",
+  "author": {
+    "name": "lwandz13",
+    "team": "Grafana Documentation"
+  },
+  "startingLocation": "/connections/add-new-connection/grafana-googlesheets-datasource",
+  "targeting": {
+    "match": {
+      "or": [
+        {
+          "urlPrefix": "/connections/add-new-connection/grafana-googlesheets-datasource"
+        }
+      ]
+    }
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "milestones": [
+    "google-sheets-data-source-business-value",
+    "google-sheets-data-source-advantages",
+    "google-sheets-data-source-install",
+    "google-sheets-data-source-create-api-key",
+    "google-sheets-data-source-config",
+    "google-sheets-data-source-end-journey"
+  ],
+  "depends": [],
+  "recommends": [],
+  "suggests": [],
+  "provides": []
+}

--- a/google-sheets-data-source-lj/manifest.json
+++ b/google-sheets-data-source-lj/manifest.json
@@ -21,8 +21,6 @@
     "tier": "cloud"
   },
   "milestones": [
-    "google-sheets-data-source-business-value",
-    "google-sheets-data-source-advantages",
     "google-sheets-data-source-install",
     "google-sheets-data-source-create-api-key",
     "google-sheets-data-source-config",

--- a/google-sheets-data-source-lj/website.yaml
+++ b/google-sheets-data-source-lj/website.yaml
@@ -1,0 +1,27 @@
+menuTitle: Connect to a Google Sheets data source
+weight: 155
+journey:
+  group: data-availability
+  skill: Beginner
+  source: Docs & blog posts
+  logo:
+    src: https://grafana.com/api/plugins/grafana-googlesheets-datasource/versions/latest/logos/large
+    background: '#FFFFFF'
+    width: 46
+    height: 46
+step: 1
+layout: single-journey
+cascade:
+  layout: single-journey
+cta:
+  type: start
+  title: Are you ready?
+  cta_text: Let's go!
+keywords:
+- Google Sheets
+- data source
+- Grafana Cloud
+- spreadsheet
+- API key
+description: Welcome to the Google Sheets data source learning path that shows you how to visualize your Google spreadsheets in Grafana Cloud.
+show_play: false

--- a/google-sheets-data-source-lj/website.yaml
+++ b/google-sheets-data-source-lj/website.yaml
@@ -5,7 +5,7 @@ journey:
   skill: Beginner
   source: Docs & blog posts
   logo:
-    src: https://grafana.com/api/plugins/grafana-googlesheets-datasource/versions/latest/logos/large
+    src: /static/img/logos/google-sheets.svg
     background: '#FFFFFF'
     width: 46
     height: 46

--- a/google-sheets-data-source-lj/website.yaml
+++ b/google-sheets-data-source-lj/website.yaml
@@ -5,7 +5,7 @@ journey:
   skill: Beginner
   source: Docs & blog posts
   logo:
-    src: /static/img/logos/google-sheets.svg
+    src: /static/img/logos/google.svg
     background: '#FFFFFF'
     width: 46
     height: 46


### PR DESCRIPTION
## What

Adds a new interactive learning path, **Connect to a Google Sheets data source in Grafana Cloud** (`google-sheets-data-source-lj`), that walks a beginner through connecting the Google Sheets data source using **API key** authentication (the fastest happy path for Grafana Cloud).

## Milestones (7 steps)

| Step | Milestone | Type |
|------|-----------|------|
| 1 | Landing / welcome | Concept |
| 2 | The case for observability | Concept |
| 3 | Advantages of the Google Sheets data source | Concept |
| 4 | Install and add the Google Sheets data source | Interactive |
| 5 | Create a Google API key | Guided (Google Cloud Console) |
| 6 | Configure the Google Sheets data source | Interactive |
| 7 | Destination reached! | Conclusion |

Each milestone ships `content.json`, `manifest.json`, and `website.yaml`, wired in a linear `depends`/`recommends` chain. Structure mirrors the sibling `github-data-source-lj`. A `.github/CODEOWNERS` entry (`@lwandz13`) is included.

## Accuracy

Content is grounded in the canonical docs and cross-checked against them:

- [Google Sheets data source](https://grafana.com/docs/plugins/grafana-googlesheets-datasource/latest/)
- [Configure](https://grafana.com/docs/plugins/grafana-googlesheets-datasource/latest/configure/)
- [Query editor](https://grafana.com/docs/plugins/grafana-googlesheets-datasource/latest/query-editor/)
- [Troubleshooting](https://grafana.com/docs/plugins/grafana-googlesheets-datasource/latest/troubleshooting/)

The API key field selector (`input[placeholder='Enter API key']`) was taken directly from the plugin's `ConfigEditor.tsx`. Verified facts include: read-only operation, API key requires publicly viewable sheets, only the Google Sheets API needs enabling for API-key auth, and the **Success** connection message.

## Still to verify live (Block Editor / Playwright pass)

These use best-effort selectors mirrored from the GitHub LJ and need confirmation at `learn.grafana.net`:

- [ ] Targeting slug / `startingLocation` — `/connections/add-new-connection/grafana-googlesheets-datasource`
- [ ] Plugin-catalog selectors (search placeholders, `a[href='/plugins/grafana-googlesheets-datasource']`)
- [ ] Auth-type selector (currently a markdown step; may be upgraded to interactive)
- [ ] Logo asset — currently the plugin-catalog logo URL; website may prefer `sheets.svg` under `/static/img/logos/`
- [ ] Install step behavior in Cloud (plugin may already be installed)

## Notes

- All 14 JSON files parse cleanly.
- The Pathfinder schema CLI was not run locally (no built `grafana-pathfinder-app` checkout available); please run `validate --packages .` in CI or with a built CLI before merge.
