### PR TITLE
Add ClickHouse data source learning path (Path 1)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -34,6 +34,7 @@
 /billing-usage-lj/                                        @Eve832
 /categorize-collector-fleet-lj/                           @tiffany76
 /categorize-collector-fleet-lj/                           @tiffany76
+/clickhouse-data-source-lj/                               @lwandz13
 /cloudwatch-data-source-lj/                               @lwandz13
 /connect-prometheus-metrics/                              @tacole02
 /core-grafana-concepts-lj/                                @moxious

--- a/clickhouse-data-source-lj/add-data-source/content.json
+++ b/clickhouse-data-source-lj/add-data-source/content.json
@@ -1,0 +1,73 @@
+{
+  "id": "clickhouse-data-source-add",
+  "title": "Add the ClickHouse data source",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "In this milestone, you add the ClickHouse data source in Grafana Cloud and give it a descriptive name. Adding a data source requires the Grafana organization administrator role.\n\nTo add the data source, complete the following steps."
+    },
+    {
+      "type": "section",
+      "autoCollapse": false,
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "a[href='/connections/datasources']",
+          "requirements": [
+            "navmenu-open",
+            "exists-reftarget"
+          ],
+          "content": "In the navigation menu, click **Connections > Data sources**."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='data-testid data-source-add-button']",
+          "requirements": [
+            "exists-reftarget"
+          ],
+          "content": "Click **Add new data source**."
+        },
+        {
+          "type": "interactive",
+          "action": "formfill",
+          "reftarget": "input[placeholder='Filter by name or type']",
+          "targetvalue": "ClickHouse",
+          "requirements": [
+            "exists-reftarget"
+          ],
+          "content": "In the search field, enter `ClickHouse`."
+        },
+        {
+          "type": "interactive",
+          "action": "button",
+          "reftarget": "ClickHouse",
+          "requirements": [
+            "exists-reftarget"
+          ],
+          "content": "From the search results, click **ClickHouse**."
+        },
+        {
+          "type": "interactive",
+          "action": "formfill",
+          "reftarget": "input[placeholder='Name']",
+          "targetvalue": "ClickHouse observability",
+          "doIt": false,
+          "requirements": [
+            "exists-reftarget"
+          ],
+          "content": "In the **Name** field, enter a descriptive name for this data source.\n\nFor example, enter `ClickHouse observability`. The name appears on dashboard panels, so choose something meaningful."
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "You now have a ClickHouse data source ready to configure.\n\nIn the next milestone, you'll enter the connection details and credentials for your ClickHouse server."
+    },
+    {
+      "type": "markdown",
+      "content": "---\n\n### More to explore (optional)\n\n- [Add the ClickHouse data source](https://grafana.com/docs/plugins/grafana-clickhouse-datasource/latest/configure/#add-the-data-source)\n- [Data source plugins for Grafana](https://grafana.com/grafana/plugins/data-source-plugins/)"
+    }
+  ]
+}

--- a/clickhouse-data-source-lj/add-data-source/content.json
+++ b/clickhouse-data-source-lj/add-data-source/content.json
@@ -1,10 +1,14 @@
 {
   "id": "clickhouse-data-source-add",
-  "title": "Add the ClickHouse data source",
+  "title": "Install and add the ClickHouse data source",
   "blocks": [
     {
       "type": "markdown",
-      "content": "In this milestone, you install the ClickHouse plugin (if it isn't already) and create a new ClickHouse data source. Adding a data source requires the Grafana organization administrator role.\n\nTo add the data source, complete the following steps."
+      "content": "The ClickHouse data source isn't built into Grafana; it's an installable plugin. In this milestone, you install the ClickHouse plugin from the plugin catalog and then add a new ClickHouse data source. Both actions require the Grafana organization administrator role."
+    },
+    {
+      "type": "markdown",
+      "content": "To install and add the data source, complete the following steps:"
     },
     {
       "type": "section",
@@ -12,41 +16,32 @@
       "blocks": [
         {
           "type": "interactive",
-          "action": "highlight",
-          "reftarget": "a[href='/connections/datasources']",
-          "requirements": [
-            "navmenu-open",
-            "exists-reftarget"
-          ],
-          "content": "In the navigation menu, click **Connections > Data sources**."
-        },
-        {
-          "type": "interactive",
-          "action": "highlight",
-          "reftarget": "[data-testid='data-testid data-source-add-button']",
-          "requirements": [
-            "exists-reftarget"
-          ],
-          "content": "Click **Add new data source**."
+          "action": "navigate",
+          "reftarget": "/plugins",
+          "content": "Open **Administration > Plugins and data > Plugins**.",
+          "verify": "on-page:/plugins"
         },
         {
           "type": "interactive",
           "action": "formfill",
-          "reftarget": "input[aria-label='Search connections by name']",
+          "reftarget": "input[placeholder='Search Grafana plugins']",
           "targetvalue": "ClickHouse",
           "requirements": [
+            "on-page:/plugins",
             "exists-reftarget"
           ],
-          "content": "In the search field, enter `ClickHouse`."
+          "content": "In the **Search** field, enter `ClickHouse` to filter the available plugins."
         },
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "[data-testid='datasource-grafana-clickhouse-datasource-card']",
+          "reftarget": "a[href='/plugins/grafana-clickhouse-datasource']",
           "requirements": [
+            "on-page:/plugins",
             "exists-reftarget"
           ],
-          "content": "Select the **ClickHouse** connection (published by Grafana Labs)."
+          "verify": "on-page:/plugins/grafana-clickhouse-datasource",
+          "content": "Locate the **ClickHouse** data source plugin (published by Grafana Labs) and click it to view the plugin details."
         },
         {
           "type": "interactive",
@@ -55,18 +50,50 @@
           "doIt": false,
           "skippable": true,
           "requirements": [
+            "on-page:/plugins/grafana-clickhouse-datasource",
             "exists-reftarget"
           ],
-          "content": "If the ClickHouse plugin isn't installed yet, click **Install** and wait for it to finish. If it's already installed, skip this step."
+          "content": "Click **Install** and wait for the status to change to **Installed**. If the plugin is already installed, skip this step."
+        },
+        {
+          "type": "interactive",
+          "action": "navigate",
+          "reftarget": "/connections/datasources",
+          "content": "Open **Connections > Data sources**.",
+          "verify": "on-page:/connections/datasources"
         },
         {
           "type": "interactive",
           "action": "highlight",
           "reftarget": "[data-testid='data-testid data-source-add-button']",
           "requirements": [
+            "on-page:/connections/datasources",
             "exists-reftarget"
           ],
-          "content": "Click **Add new data source** to create a ClickHouse connection."
+          "verify": "on-page:/connections/datasources/new",
+          "content": "Click **Add new data source** in the upper right of the page."
+        },
+        {
+          "type": "interactive",
+          "action": "formfill",
+          "reftarget": "input[placeholder='Filter by name or type']",
+          "targetvalue": "ClickHouse",
+          "requirements": [
+            "on-page:/connections/datasources/new",
+            "exists-reftarget"
+          ],
+          "content": "In the search field, enter `ClickHouse` to filter the available data source types."
+        },
+        {
+          "type": "interactive",
+          "action": "button",
+          "reftarget": "ClickHouse",
+          "requirements": [
+            "on-page:/connections/datasources/new",
+            "exists-reftarget"
+          ],
+          "verify": "on-page:/connections/datasources/edit",
+          "content": "Click **ClickHouse** to select the data source and begin configuration."
         }
       ]
     },
@@ -76,7 +103,7 @@
     },
     {
       "type": "markdown",
-      "content": "---\n\n### More to explore (optional)\n\n- [Add the ClickHouse data source](https://grafana.com/docs/plugins/grafana-clickhouse-datasource/latest/configure/#add-the-data-source)\n- [Data source plugins for Grafana](https://grafana.com/grafana/plugins/data-source-plugins/)"
+      "content": "---\n\n### More to explore (optional)\n\n- [Install the ClickHouse data source](https://grafana.com/docs/plugins/grafana-clickhouse-datasource/latest/configure/#install-the-data-source)\n- [Data source plugins for Grafana](https://grafana.com/grafana/plugins/data-source-plugins/)"
     }
   ]
 }

--- a/clickhouse-data-source-lj/add-data-source/content.json
+++ b/clickhouse-data-source-lj/add-data-source/content.json
@@ -4,7 +4,7 @@
   "blocks": [
     {
       "type": "markdown",
-      "content": "In this milestone, you add the ClickHouse data source in Grafana Cloud and give it a descriptive name. Adding a data source requires the Grafana organization administrator role.\n\nTo add the data source, complete the following steps."
+      "content": "In this milestone, you install the ClickHouse plugin (if it isn't already) and create a new ClickHouse data source. Adding a data source requires the Grafana organization administrator role.\n\nTo add the data source, complete the following steps."
     },
     {
       "type": "section",
@@ -32,7 +32,7 @@
         {
           "type": "interactive",
           "action": "formfill",
-          "reftarget": "input[placeholder='Filter by name or type']",
+          "reftarget": "input[aria-label='Search connections by name']",
           "targetvalue": "ClickHouse",
           "requirements": [
             "exists-reftarget"
@@ -41,29 +41,38 @@
         },
         {
           "type": "interactive",
-          "action": "button",
-          "reftarget": "ClickHouse",
+          "action": "highlight",
+          "reftarget": "[data-testid='datasource-grafana-clickhouse-datasource-card']",
           "requirements": [
             "exists-reftarget"
           ],
-          "content": "From the search results, click **ClickHouse**."
+          "content": "Select the **ClickHouse** connection (published by Grafana Labs)."
         },
         {
           "type": "interactive",
-          "action": "formfill",
-          "reftarget": "input[placeholder='Name']",
-          "targetvalue": "ClickHouse observability",
+          "action": "button",
+          "reftarget": "Install",
           "doIt": false,
+          "skippable": true,
           "requirements": [
             "exists-reftarget"
           ],
-          "content": "In the **Name** field, enter a descriptive name for this data source.\n\nFor example, enter `ClickHouse observability`. The name appears on dashboard panels, so choose something meaningful."
+          "content": "If the ClickHouse plugin isn't installed yet, click **Install** and wait for it to finish. If it's already installed, skip this step."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='data-testid data-source-add-button']",
+          "requirements": [
+            "exists-reftarget"
+          ],
+          "content": "Click **Add new data source** to create a ClickHouse connection."
         }
       ]
     },
     {
       "type": "markdown",
-      "content": "You now have a ClickHouse data source ready to configure.\n\nIn the next milestone, you'll enter the connection details and credentials for your ClickHouse server."
+      "content": "You now have a ClickHouse data source ready to configure. It's named `grafana-clickhouse-datasource` by default; you can rename it by clicking the name at the top of the settings page, for example to `ClickHouse observability`. The name appears on dashboard panels, so choose something meaningful.\n\nIn the next milestone, you'll enter the connection details and credentials for your ClickHouse server."
     },
     {
       "type": "markdown",

--- a/clickhouse-data-source-lj/add-data-source/manifest.json
+++ b/clickhouse-data-source-lj/add-data-source/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "clickhouse-data-source-add",
   "type": "guide",
-  "description": "Add the ClickHouse data source plugin in Grafana Cloud and give it a descriptive name.",
+  "description": "Install the ClickHouse plugin and add a ClickHouse data source in Grafana Cloud.",
   "category": "data-availability",
   "author": {
     "team": "Grafana Documentation",

--- a/clickhouse-data-source-lj/add-data-source/manifest.json
+++ b/clickhouse-data-source-lj/add-data-source/manifest.json
@@ -1,0 +1,17 @@
+{
+  "id": "clickhouse-data-source-add",
+  "type": "guide",
+  "description": "Add the ClickHouse data source plugin in Grafana Cloud and give it a descriptive name.",
+  "category": "data-availability",
+  "author": {
+    "team": "Grafana Documentation",
+    "name": "lwandz13"
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": ["clickhouse-data-source-prepare"],
+  "recommends": ["clickhouse-data-source-configure"],
+  "suggests": [],
+  "provides": []
+}

--- a/clickhouse-data-source-lj/add-data-source/website.yaml
+++ b/clickhouse-data-source-lj/add-data-source/website.yaml
@@ -1,4 +1,4 @@
-menuTitle: Add the ClickHouse data source
+menuTitle: Install and add the ClickHouse data source
 weight: 300
 step: 4
 layout: single-journey
@@ -8,5 +8,7 @@ keywords:
 - ClickHouse
 - data source
 - add
+- install
+- plugin
 - Grafana Cloud
-description: Add the ClickHouse data source plugin in Grafana Cloud and give it a descriptive name.
+description: Install the ClickHouse plugin and add a ClickHouse data source in Grafana Cloud.

--- a/clickhouse-data-source-lj/add-data-source/website.yaml
+++ b/clickhouse-data-source-lj/add-data-source/website.yaml
@@ -1,0 +1,12 @@
+menuTitle: Add the ClickHouse data source
+weight: 300
+step: 4
+layout: single-journey
+cta:
+  type: continue
+keywords:
+- ClickHouse
+- data source
+- add
+- Grafana Cloud
+description: Add the ClickHouse data source plugin in Grafana Cloud and give it a descriptive name.

--- a/clickhouse-data-source-lj/configure-datasource/content.json
+++ b/clickhouse-data-source-lj/configure-datasource/content.json
@@ -13,7 +13,7 @@
         {
           "type": "interactive",
           "action": "formfill",
-          "reftarget": "",
+          "reftarget": "[data-testid='clickhouse-v2-config-host-input']",
           "targetvalue": "clickhouse.example.com",
           "doIt": false,
           "requirements": [
@@ -24,39 +24,28 @@
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "",
+          "reftarget": "[data-testid='data-testid radio-button-option native']",
           "doIt": false,
           "requirements": [
             "exists-reftarget"
           ],
-          "content": "For **Protocol**, choose **Native** for best performance, or **HTTP** if your network requires HTTP-based connectivity (for example, through a reverse proxy)."
+          "content": "For **Protocol**, select **Native** for best performance. Choose **HTTP** instead if your network requires HTTP-based connectivity, for example through a reverse proxy."
         },
         {
           "type": "interactive",
           "action": "formfill",
-          "reftarget": "",
+          "reftarget": "[data-testid='clickhouse-v2-config-port-input']",
           "targetvalue": "9000",
           "doIt": false,
           "requirements": [
             "exists-reftarget"
           ],
-          "content": "In the **Port** field, enter the port that matches your protocol. Native uses `9000` (or `9440` with TLS); HTTP uses `8123` (or `8443` with TLS)."
-        },
-        {
-          "type": "interactive",
-          "action": "highlight",
-          "reftarget": "",
-          "doIt": false,
-          "skippable": true,
-          "requirements": [
-            "exists-reftarget"
-          ],
-          "content": "If your ClickHouse server uses TLS, enable **Secure connection**, then set the **Port** to a TLS-enabled port. Grafana doesn't change the port automatically when you toggle TLS."
+          "content": "In the **Server port** field, enter the port that matches your protocol. Native uses `9000` (or `9440` with TLS); HTTP uses `8123` (or `8443` with TLS)."
         },
         {
           "type": "interactive",
           "action": "formfill",
-          "reftarget": "",
+          "reftarget": "input[aria-label='Username']",
           "targetvalue": "grafana_reader",
           "doIt": false,
           "requirements": [
@@ -67,25 +56,18 @@
         {
           "type": "interactive",
           "action": "formfill",
-          "reftarget": "",
+          "reftarget": "input[aria-label='Password']",
           "doIt": false,
           "requirements": [
             "exists-reftarget"
           ],
           "content": "In the **Password** field, enter the password for your read-only user.\n\nFor your security, enter this value yourself rather than having Grafana fill it in."
-        },
-        {
-          "type": "interactive",
-          "action": "highlight",
-          "reftarget": "",
-          "doIt": false,
-          "skippable": true,
-          "requirements": [
-            "exists-reftarget"
-          ],
-          "content": "Leave **Default database** blank on Grafana Cloud. ClickHouse Cloud already routes to the correct database, and setting a name that doesn't match can cause an `Unknown database` error. On self-hosted ClickHouse, you can optionally set the database you query most often."
         }
       ]
+    },
+    {
+      "type": "markdown",
+      "content": "**Optional settings:**\n\n- **Secure Connection:** If your ClickHouse server uses TLS, enable **Secure Connection**, then set the **Server port** to a TLS-enabled port. Grafana doesn't change the port automatically when you toggle TLS.\n- **Default database:** On Grafana Cloud, leave the default database unset. ClickHouse Cloud already routes to the correct database, and setting a name that doesn't match can cause an `Unknown database` error."
     },
     {
       "type": "markdown",

--- a/clickhouse-data-source-lj/configure-datasource/content.json
+++ b/clickhouse-data-source-lj/configure-datasource/content.json
@@ -1,0 +1,99 @@
+{
+  "id": "clickhouse-data-source-configure",
+  "title": "Configure the ClickHouse connection",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "In this milestone, you enter the connection details so Grafana Cloud can reach your ClickHouse server. You'll set the server address, protocol, port, and the read-only credentials you created earlier.\n\nTo configure the connection, complete the following steps."
+    },
+    {
+      "type": "section",
+      "autoCollapse": false,
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "formfill",
+          "reftarget": "",
+          "targetvalue": "clickhouse.example.com",
+          "doIt": false,
+          "requirements": [
+            "exists-reftarget"
+          ],
+          "content": "In the **Server address** field, enter the hostname or IP address of your ClickHouse server.\n\nFor example, enter `clickhouse.example.com`."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "",
+          "doIt": false,
+          "requirements": [
+            "exists-reftarget"
+          ],
+          "content": "For **Protocol**, choose **Native** for best performance, or **HTTP** if your network requires HTTP-based connectivity (for example, through a reverse proxy)."
+        },
+        {
+          "type": "interactive",
+          "action": "formfill",
+          "reftarget": "",
+          "targetvalue": "9000",
+          "doIt": false,
+          "requirements": [
+            "exists-reftarget"
+          ],
+          "content": "In the **Port** field, enter the port that matches your protocol. Native uses `9000` (or `9440` with TLS); HTTP uses `8123` (or `8443` with TLS)."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "",
+          "doIt": false,
+          "skippable": true,
+          "requirements": [
+            "exists-reftarget"
+          ],
+          "content": "If your ClickHouse server uses TLS, enable **Secure connection**, then set the **Port** to a TLS-enabled port. Grafana doesn't change the port automatically when you toggle TLS."
+        },
+        {
+          "type": "interactive",
+          "action": "formfill",
+          "reftarget": "",
+          "targetvalue": "grafana_reader",
+          "doIt": false,
+          "requirements": [
+            "exists-reftarget"
+          ],
+          "content": "In the **Username** field, enter the read-only user you created earlier.\n\nFor example, enter `grafana_reader`."
+        },
+        {
+          "type": "interactive",
+          "action": "formfill",
+          "reftarget": "",
+          "doIt": false,
+          "requirements": [
+            "exists-reftarget"
+          ],
+          "content": "In the **Password** field, enter the password for your read-only user.\n\nFor your security, enter this value yourself rather than having Grafana fill it in."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "",
+          "doIt": false,
+          "skippable": true,
+          "requirements": [
+            "exists-reftarget"
+          ],
+          "content": "Leave **Default database** blank on Grafana Cloud. ClickHouse Cloud already routes to the correct database, and setting a name that doesn't match can cause an `Unknown database` error. On self-hosted ClickHouse, you can optionally set the database you query most often."
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "Your connection details are in place.\n\nIn the next milestone, you'll save and test the connection."
+    },
+    {
+      "type": "markdown",
+      "content": "---\n\n### More to explore (optional)\n\n- [Configure the ClickHouse data source](https://grafana.com/docs/plugins/grafana-clickhouse-datasource/latest/configure/#configure-settings)\n- [ClickHouse protocol support and default ports](https://grafana.com/docs/plugins/grafana-clickhouse-datasource/latest/configure/#clickhouse-protocol-support)"
+    }
+  ]
+}

--- a/clickhouse-data-source-lj/configure-datasource/content.json
+++ b/clickhouse-data-source-lj/configure-datasource/content.json
@@ -55,7 +55,7 @@
         },
         {
           "type": "interactive",
-          "action": "formfill",
+          "action": "highlight",
           "reftarget": "input[aria-label='Password']",
           "doIt": false,
           "requirements": [
@@ -67,11 +67,15 @@
     },
     {
       "type": "markdown",
-      "content": "**Optional settings:**\n\n- **Secure Connection:** If your ClickHouse server uses TLS, enable **Secure Connection**, then set the **Server port** to a TLS-enabled port. Grafana doesn't change the port automatically when you toggle TLS.\n- **Default database:** On Grafana Cloud, leave the default database unset. ClickHouse Cloud already routes to the correct database, and setting a name that doesn't match can cause an `Unknown database` error."
+      "content": "Your connection details are in place."
     },
     {
       "type": "markdown",
-      "content": "Your connection details are in place.\n\nIn the next milestone, you'll save and test the connection."
+      "content": "**Optional settings:**\n\n- **Secure Connection:** If your ClickHouse server uses TLS, enable **Secure Connection**, then set the **Server port** to a TLS-enabled port. Grafana doesn't change the port automatically when you toggle TLS.\n- **Default database:** For self-hosted ClickHouse, set the database you query most often. On ClickHouse Cloud you can leave this blank, because Cloud routes to the correct database. A blank value makes the plugin use the `default` database, and setting a name that doesn't exist can cause an `Unknown database` error."
+    },
+    {
+      "type": "markdown",
+      "content": "In the next milestone, you'll save and test the connection."
     },
     {
       "type": "markdown",

--- a/clickhouse-data-source-lj/configure-datasource/manifest.json
+++ b/clickhouse-data-source-lj/configure-datasource/manifest.json
@@ -1,0 +1,17 @@
+{
+  "id": "clickhouse-data-source-configure",
+  "type": "guide",
+  "description": "Enter the connection details, protocol, and read-only credentials for your ClickHouse server.",
+  "category": "data-availability",
+  "author": {
+    "team": "Grafana Documentation",
+    "name": "lwandz13"
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": ["clickhouse-data-source-add"],
+  "recommends": ["clickhouse-data-source-test"],
+  "suggests": [],
+  "provides": []
+}

--- a/clickhouse-data-source-lj/configure-datasource/website.yaml
+++ b/clickhouse-data-source-lj/configure-datasource/website.yaml
@@ -1,0 +1,13 @@
+menuTitle: Configure the connection
+weight: 400
+step: 5
+layout: single-journey
+cta:
+  type: continue
+keywords:
+- ClickHouse
+- connection
+- protocol
+- TLS
+- credentials
+description: Enter the connection details, protocol, and read-only credentials for your ClickHouse server.

--- a/clickhouse-data-source-lj/content.json
+++ b/clickhouse-data-source-lj/content.json
@@ -1,0 +1,22 @@
+{
+  "id": "clickhouse-data-source-lj",
+  "title": "Connect to a ClickHouse data source in Grafana Cloud",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "Welcome to the Grafana learning path for connecting a ClickHouse data source.\n\nClickHouse is a fast, open source, column-oriented database built for online analytical processing (OLAP). It excels at storing and querying huge volumes of logs, traces, and events, which makes it a popular backend for observability and analytics at scale. The ClickHouse data source lets you query and visualize that data directly in Grafana, using either a visual query builder or raw SQL.\n\nThis journey walks you through connecting Grafana Cloud to your ClickHouse server so you can query, visualize, and build dashboards from your ClickHouse data."
+    },
+    {
+      "type": "markdown",
+      "content": "## Here's what to expect\n\nWhen you complete this journey, you'll be able to:\n\n- Understand why ClickHouse pairs well with Grafana for logs, traces, and analytics\n- Create a read-only ClickHouse user that Grafana can use safely\n- Add the ClickHouse data source plugin in Grafana Cloud\n- Configure the connection details, protocol, and credentials for your ClickHouse server\n- Save and test the connection, and recognize the most common connection errors\n- Verify that your ClickHouse data returns by running a query in Explore"
+    },
+    {
+      "type": "markdown",
+      "content": "## Before you begin\n\nBefore you connect to a ClickHouse data source, ensure you have:\n\n- A running ClickHouse server that Grafana Cloud can reach on its query port (Native: `9000`, or `9440` with TLS; HTTP: `8123`, or `8443` with TLS).\n- A read-only ClickHouse user, or permission to create one (you'll set this up in this journey).\n- The connection details for your server: host, port, username, and password.\n- Organization administrator access in Grafana, which is required to add a data source.\n- If your ClickHouse server sits behind a firewall, network access from Grafana Cloud (for example, an allowlist entry or a private data source connection)."
+    },
+    {
+      "type": "markdown",
+      "content": "## Troubleshooting\n\nIf you get stuck, help is close at hand. Where it's useful, this journey links to the relevant [ClickHouse data source troubleshooting](https://grafana.com/docs/plugins/grafana-clickhouse-datasource/latest/troubleshooting/) topics.\n\n## More to explore\n\nWhere it makes sense, we'll point you to related capabilities such as the prebuilt OpenTelemetry dashboards and Drilldown apps so you can keep going after you're connected."
+    }
+  ]
+}

--- a/clickhouse-data-source-lj/end-journey/content.json
+++ b/clickhouse-data-source-lj/end-journey/content.json
@@ -1,0 +1,18 @@
+{
+  "id": "clickhouse-data-source-end",
+  "title": "Destination reached!",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "Congratulations on completing this journey! You've connected Grafana Cloud to ClickHouse from start to finish.\n\nAlong the way, you:\n\n- Learned why ClickHouse pairs well with Grafana for logs, traces, and analytics\n- Created a read-only ClickHouse user that can still enforce query timeouts\n- Added the ClickHouse data source in Grafana Cloud\n- Configured the server address, protocol, port, and credentials\n- Saved and tested the connection, and learned to read the error categories\n- Verified your data by running a query in Explore"
+    },
+    {
+      "type": "markdown",
+      "content": "---\n\n### Related paths\n\nConsider taking the following paths after you complete this journey:\n\n- [Explore logs with Logs Drilldown](https://grafana.com/docs/learning-paths/drilldown-logs/)\n- [Explore traces with Traces Drilldown](https://grafana.com/docs/learning-paths/drilldown-traces/)"
+    },
+    {
+      "type": "markdown",
+      "content": "---\n\n### More to explore (optional)\n\n- [ClickHouse OpenTelemetry dashboards](https://grafana.com/docs/plugins/grafana-clickhouse-datasource/latest/dashboards/)\n- [ClickHouse template variables](https://grafana.com/docs/plugins/grafana-clickhouse-datasource/latest/template-variables/)\n- [ClickHouse alerting](https://grafana.com/docs/plugins/grafana-clickhouse-datasource/latest/alerting/)"
+    }
+  ]
+}

--- a/clickhouse-data-source-lj/end-journey/manifest.json
+++ b/clickhouse-data-source-lj/end-journey/manifest.json
@@ -1,0 +1,17 @@
+{
+  "id": "clickhouse-data-source-end",
+  "type": "guide",
+  "description": "Recap what you accomplished and find related paths to continue your ClickHouse journey.",
+  "category": "data-availability",
+  "author": {
+    "team": "Grafana Documentation",
+    "name": "lwandz13"
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": ["clickhouse-data-source-verify"],
+  "recommends": [],
+  "suggests": ["drilldown-logs-lj", "drilldown-traces-lj"],
+  "provides": []
+}

--- a/clickhouse-data-source-lj/end-journey/website.yaml
+++ b/clickhouse-data-source-lj/end-journey/website.yaml
@@ -1,0 +1,12 @@
+menuTitle: Destination reached!
+weight: 700
+step: 8
+layout: single-journey
+cta:
+  type: continue
+keywords:
+- ClickHouse
+- data source
+- summary
+- next steps
+description: Recap what you accomplished and find related paths to continue your ClickHouse journey.

--- a/clickhouse-data-source-lj/end-journey/website.yaml
+++ b/clickhouse-data-source-lj/end-journey/website.yaml
@@ -3,7 +3,7 @@ weight: 700
 step: 8
 layout: single-journey
 cta:
-  type: continue
+  type: conclusion
 keywords:
 - ClickHouse
 - data source

--- a/clickhouse-data-source-lj/intro-clickhouse/content.json
+++ b/clickhouse-data-source-lj/intro-clickhouse/content.json
@@ -1,0 +1,22 @@
+{
+  "id": "clickhouse-data-source-intro",
+  "title": "Why ClickHouse and Grafana",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "ClickHouse is a column-oriented database built for online analytical processing (OLAP). Instead of optimizing for single-row lookups like a traditional transactional database, it scans and aggregates across billions of rows in a fraction of a second. That speed at scale is why teams reach for ClickHouse to store logs, traces, metrics, and high-volume event data."
+    },
+    {
+      "type": "markdown",
+      "content": "## Why connect ClickHouse to Grafana\n\nPairing ClickHouse with Grafana gives you a single place to explore and visualize that data:\n\n- **Query with the builder or SQL.** Use the visual query builder for common patterns, or write raw ClickHouse SQL when you need full control.\n- **Purpose-built for observability.** The data source understands logs, traces, and time series, and ships prebuilt OpenTelemetry dashboards for data written by the OpenTelemetry Collector.\n- **Dynamic dashboards.** ClickHouse-specific macros and template variables let you build reusable, parameterized dashboards.\n- **Alerting.** Turn ClickHouse queries into Grafana alert rules and recording rules."
+    },
+    {
+      "type": "markdown",
+      "content": "## What you'll do in this journey\n\nThis first journey focuses on getting connected safely. You'll create a read-only ClickHouse user, add the data source, configure the connection, test it, and run your first query. Once you're connected, the follow-on paths cover exploring observability data and building dashboards.\n\nIn the next milestone, you'll prepare a read-only ClickHouse user for Grafana to use."
+    },
+    {
+      "type": "markdown",
+      "content": "---\n\n### More to explore (optional)\n\n- [ClickHouse data source overview](https://grafana.com/docs/plugins/grafana-clickhouse-datasource/latest/)\n- [ClickHouse documentation](https://clickhouse.com/docs)"
+    }
+  ]
+}

--- a/clickhouse-data-source-lj/intro-clickhouse/content.json
+++ b/clickhouse-data-source-lj/intro-clickhouse/content.json
@@ -8,11 +8,11 @@
     },
     {
       "type": "markdown",
-      "content": "## Why connect ClickHouse to Grafana\n\nPairing ClickHouse with Grafana gives you a single place to explore and visualize that data:\n\n- **Query with the builder or SQL.** Use the visual query builder for common patterns, or write raw ClickHouse SQL when you need full control.\n- **Purpose-built for observability.** The data source understands logs, traces, and time series, and ships prebuilt OpenTelemetry dashboards for data written by the OpenTelemetry Collector.\n- **Dynamic dashboards.** ClickHouse-specific macros and template variables let you build reusable, parameterized dashboards.\n- **Alerting.** Turn ClickHouse queries into Grafana alert rules and recording rules."
+      "content": "**Why connect ClickHouse to Grafana**\n\nPairing ClickHouse with Grafana gives you a single place to explore and visualize that data:\n\n- **Query with the builder or SQL.** Use the visual query builder for common patterns, or write raw ClickHouse SQL when you need full control.\n- **Purpose-built for observability.** The data source understands logs, traces, and time series, and ships prebuilt OpenTelemetry dashboards for data written by the OpenTelemetry Collector.\n- **Dynamic dashboards.** ClickHouse-specific macros and template variables let you build reusable, parameterized dashboards.\n- **Alerting.** Turn ClickHouse queries into Grafana alert rules and recording rules."
     },
     {
       "type": "markdown",
-      "content": "## What you'll do in this journey\n\nThis first journey focuses on getting connected safely. You'll create a read-only ClickHouse user, add the data source, configure the connection, test it, and run your first query. Once you're connected, the follow-on paths cover exploring observability data and building dashboards.\n\nIn the next milestone, you'll prepare a read-only ClickHouse user for Grafana to use."
+      "content": "**What you'll do in this journey**\n\nThis first journey focuses on getting connected safely. You'll create a read-only ClickHouse user, add the data source, configure the connection, test it, and run your first query. Once you're connected, the follow-on paths cover exploring observability data and building dashboards.\n\nIn the next milestone, you'll prepare a read-only ClickHouse user for Grafana to use."
     },
     {
       "type": "markdown",

--- a/clickhouse-data-source-lj/intro-clickhouse/content.json
+++ b/clickhouse-data-source-lj/intro-clickhouse/content.json
@@ -4,7 +4,7 @@
   "blocks": [
     {
       "type": "markdown",
-      "content": "ClickHouse is a column-oriented database built for online analytical processing (OLAP). Instead of optimizing for single-row lookups like a traditional transactional database, it scans and aggregates across billions of rows in a fraction of a second. That speed at scale is why teams reach for ClickHouse to store logs, traces, metrics, and high-volume event data."
+      "content": "ClickHouse is a column-oriented database built for online analytical processing (OLAP). Instead of optimizing for single-row lookups like a traditional transactional database, it's built to scan and aggregate across very large datasets quickly. That performance at scale is why teams reach for ClickHouse to store logs, traces, metrics, and high-volume event data."
     },
     {
       "type": "markdown",

--- a/clickhouse-data-source-lj/intro-clickhouse/manifest.json
+++ b/clickhouse-data-source-lj/intro-clickhouse/manifest.json
@@ -1,0 +1,17 @@
+{
+  "id": "clickhouse-data-source-intro",
+  "type": "guide",
+  "description": "Understand why ClickHouse pairs well with Grafana for logs, traces, and analytics.",
+  "category": "data-availability",
+  "author": {
+    "team": "Grafana Documentation",
+    "name": "lwandz13"
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": [],
+  "recommends": ["clickhouse-data-source-prepare"],
+  "suggests": [],
+  "provides": []
+}

--- a/clickhouse-data-source-lj/intro-clickhouse/website.yaml
+++ b/clickhouse-data-source-lj/intro-clickhouse/website.yaml
@@ -1,0 +1,12 @@
+menuTitle: Why ClickHouse and Grafana
+weight: 100
+step: 2
+layout: single-journey
+cta:
+  type: continue
+keywords:
+- ClickHouse
+- OLAP
+- observability
+- data source
+description: Understand why ClickHouse pairs well with Grafana for logs, traces, and analytics.

--- a/clickhouse-data-source-lj/manifest.json
+++ b/clickhouse-data-source-lj/manifest.json
@@ -1,0 +1,60 @@
+{
+  "id": "clickhouse-data-source-lj",
+  "type": "path",
+  "description": "How to connect and verify the ClickHouse data source in Grafana Cloud.",
+  "category": "data-availability",
+  "author": {
+    "team": "Grafana Documentation",
+    "name": "lwandz13"
+  },
+  "startingLocation": "/connections/datasources",
+  "targeting": {
+    "match": {
+      "or": [
+        {
+          "and": [
+            {
+              "or": [
+                {
+                  "and": [
+                    {
+                      "urlPrefix": "/connections/datasources"
+                    },
+                    {
+                      "tag": "selected-datasource:clickhouse"
+                    }
+                  ]
+                },
+                {
+                  "urlPrefix": "/connections/datasources/clickhouse"
+                },
+                {
+                  "urlRegex": "/connections/add-new-connection/?$"
+                }
+              ]
+            },
+            {
+              "targetPlatform": "cloud"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "milestones": [
+    "clickhouse-data-source-intro",
+    "clickhouse-data-source-prepare",
+    "clickhouse-data-source-add",
+    "clickhouse-data-source-configure",
+    "clickhouse-data-source-test",
+    "clickhouse-data-source-verify",
+    "clickhouse-data-source-end"
+  ],
+  "depends": [],
+  "recommends": [],
+  "suggests": ["drilldown-logs-lj", "drilldown-traces-lj"],
+  "provides": []
+}

--- a/clickhouse-data-source-lj/prepare-clickhouse/content.json
+++ b/clickhouse-data-source-lj/prepare-clickhouse/content.json
@@ -1,0 +1,52 @@
+{
+  "id": "clickhouse-data-source-prepare",
+  "title": "Prepare a read-only ClickHouse user",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "Grafana runs the queries you write exactly as written and does not restrict SQL. To keep your data safe, connect Grafana with a **read-only** ClickHouse user so a mistaken or malicious query can't modify or drop tables.\n\nThere's one important nuance: the ClickHouse data source client sets `max_execution_time` on every query to enforce the query timeout. A plain `readonly = 1` user is blocked from changing any setting, so you must also allow that one setting to change in read-only mode. If you skip this, the connection test can pass but queries fail at runtime with `Cannot modify 'max_execution_time': Setting is locked`."
+    },
+    {
+      "type": "markdown",
+      "content": "## Before you begin\n\n- Confirm your ClickHouse server is running and reachable from Grafana Cloud on its query port (Native `9000`/`9440`, or HTTP `8123`/`8443`).\n- You'll need an account that can create users and alter settings profiles in ClickHouse.\n\nIf your ClickHouse administrator has already given you a read-only user and connection details, you can skip ahead to the next milestone."
+    },
+    {
+      "type": "markdown",
+      "content": "To prepare a read-only user, complete the following steps."
+    },
+    {
+      "type": "section",
+      "autoCollapse": false,
+      "blocks": [
+        {
+          "type": "markdown",
+          "content": "Connect to your ClickHouse server as an administrative user, for example with `clickhouse-client`:\n\n```bash\nclickhouse-client --user default --password\n```"
+        },
+        {
+          "type": "markdown",
+          "content": "Create a dedicated user for Grafana:\n\n```sql\nCREATE USER grafana_reader IDENTIFIED BY 'REPLACE_WITH_STRONG_PASSWORD';\n```"
+        },
+        {
+          "type": "markdown",
+          "content": "Grant read access to the databases you want to query. For example, to grant read access to a single database:\n\n```sql\nGRANT SELECT ON otel.* TO grafana_reader;\n```"
+        },
+        {
+          "type": "markdown",
+          "content": "Create a settings profile that keeps the user read-only but lets the plugin change `max_execution_time`:\n\n```sql\nCREATE SETTINGS PROFILE grafana_reader_profile\n  SETTINGS readonly = 1,\n           max_execution_time CHANGEABLE_IN_READONLY\n  TO grafana_reader;\n```"
+        },
+        {
+          "type": "markdown",
+          "content": "Verify the user can run a query with the timeout setting applied:\n\n```bash\nclickhouse-client --user grafana_reader --password --query \"SELECT 1 SETTINGS max_execution_time = 30\"\n```"
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "Note the host, port, user name, and password. You'll enter these when you configure the data source.\n\nIn the next milestone, you'll add the ClickHouse data source in Grafana Cloud."
+    },
+    {
+      "type": "markdown",
+      "content": "---\n\n### More to explore (optional)\n\n- [Configure a read-only ClickHouse user](https://grafana.com/docs/plugins/grafana-clickhouse-datasource/latest/configure/#clickhouse-user-and-permissions)\n- [Creating users and roles in ClickHouse](https://clickhouse.com/docs/en/operations/access-rights)"
+    }
+  ]
+}

--- a/clickhouse-data-source-lj/prepare-clickhouse/content.json
+++ b/clickhouse-data-source-lj/prepare-clickhouse/content.json
@@ -8,7 +8,7 @@
     },
     {
       "type": "markdown",
-      "content": "## Before you begin\n\n- Confirm your ClickHouse server is running and reachable from Grafana Cloud on its query port (Native `9000`/`9440`, or HTTP `8123`/`8443`).\n- You'll need an account that can create users and alter settings profiles in ClickHouse.\n\nIf your ClickHouse administrator has already given you a read-only user and connection details, you can skip ahead to the next milestone."
+      "content": "**Before you begin**\n\n- Confirm your ClickHouse server is running and reachable from Grafana Cloud on its query port (Native `9000`/`9440`, or HTTP `8123`/`8443`).\n- You'll need an account that can create users and alter settings profiles in ClickHouse.\n\nIf your ClickHouse administrator has already given you a read-only user and connection details, you can skip ahead to the next milestone."
     },
     {
       "type": "markdown",

--- a/clickhouse-data-source-lj/prepare-clickhouse/manifest.json
+++ b/clickhouse-data-source-lj/prepare-clickhouse/manifest.json
@@ -1,0 +1,17 @@
+{
+  "id": "clickhouse-data-source-prepare",
+  "type": "guide",
+  "description": "Create a read-only ClickHouse user that Grafana can use, and gather your connection details.",
+  "category": "data-availability",
+  "author": {
+    "team": "Grafana Documentation",
+    "name": "lwandz13"
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": ["clickhouse-data-source-intro"],
+  "recommends": ["clickhouse-data-source-add"],
+  "suggests": [],
+  "provides": []
+}

--- a/clickhouse-data-source-lj/prepare-clickhouse/website.yaml
+++ b/clickhouse-data-source-lj/prepare-clickhouse/website.yaml
@@ -1,0 +1,12 @@
+menuTitle: Prepare a read-only user
+weight: 200
+step: 3
+layout: single-journey
+cta:
+  type: continue
+keywords:
+- ClickHouse
+- read-only user
+- permissions
+- max_execution_time
+description: Create a read-only ClickHouse user that Grafana can use, and gather your connection details.

--- a/clickhouse-data-source-lj/test-connection/content.json
+++ b/clickhouse-data-source-lj/test-connection/content.json
@@ -23,7 +23,7 @@
     },
     {
       "type": "markdown",
-      "content": "## If the test fails\n\nThe plugin prefixes each error with a category in square brackets so you can pinpoint the problem quickly:\n\n- `[config]` -- a setting is missing or invalid. The most common fix is to **clear the Default database field**, especially on ClickHouse Cloud.\n- `[auth]` -- the credentials or privileges are wrong. Re-check the username and password for your read-only user.\n- `[network]` -- Grafana can't reach ClickHouse. Confirm the host, port, and that any firewall allows Grafana Cloud.\n- `[tls]` -- a TLS or certificate problem. Check that **Secure connection** and the port match your server.\n\nIf the test passes but queries later fail with `Cannot modify 'max_execution_time': Setting is locked`, revisit the read-only user's settings profile from the earlier milestone."
+      "content": "**If the test fails**\n\nThe plugin prefixes each error with a category in square brackets so you can pinpoint the problem quickly:\n\n- `[config]` -- a setting is missing or invalid. The most common fix is to **clear the Default database field**, especially on ClickHouse Cloud.\n- `[auth]` -- the credentials or privileges are wrong. Re-check the username and password for your read-only user.\n- `[network]` -- Grafana can't reach ClickHouse. Confirm the host, port, and that any firewall allows Grafana Cloud.\n- `[tls]` -- a TLS or certificate problem. Check that **Secure connection** and the port match your server.\n\nIf the test passes but queries later fail with `Cannot modify 'max_execution_time': Setting is locked`, revisit the read-only user's settings profile from the earlier milestone."
     },
     {
       "type": "markdown",

--- a/clickhouse-data-source-lj/test-connection/content.json
+++ b/clickhouse-data-source-lj/test-connection/content.json
@@ -1,0 +1,37 @@
+{
+  "id": "clickhouse-data-source-test",
+  "title": "Save and test the connection",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "With the connection details entered, save the data source and confirm Grafana can reach ClickHouse.\n\nTo test the connection, complete the following step."
+    },
+    {
+      "type": "section",
+      "autoCollapse": false,
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "button",
+          "reftarget": "Save & test",
+          "requirements": [
+            "exists-reftarget"
+          ],
+          "content": "Click **Save & test**.\n\nWhen the test succeeds, you'll see the message `Data source is working`. This confirms Grafana can reach ClickHouse and that the credentials are valid."
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "## If the test fails\n\nThe plugin prefixes each error with a category in square brackets so you can pinpoint the problem quickly:\n\n- `[config]` -- a setting is missing or invalid. The most common fix is to **clear the Default database field**, especially on ClickHouse Cloud.\n- `[auth]` -- the credentials or privileges are wrong. Re-check the username and password for your read-only user.\n- `[network]` -- Grafana can't reach ClickHouse. Confirm the host, port, and that any firewall allows Grafana Cloud.\n- `[tls]` -- a TLS or certificate problem. Check that **Secure connection** and the port match your server.\n\nIf the test passes but queries later fail with `Cannot modify 'max_execution_time': Setting is locked`, revisit the read-only user's settings profile from the earlier milestone."
+    },
+    {
+      "type": "markdown",
+      "content": "In the next milestone, you'll verify your data by running a query in Explore."
+    },
+    {
+      "type": "markdown",
+      "content": "---\n\n### Troubleshooting\n\nExplore the following troubleshooting topics if you need help:\n\n- [Failed to create ClickHouse client](https://grafana.com/docs/plugins/grafana-clickhouse-datasource/latest/troubleshooting/#failed-to-create-clickhouse-client)\n- [Setting is locked (readonly)](https://grafana.com/docs/plugins/grafana-clickhouse-datasource/latest/troubleshooting/#setting-is-locked-readonly)\n- [Full troubleshooting guide](https://grafana.com/docs/plugins/grafana-clickhouse-datasource/latest/troubleshooting/)"
+    }
+  ]
+}

--- a/clickhouse-data-source-lj/test-connection/content.json
+++ b/clickhouse-data-source-lj/test-connection/content.json
@@ -23,7 +23,11 @@
     },
     {
       "type": "markdown",
-      "content": "**If the test fails**\n\nThe plugin prefixes each error with a category in square brackets so you can pinpoint the problem quickly:\n\n- `[config]` -- a setting is missing or invalid. The most common fix is to **clear the Default database field**, especially on ClickHouse Cloud.\n- `[auth]` -- the credentials or privileges are wrong. Re-check the username and password for your read-only user.\n- `[network]` -- Grafana can't reach ClickHouse. Confirm the host, port, and that any firewall allows Grafana Cloud.\n- `[tls]` -- a TLS or certificate problem. Check that **Secure connection** and the port match your server.\n\nIf the test passes but queries later fail with `Cannot modify 'max_execution_time': Setting is locked`, revisit the read-only user's settings profile from the earlier milestone."
+      "content": "You've saved the data source and confirmed Grafana can reach ClickHouse."
+    },
+    {
+      "type": "markdown",
+      "content": "**If the test fails**\n\nThe plugin prefixes each error with a category in square brackets so you can pinpoint the problem quickly:\n\n- `[config]` -- a connection setting is missing or invalid, such as an empty host, an out-of-range port, or malformed JSON. Recheck the **Server address** and **Server port**.\n- `[auth]` -- the credentials or privileges are wrong. Re-check the username and password for your read-only user.\n- `[network]` -- Grafana can't reach ClickHouse. Confirm the host, port, and that any firewall allows Grafana Cloud.\n- `[tls]` -- a TLS or certificate problem. Check that **Secure Connection** and the port match your server.\n\nIf the test reports `failed to create ClickHouse client`, clear the **Default database** field and try again -- a database name that doesn't exist is a common cause, especially on ClickHouse Cloud.\n\nIf the test passes but queries later fail with `Cannot modify 'max_execution_time': Setting is locked`, revisit the read-only user's settings profile from the earlier milestone."
     },
     {
       "type": "markdown",

--- a/clickhouse-data-source-lj/test-connection/manifest.json
+++ b/clickhouse-data-source-lj/test-connection/manifest.json
@@ -1,0 +1,17 @@
+{
+  "id": "clickhouse-data-source-test",
+  "type": "guide",
+  "description": "Save the data source, test the connection, and recognize the most common connection errors.",
+  "category": "data-availability",
+  "author": {
+    "team": "Grafana Documentation",
+    "name": "lwandz13"
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": ["clickhouse-data-source-configure"],
+  "recommends": ["clickhouse-data-source-verify"],
+  "suggests": [],
+  "provides": []
+}

--- a/clickhouse-data-source-lj/test-connection/website.yaml
+++ b/clickhouse-data-source-lj/test-connection/website.yaml
@@ -1,0 +1,12 @@
+menuTitle: Save and test the connection
+weight: 500
+step: 6
+layout: single-journey
+cta:
+  type: continue
+keywords:
+- ClickHouse
+- Save and test
+- connection
+- troubleshooting
+description: Save the data source, test the connection, and recognize the most common connection errors.

--- a/clickhouse-data-source-lj/verify-data/content.json
+++ b/clickhouse-data-source-lj/verify-data/content.json
@@ -56,7 +56,7 @@
     },
     {
       "type": "markdown",
-      "content": "## Confirm successful access\n\nAfter running the query, you should see:\n\n- Rows returned in the Explore results panel\n- No connection errors or timeouts\n- Table names from your ClickHouse server\n\n**Congratulations!** You've connected ClickHouse to Grafana Cloud and confirmed it returns data."
+      "content": "**Confirm successful access**\n\nAfter running the query, you should see:\n\n- Rows returned in the Explore results panel\n- No connection errors or timeouts\n- Table names from your ClickHouse server\n\n**Congratulations!** You've connected ClickHouse to Grafana Cloud and confirmed it returns data."
     },
     {
       "type": "markdown",

--- a/clickhouse-data-source-lj/verify-data/content.json
+++ b/clickhouse-data-source-lj/verify-data/content.json
@@ -1,0 +1,66 @@
+{
+  "id": "clickhouse-data-source-verify",
+  "title": "Verify your ClickHouse data",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "Confirm the data source works end to end by running a query in Explore. Every ClickHouse server exposes the `system` database, so you can verify the connection even before you know your own table names.\n\nTo verify your data, complete the following steps."
+    },
+    {
+      "type": "section",
+      "autoCollapse": false,
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "a[href='/explore']",
+          "requirements": [
+            "navmenu-open",
+            "exists-reftarget"
+          ],
+          "content": "In the navigation menu, click **Explore**."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='data-testid Select a data source']",
+          "doIt": false,
+          "requirements": [
+            "on-page:/explore",
+            "exists-reftarget"
+          ],
+          "content": "From the data source dropdown at the top-left, select your ClickHouse data source.\n\nFor example, select **ClickHouse observability**."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='query-editor-rows']",
+          "doIt": false,
+          "requirements": [
+            "on-page:/explore",
+            "exists-reftarget"
+          ],
+          "content": "Switch the editor to **SQL** and enter a simple query to confirm the connection:\n\n```sql\nSELECT name FROM system.tables LIMIT 10\n```"
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "button[aria-label='Run query']",
+          "requirements": [
+            "on-page:/explore",
+            "exists-reftarget"
+          ],
+          "content": "Click **Run query**.\n\nYou should see a list of table names in the results panel below the editor. That confirms Grafana is querying ClickHouse successfully."
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "## Confirm successful access\n\nAfter running the query, you should see:\n\n- Rows returned in the Explore results panel\n- No connection errors or timeouts\n- Table names from your ClickHouse server\n\n**Congratulations!** You've connected ClickHouse to Grafana Cloud and confirmed it returns data."
+    },
+    {
+      "type": "markdown",
+      "content": "---\n\n### More to explore (optional)\n\n- [ClickHouse query editor](https://grafana.com/docs/plugins/grafana-clickhouse-datasource/latest/query-editor/)\n- [Build dashboards in Grafana](https://grafana.com/docs/grafana/latest/dashboards/)"
+    }
+  ]
+}

--- a/clickhouse-data-source-lj/verify-data/content.json
+++ b/clickhouse-data-source-lj/verify-data/content.json
@@ -4,7 +4,7 @@
   "blocks": [
     {
       "type": "markdown",
-      "content": "Confirm the data source works end to end by running a query in Explore. Every ClickHouse server exposes the `system` database, so you can verify the connection even before you know your own table names.\n\nTo verify your data, complete the following steps."
+      "content": "Confirm the data source works end to end by running a query in Explore. A simple `SELECT 1` confirms Grafana can query ClickHouse and get a result back, without needing access to any specific table.\n\nTo verify your data, complete the following steps."
     },
     {
       "type": "section",
@@ -34,13 +34,24 @@
         {
           "type": "interactive",
           "action": "highlight",
+          "reftarget": "[data-testid='data-testid radio-button-option sql']",
+          "skippable": true,
+          "requirements": [
+            "on-page:/explore",
+            "exists-reftarget"
+          ],
+          "content": "The editor opens in **Query Builder** mode by default. Switch it to **SQL Editor**.\n\nSkip this step if the editor is already set to **SQL Editor**."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
           "reftarget": "[data-testid='query-editor-rows']",
           "doIt": false,
           "requirements": [
             "on-page:/explore",
             "exists-reftarget"
           ],
-          "content": "Switch the editor to **SQL** and enter a simple query to confirm the connection:\n\n```sql\nSELECT name FROM system.tables LIMIT 10\n```"
+          "content": "In the SQL editor, enter a simple query to confirm the connection:\n\n```sql\nSELECT 1\n```"
         },
         {
           "type": "interactive",
@@ -50,13 +61,13 @@
             "on-page:/explore",
             "exists-reftarget"
           ],
-          "content": "Click **Run query**.\n\nYou should see a list of table names in the results panel below the editor. That confirms Grafana is querying ClickHouse successfully."
+          "content": "Click **Run query**.\n\nYou should see a single row with the value `1` in the results panel below the editor. That confirms Grafana is querying ClickHouse successfully."
         }
       ]
     },
     {
       "type": "markdown",
-      "content": "**Confirm successful access**\n\nAfter running the query, you should see:\n\n- Rows returned in the Explore results panel\n- No connection errors or timeouts\n- Table names from your ClickHouse server\n\n**Congratulations!** You've connected ClickHouse to Grafana Cloud and confirmed it returns data."
+      "content": "**Confirm successful access**\n\nAfter running the query, you should see:\n\n- A single row with the value `1` in the Explore results panel\n- No connection errors or timeouts\n\n**Congratulations!** You've connected ClickHouse to Grafana Cloud and confirmed it returns data."
     },
     {
       "type": "markdown",

--- a/clickhouse-data-source-lj/verify-data/manifest.json
+++ b/clickhouse-data-source-lj/verify-data/manifest.json
@@ -1,0 +1,17 @@
+{
+  "id": "clickhouse-data-source-verify",
+  "type": "guide",
+  "description": "Run a query in Explore to verify that your ClickHouse data source returns data.",
+  "category": "data-availability",
+  "author": {
+    "team": "Grafana Documentation",
+    "name": "lwandz13"
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": ["clickhouse-data-source-test"],
+  "recommends": ["clickhouse-data-source-end"],
+  "suggests": [],
+  "provides": []
+}

--- a/clickhouse-data-source-lj/verify-data/website.yaml
+++ b/clickhouse-data-source-lj/verify-data/website.yaml
@@ -1,0 +1,12 @@
+menuTitle: Verify your ClickHouse data
+weight: 600
+step: 7
+layout: single-journey
+cta:
+  type: continue
+keywords:
+- ClickHouse
+- Explore
+- query
+- verify
+description: Run a query in Explore to verify that your ClickHouse data source returns data.

--- a/clickhouse-data-source-lj/website.yaml
+++ b/clickhouse-data-source-lj/website.yaml
@@ -1,0 +1,36 @@
+menuTitle: Connect to a ClickHouse data source
+weight: 350
+journey:
+  group: data-availability
+  skill: Beginner
+  source: Docs & blog posts
+  logo:
+    src: /static/img/logos/clickhouse.png
+    background: '#FFFFFF'
+    width: 46
+    height: 55
+step: 1
+layout: single-journey
+cascade:
+  layout: single-journey
+cta:
+  type: start
+  title: Are you ready?
+  cta_text: Let's go!
+keywords:
+- ClickHouse
+- data source
+- Grafana Cloud
+- OLAP
+- observability
+- SQL queries
+related_journeys:
+  title: Related paths
+  heading: Consider taking the following paths after you complete this journey.
+  items:
+  - title: Explore logs with Logs Drilldown
+    link: /docs/learning-paths/drilldown-logs/
+  - title: Explore traces with Traces Drilldown
+    link: /docs/learning-paths/drilldown-traces/
+description: Welcome to the Grafana learning path for connecting and verifying a ClickHouse data source in Grafana Cloud.
+show_play: false


### PR DESCRIPTION
## Summary

Adds `clickhouse-data-source-lj`, a 7-milestone beginner learning path for connecting and verifying the ClickHouse data source in Grafana Cloud. This is **Path 1** of a planned four-path ClickHouse course ("Master ClickHouse with Grafana").

Milestones:
1. Why ClickHouse and Grafana (intro)
2. Prepare a read-only ClickHouse user (`readonly = 1` + `max_execution_time CHANGEABLE_IN_READONLY`)
3. Add the ClickHouse data source
4. Configure the connection (protocol/port/TLS/credentials; Default database blank on Cloud)
5. Save and test (with `[config]`/`[auth]`/`[network]`/`[tls]` error categories)
6. Verify your data (first query in Explore)
7. Destination reached! (recap + related paths)

Content is grounded in the [ClickHouse data source docs](https://grafana.com/docs/plugins/grafana-clickhouse-datasource/latest/). Adds the package to CODEOWNERS.

## Status: draft / WIP

- [ ] **Selector discovery** — the generic add/test/Explore selectors reuse the proven MySQL path, but the ClickHouse-specific connection fields in `configure-datasource` have empty `reftarget`s pending Playwright discovery on a live stack.
- [ ] **CLI validation** — `validate --packages .` not yet run locally (no `grafana-pathfinder-app` checkout available at scaffold time).
- [ ] **Block Editor smoke test** — Show me / Do it not yet verified.
- [ ] **Logo asset** — `website.yaml` references `/static/img/logos/clickhouse.png`; confirm the asset path.

## Follow-on

Paths 2-4 (OTel observability, dynamic dashboards, query mastery) and the `courses/clickhouse` catalog entry + completion badge are planned as separate PRs.

Made with [Cursor](https://cursor.com)