### PR TITLE
feat(k8s): interactive guide for connecting your first Kubernetes cluster

### DIFF
--- a/k8s-connect-first-cluster/content.json
+++ b/k8s-connect-first-cluster/content.json
@@ -4,7 +4,7 @@
   "blocks": [
     {
       "type": "markdown",
-      "content": "This wizard collects everything the Helm chart needs across four steps \u2014 **Stack and platform**, **Monitoring type**, **Backend and token** and **Deployment** \u2014 and each unlocks only once the one before it is complete. You start here, with the cluster's name and platform."
+      "content": "Connecting a cluster takes four steps, and the wizard won't let you skip ahead \u2014 each one unlocks the next. You'll name the cluster, choose what to collect, set up a credential, and walk away with a command to run. Start here."
     },
     {
       "type": "section",
@@ -21,12 +21,13 @@
           "reftarget": "[data-testid='cluster-name-input']",
           "targetvalue": "production-eu-west",
           "formHint": "An example \u2014 replace it with the name your team already uses",
-          "content": "The **Cluster name** field starts as `my-cluster`. Every metric, log and trace from this cluster is labelled with it, so set it to whatever your team already calls the cluster \u2014 `production-eu-west` here is only an example. Nothing else in the wizard depends on the value, but changing it later means relabelling everything you have already collected.",
+          "content": "Start with a name. Whatever you put here is stamped on every metric, log and trace this cluster produces, so use the name your team already says out loud \u2014 `production-eu-west` below is only an example. It's worth getting right now: changing it later means everything you've already collected is filed under the old name.",
           "doIt": false,
           "requirements": [
             "exists-reftarget",
             "on-page:/a/grafana-k8s-app/configuration"
-          ]
+          ],
+          "tooltip": "Use the name your team already calls this cluster."
         },
         {
           "type": "interactive",
@@ -34,44 +35,47 @@
           "reftarget": "[data-testid='namespace-input']",
           "targetvalue": "monitoring",
           "formHint": "Lowercase, alphanumeric, dashes allowed inside",
-          "content": "The **Namespace** is where the collector itself is deployed, not what it watches \u2014 it collects from the whole cluster either way. `monitoring` is the default and is a fine choice. It must be lowercase and alphanumeric, with dashes allowed inside the name but not at either end.",
+          "content": "This is where the collector itself runs, not what it watches \u2014 it sees the whole cluster either way. `monitoring` is the default and there's no reason to change it unless your team has a convention of its own. Lowercase and alphanumeric, dashes allowed in the middle.",
           "doIt": true,
           "requirements": [
             "exists-reftarget",
             "on-page:/a/grafana-k8s-app/configuration"
-          ]
+          ],
+          "tooltip": "Where the collector runs. `monitoring` is fine."
         },
         {
           "type": "interactive",
           "action": "button",
           "reftarget": "[data-testid='platform-card-kubernetes']",
-          "content": "Pick the card matching your cluster. **Kubernetes** covers EKS on EC2, GKE and self-managed, and is selected by default. The choice is not cosmetic: GKE Autopilot and EKS on Fargate have no node-level access, so picking those disables energy metrics and node logs on the next step.",
+          "content": "Pick the card that matches where your cluster runs. **Kubernetes** covers EKS on EC2, GKE and anything self-managed, and it's already selected. Worth being accurate here: managed platforms like GKE Autopilot and EKS on Fargate don't give anyone access to the underlying nodes, so choosing one of those quietly removes a few collectors on the next step.",
           "doIt": true,
           "requirements": [
             "exists-reftarget",
             "on-page:/a/grafana-k8s-app/configuration"
-          ]
+          ],
+          "tooltip": "Pick where your cluster actually runs."
         },
         {
           "type": "interactive",
           "action": "button",
           "reftarget": "[data-testid='config-next-button']",
-          "content": "Select **Next** to move on to the monitoring type step.",
+          "content": "That's the cluster identified. On to what you want to collect from it.",
           "doIt": true,
           "requirements": [
             "exists-reftarget",
             "on-page:/a/grafana-k8s-app/configuration"
-          ]
+          ],
+          "tooltip": "That's the cluster identified."
         }
       ]
     },
     {
       "type": "markdown",
-      "content": "The cluster now has a name, a target namespace, and a confirmed platform."
+      "content": "Your cluster has a name, somewhere to run the collector, and a platform."
     },
     {
       "type": "markdown",
-      "content": "Step 2 turns your chosen monitoring type into a set of feature toggles you can fine-tune."
+      "content": "Next you decide how much to collect. This is the step that shapes your bill as well as your dashboards, so it's worth a minute rather than a click."
     },
     {
       "type": "section",
@@ -87,68 +91,73 @@
           "action": "button",
           "reftarget": "[data-testid='monitoring-type-kubernetes-monitoring']",
           "targetstate": "true",
-          "content": "**Kubernetes Monitoring** is ticked by default and enables cluster metrics, cost, energy, events and pod logs collection. **Application Observability** is the other option, and you can select it in addition.",
+          "content": "**Kubernetes Monitoring** is what you want for a first cluster. It brings in the metrics, events and pod logs behind every dashboard in this app. Leave it ticked.",
           "doIt": true,
           "requirements": [
             "exists-reftarget",
             "on-page:/a/grafana-k8s-app/configuration"
-          ]
+          ],
+          "tooltip": "Leave this ticked \u2014 it's the core of the app."
         },
         {
           "type": "interactive",
           "action": "button",
           "reftarget": "[data-testid='config-details-toggle']",
-          "content": "Select **Show config details** to reveal the roughly twelve individual collectors bundled into the monitoring type; the button then reads **Hide config details**.",
+          "content": "Behind that single tick sit a dozen or so individual collectors. You don't have to look \u2014 the defaults are sensible \u2014 but it's worth seeing once, because this is the panel you'll come back to when someone asks why the bill went up.",
           "doIt": true,
           "requirements": [
             "exists-reftarget",
             "on-page:/a/grafana-k8s-app/configuration"
-          ]
+          ],
+          "tooltip": "Open this once to see what you're collecting."
         },
         {
           "type": "interactive",
           "action": "button",
           "reftarget": "[data-testid='feature-toggle-clusterMetrics']",
           "targetstate": "true",
-          "content": "**Cluster Metrics** collects node, pod and container resource metrics and is on by default \u2014 confirm it stays enabled.",
+          "content": "**Cluster Metrics** is the CPU, memory and storage of every node and pod. It's the backbone of the whole app, and it's already on \u2014 this is just so you know where it lives.",
           "doIt": true,
           "requirements": [
             "exists-reftarget",
             "on-page:/a/grafana-k8s-app/configuration"
-          ]
+          ],
+          "tooltip": "CPU, memory and storage per node and pod."
         },
         {
           "type": "interactive",
           "action": "button",
           "reftarget": "[data-testid='feature-toggle-clusterEvents']",
           "targetstate": "true",
-          "content": "**Cluster Events** ships the Kubernetes events that explain why a pod restarted to Loki as logs, and is on by default \u2014 confirm it stays enabled.",
+          "content": "**Cluster Events** is the one people forget to check and then miss. It captures Kubernetes' own account of what happened \u2014 why a pod was evicted, why a deployment stalled \u2014 which is usually the answer you're hunting for at 3am. Also already on.",
           "doIt": true,
           "requirements": [
             "exists-reftarget",
             "on-page:/a/grafana-k8s-app/configuration"
-          ]
+          ],
+          "tooltip": "Kubernetes' own account of what went wrong."
         },
         {
           "type": "interactive",
           "action": "button",
           "reftarget": "[data-testid='config-next-button']",
-          "content": "Select **Next** to move on to the backend and token step \u2014 it requires the backend integration to be installed first.",
+          "content": "Everything else can wait. Each extra collector costs something, and you can turn them on later once you know what you're missing.",
           "doIt": true,
           "requirements": [
             "exists-reftarget",
             "on-page:/a/grafana-k8s-app/configuration"
-          ]
+          ],
+          "tooltip": "Defaults are sensible \u2014 move on."
         }
       ]
     },
     {
       "type": "markdown",
-      "content": "Kubernetes Monitoring is selected, with cluster metrics and cluster events collection confirmed on."
+      "content": "You're collecting the essentials: resource usage, cluster events and pod logs."
     },
     {
       "type": "markdown",
-      "content": "Step 3 installs the Grafana Cloud backend integration and captures the token the collector will use to write data \u2014 step 4 isn't reachable until both are in place."
+      "content": "Two things have to be in place before Grafana can do anything with your cluster's data: the rules that turn raw metrics into the dashboards and alerts you'll actually look at, and a credential that lets the collector send data in. You'll set up both here."
     },
     {
       "type": "section",
@@ -161,32 +170,22 @@
       "blocks": [
         {
           "type": "callout",
-          "title": "Install the backend integration",
-          "content": "**Backend Installation** at the top of this step installs the alert and recording rules that the Kubernetes Monitoring dashboards query. The panel is contributed by a different plugin \u2014 `grafana-easystart-app` \u2014 through an extension point, so on a stack where that plugin is absent the panel reads *Failed to load integration management extension* and **Next** never enables. That is a missing plugin, not a mistake you made."
-        },
-        {
-          "type": "interactive",
-          "action": "highlight",
-          "reftarget": "[data-testid='access-policy-token-type']",
-          "doIt": false,
-          "requirements": [
-            "exists-reftarget",
-            "on-page:/a/grafana-k8s-app/configuration"
-          ],
-          "content": "Alloy needs a Grafana Cloud access policy token to write data. Three ways to supply one: **Create a new token**, **Use an existing token**, or **Use a stored Kubernetes Secret**. **Create a new token** is selected by default and is the path below; the stored-secret option is the one to use if your org keeps credentials in the cluster rather than pasting them into a browser."
+          "title": "Install the backend first",
+          "content": "The panel at the top of this step installs the alerting and recording rules that the Kubernetes dashboards are built on. Skip it and the dashboards will load but stay empty. Select **Install** and give it a moment to finish.\n\nIf you see an error here instead of an install button, this Grafana stack is missing the Integrations plugin. That's something whoever administers the stack needs to sort out \u2014 it isn't anything you've done."
         },
         {
           "type": "interactive",
           "action": "formfill",
           "reftarget": "[data-testid='generate-token-name-input']",
           "targetvalue": "k8s-monitoring-alloy",
-          "formHint": "The name this token appears under in grafana.com",
+          "formHint": "A name you'll recognise later",
           "doIt": true,
           "requirements": [
             "exists-reftarget",
             "on-page:/a/grafana-k8s-app/configuration"
           ],
-          "content": "Name the token. This is the name you will look for in grafana.com when you need to audit or revoke it, so make it say where the token is used rather than when it was made."
+          "content": "Now the credential. Give it a name you'll recognise months from now, when you're looking at a list of tokens and trying to work out which one you can safely revoke. Something that says where it's used beats something that says when you made it.",
+          "tooltip": "Name it for where it's used, not when you made it."
         },
         {
           "type": "interactive",
@@ -197,7 +196,8 @@
             "exists-reftarget",
             "on-page:/a/grafana-k8s-app/configuration"
           ],
-          "content": "The scopes are fixed: `metrics:read` and `set:alloy-data-write`. That is the minimum Alloy needs to ship data and read back what it wrote \u2014 you cannot widen them here, which is deliberate."
+          "content": "You don't need to touch the permissions. These two let the collector send your cluster's data and read back what it sent, and nothing else \u2014 Grafana picks them for you so you can't accidentally hand out more access than the job needs.",
+          "tooltip": "Nothing to change \u2014 Grafana sets these for you."
         },
         {
           "type": "interactive",
@@ -208,7 +208,8 @@
             "exists-reftarget",
             "on-page:/a/grafana-k8s-app/configuration"
           ],
-          "content": "Select **Create token** yourself. This guide will not press it: it mints a real credential against your Grafana Cloud account, and that is not something a tutorial should do on your behalf. The token is shown once \u2014 copy it before leaving the page."
+          "content": "Go ahead and select **Create token** yourself. This one's left to you on purpose: it creates a real credential on your Grafana Cloud account, and that's your call to make, not this guide's.\n\n**Copy the token as soon as it appears.** You won't be shown it a second time, and the next step needs it.",
+          "tooltip": "Your call to make. Copy the token when it appears."
         },
         {
           "type": "interactive",
@@ -219,17 +220,18 @@
             "exists-reftarget",
             "on-page:/a/grafana-k8s-app/configuration"
           ],
-          "content": "**Next** needs both the backend installed and a token in place. Hovering it says which of the two is still missing."
+          "content": "**Next** wakes up once the backend is installed and your token exists. If it's still greyed out, hover over it \u2014 it'll tell you which of the two is holding things up.",
+          "tooltip": "Waits for the backend and your token."
         }
       ]
     },
     {
       "type": "markdown",
-      "content": "With the backend installed and a token supplied, the wizard can generate a deployment for you to run."
+      "content": "That's the fiddly part behind you. Grafana can make sense of the data now, and the collector has permission to send it."
     },
     {
       "type": "markdown",
-      "content": "The final step turns your choices into a deployment command to run against the cluster, though it's unreachable on a stack that doesn't have the backend integration installed."
+      "content": "Last step. Everything you've chosen becomes a command you run against the cluster.\n\nYou'll only reach this screen once the backend is installed, so if you're stuck on step 3 the rest of this is a preview of where you're heading."
     },
     {
       "type": "section",
@@ -244,43 +246,84 @@
           "type": "interactive",
           "action": "highlight",
           "reftarget": "[data-testid='platform-card-helm']",
-          "content": "Pick a deployment method from three cards \u2014 **Helm**, **Terraform**, or **ArgoCD** \u2014 with **Helm** selected by default; this choice changes what's generated below, not what gets collected.",
+          "content": "**Helm** is the right answer if you don't already have an opinion \u2014 it's selected for you. The other two are here for teams who deploy everything through Terraform or ArgoCD and want this to match. Your choice changes the shape of what's generated below, not what ends up collected.",
           "doIt": false,
           "skippable": true,
           "requirements": [
             "exists-reftarget",
             "on-page:/a/grafana-k8s-app/configuration"
-          ]
+          ],
+          "tooltip": "Helm unless your team deploys another way."
         },
         {
           "type": "interactive",
           "action": "highlight",
           "reftarget": "[data-testid='clipboard-content']",
-          "content": "The generated `helm upgrade --install` command carries the cluster name, namespace, enabled features and token \u2014 check that kubectl points at the right cluster before you run it.",
+          "content": "Here's your command, with the cluster name, namespace, collectors and token already filled in. One thing to check before you paste it anywhere: make sure `kubectl` is pointed at the cluster you think it is. It's the mistake everyone makes once.",
           "doIt": false,
           "skippable": true,
           "requirements": [
             "exists-reftarget",
             "on-page:/a/grafana-k8s-app/configuration"
-          ]
+          ],
+          "tooltip": "Check kubectl points at the right cluster first."
         },
         {
           "type": "interactive",
           "action": "highlight",
           "reftarget": "[data-testid='config-back-button']",
-          "content": "Select **Back** to change anything \u2014 the generated command is recomputed from the wizard state, so editing a toggle and returning here updates what you copy.",
+          "content": "Changed your mind about something? Go **Back**. The command is rebuilt from your choices every time, so flip a toggle, return here, and you'll get an updated one to copy.",
           "doIt": false,
           "skippable": true,
           "requirements": [
             "exists-reftarget",
             "on-page:/a/grafana-k8s-app/configuration"
-          ]
+          ],
+          "tooltip": "Change anything and the command rebuilds itself."
         }
       ]
     },
     {
       "type": "markdown",
-      "content": "You now have a generated deployment command for this cluster, plus a way back to change any of it."
+      "content": "Run that command and the cluster starts reporting. The last thing worth knowing is where to watch for it."
+    },
+    {
+      "type": "section",
+      "id": "see-it-arrive",
+      "title": "Check the data is arriving",
+      "requirements": [
+        "on-page:/a/grafana-k8s-app/configuration"
+      ],
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "button",
+          "reftarget": "[data-testid='data-testid Tab Metrics status']",
+          "tooltip": "Where you find out whether it worked.",
+          "doIt": true,
+          "requirements": [
+            "exists-reftarget",
+            "on-page:/a/grafana-k8s-app/configuration"
+          ],
+          "content": "Once you've run the command, come back here and open **Metrics status**. This is the page that answers the only question that matters in the next five minutes: is anything actually arriving?"
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='status-panel']:nth-match(1)",
+          "tooltip": "Green means that collector is reporting.",
+          "doIt": false,
+          "requirements": [
+            "exists-reftarget",
+            "on-page:/a/grafana-k8s-app/configuration"
+          ],
+          "content": "Each panel is one collector, and each turns green when Grafana has seen data from it. Give it a minute or two \u2014 they don't all light up at once, and a couple staying dark usually means that collector was switched off back on step 2 rather than anything being broken."
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "That's a cluster connected: named, collecting, authorised, deployed, and reporting. From here the rest of the app \u2014 nodes, workloads, cost \u2014 is populated with your own data."
     }
   ]
 }

--- a/k8s-connect-first-cluster/content.json
+++ b/k8s-connect-first-cluster/content.json
@@ -1,0 +1,277 @@
+{
+  "id": "k8s-connect-first-cluster",
+  "title": "Connect your first Kubernetes cluster",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "This wizard collects everything the Helm chart needs across four steps, starting here with the cluster's name and platform."
+    },
+    {
+      "type": "section",
+      "id": "stack-and-platform",
+      "title": "Stack and platform",
+      "requirements": [
+        "has-permission:grafana-k8s-app.configuration:read",
+        "on-page:/a/grafana-k8s-app/configuration"
+      ],
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='config-step-nav-1']",
+          "content": "The configuration wizard has four steps: **Stack and platform**, **Monitoring type**, **Backend and token**, and **Deployment**. Each step unlocks only once the one before it is complete, so there's no jumping ahead.",
+          "tooltip": "Progress through the wizard is tracked here, and each step unlocks only once the one before it is complete.",
+          "doIt": false,
+          "requirements": [
+            "exists-reftarget",
+            "on-page:/a/grafana-k8s-app/configuration"
+          ]
+        },
+        {
+          "type": "interactive",
+          "action": "formfill",
+          "reftarget": "[data-testid='cluster-name-input']",
+          "targetvalue": "production-us-east",
+          "formHint": "The name this cluster appears under in Grafana",
+          "content": "The **Cluster name** field is pre-filled with my-cluster. Every metric, log and trace from this cluster is labeled with this name, so set it to match what your team already calls the cluster.",
+          "doIt": true,
+          "requirements": [
+            "exists-reftarget",
+            "on-page:/a/grafana-k8s-app/configuration"
+          ]
+        },
+        {
+          "type": "interactive",
+          "action": "formfill",
+          "reftarget": "[data-testid='namespace-input']",
+          "targetvalue": "monitoring",
+          "formHint": "Lowercase, alphanumeric, dashes allowed inside",
+          "content": "Set the **Namespace** the collector deploys into. It must be lowercase and alphanumeric, with dashes allowed inside the name but not at either end.",
+          "doIt": true,
+          "requirements": [
+            "exists-reftarget",
+            "on-page:/a/grafana-k8s-app/configuration"
+          ]
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='platform-card-kubernetes']",
+          "content": "The **Kubernetes** card is already selected by default. The platform you pick decides which features are available \u2014 GKE Autopilot and EKS on Fargate disable node-level collection \u2014 so confirm Kubernetes to continue.",
+          "doIt": true,
+          "requirements": [
+            "exists-reftarget",
+            "on-page:/a/grafana-k8s-app/configuration"
+          ]
+        },
+        {
+          "type": "interactive",
+          "action": "button",
+          "reftarget": "[data-testid='config-next-button']",
+          "content": "Select **Next** to move on to the monitoring type step.",
+          "doIt": true,
+          "requirements": [
+            "exists-reftarget",
+            "on-page:/a/grafana-k8s-app/configuration"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "The cluster now has a name, a target namespace, and a confirmed platform."
+    },
+    {
+      "type": "markdown",
+      "content": "Step 2 turns your chosen monitoring type into a set of feature toggles you can fine-tune."
+    },
+    {
+      "type": "section",
+      "id": "monitoring-type",
+      "title": "Monitoring type",
+      "requirements": [
+        "has-permission:grafana-k8s-app.configuration:read",
+        "on-page:/a/grafana-k8s-app/configuration"
+      ],
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "button",
+          "reftarget": "[data-testid='monitoring-type-kubernetes-monitoring']",
+          "targetstate": "true",
+          "content": "**Kubernetes Monitoring** is ticked by default and enables cluster metrics, cost, energy, events and pod logs collection. **Application Observability** is the other option, and you can select it in addition.",
+          "doIt": true,
+          "requirements": [
+            "exists-reftarget",
+            "on-page:/a/grafana-k8s-app/configuration"
+          ]
+        },
+        {
+          "type": "interactive",
+          "action": "button",
+          "reftarget": "[data-testid='config-details-toggle']",
+          "content": "Select **Show config details** to reveal the roughly twelve individual collectors bundled into the monitoring type; the button then reads **Hide config details**.",
+          "doIt": true,
+          "requirements": [
+            "exists-reftarget",
+            "on-page:/a/grafana-k8s-app/configuration"
+          ]
+        },
+        {
+          "type": "interactive",
+          "action": "button",
+          "reftarget": "[data-testid='feature-toggle-clusterMetrics']",
+          "targetstate": "true",
+          "content": "**Cluster Metrics** collects node, pod and container resource metrics and is on by default \u2014 confirm it stays enabled.",
+          "doIt": true,
+          "requirements": [
+            "exists-reftarget",
+            "on-page:/a/grafana-k8s-app/configuration"
+          ]
+        },
+        {
+          "type": "interactive",
+          "action": "button",
+          "reftarget": "[data-testid='feature-toggle-clusterEvents']",
+          "targetstate": "true",
+          "content": "**Cluster Events** ships the Kubernetes events that explain why a pod restarted to Loki as logs, and is on by default \u2014 confirm it stays enabled.",
+          "doIt": true,
+          "requirements": [
+            "exists-reftarget",
+            "on-page:/a/grafana-k8s-app/configuration"
+          ]
+        },
+        {
+          "type": "interactive",
+          "action": "button",
+          "reftarget": "[data-testid='config-next-button']",
+          "content": "Select **Next** to move on to the backend and token step \u2014 it requires the backend integration to be installed first.",
+          "doIt": true,
+          "requirements": [
+            "exists-reftarget",
+            "on-page:/a/grafana-k8s-app/configuration"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "Kubernetes Monitoring is selected, with cluster metrics and cluster events collection confirmed on."
+    },
+    {
+      "type": "markdown",
+      "content": "Step 3 installs the Grafana Cloud backend integration and captures the token the collector will use to write data \u2014 step 4 isn't reachable until both are in place."
+    },
+    {
+      "type": "section",
+      "id": "backend-and-token",
+      "title": "Backend and token",
+      "requirements": [
+        "has-permission:grafana-k8s-app.configuration:read",
+        "on-page:/a/grafana-k8s-app/configuration"
+      ],
+      "blocks": [
+        {
+          "type": "callout",
+          "title": "Install the backend integration",
+          "content": "The panel at the top of this step has a button to install the Kubernetes Monitoring backend integration, which comes from a separate plugin. Installation may take a moment, and if the panel is missing entirely, that plugin isn't present on this stack."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='access-policy-token-type']",
+          "content": "Choose how to supply the token: **Create a new token**, **Use an existing token**, or **Use a stored Kubernetes Secret** \u2014 **Create a new token** is selected by default. Pick whichever matches how your org issues credentials.",
+          "doIt": false,
+          "skippable": true,
+          "requirements": [
+            "exists-reftarget",
+            "on-page:/a/grafana-k8s-app/configuration"
+          ]
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='access-policy-existing-token-input']",
+          "content": "This field appears once **Use an existing token** is chosen. Paste in a token with permission to publish metrics, logs and traces \u2014 Grafana does not store it.",
+          "doIt": false,
+          "skippable": true,
+          "requirements": [
+            "exists-reftarget",
+            "on-page:/a/grafana-k8s-app/configuration"
+          ]
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='config-next-button']",
+          "content": "**Next** stays disabled until the backend is installed and a token is supplied \u2014 hover over it to see which of the two is still missing.",
+          "doIt": false,
+          "skippable": true,
+          "requirements": [
+            "exists-reftarget",
+            "on-page:/a/grafana-k8s-app/configuration"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "With the backend installed and a token supplied, the wizard can generate a deployment for you to run."
+    },
+    {
+      "type": "markdown",
+      "content": "The final step turns your choices into a deployment command to run against the cluster, though it's unreachable on a stack that doesn't have the backend integration installed."
+    },
+    {
+      "type": "section",
+      "id": "deployment",
+      "title": "Deployment",
+      "requirements": [
+        "has-permission:grafana-k8s-app.configuration:read",
+        "on-page:/a/grafana-k8s-app/configuration"
+      ],
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='platform-card-helm']",
+          "content": "Pick a deployment method from three cards \u2014 **Helm**, **Terraform**, or **ArgoCD** \u2014 with **Helm** selected by default; this choice changes what's generated below, not what gets collected.",
+          "doIt": false,
+          "skippable": true,
+          "requirements": [
+            "exists-reftarget",
+            "on-page:/a/grafana-k8s-app/configuration"
+          ]
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='clipboard-content']",
+          "content": "The generated `helm upgrade --install` command carries the cluster name, namespace, enabled features and token \u2014 check that kubectl points at the right cluster before you run it.",
+          "doIt": false,
+          "skippable": true,
+          "requirements": [
+            "exists-reftarget",
+            "on-page:/a/grafana-k8s-app/configuration"
+          ]
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='config-back-button']",
+          "content": "Select **Back** to change anything \u2014 the generated command is recomputed from the wizard state, so editing a toggle and returning here updates what you copy.",
+          "doIt": false,
+          "skippable": true,
+          "requirements": [
+            "exists-reftarget",
+            "on-page:/a/grafana-k8s-app/configuration"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "You now have a generated deployment command for this cluster, plus a way back to change any of it."
+    }
+  ]
+}

--- a/k8s-connect-first-cluster/content.json
+++ b/k8s-connect-first-cluster/content.json
@@ -4,7 +4,34 @@
   "blocks": [
     {
       "type": "markdown",
-      "content": "Connecting a cluster takes four steps, and the wizard won't let you skip ahead \u2014 each one unlocks the next. You'll name the cluster, choose what to collect, set up a credential, and walk away with a command to run. Start here."
+      "content": "Connecting a cluster takes four steps, and the wizard won't let you skip ahead \u2014 each one unlocks the next. You'll name the cluster, choose what to collect, set up a credential, and walk away with a command to run."
+    },
+    {
+      "type": "markdown",
+      "content": "First, get to the right screen \u2014 the rest of the guide assumes you're on it."
+    },
+    {
+      "type": "section",
+      "id": "open-configuration",
+      "title": "Open the configuration page",
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "navigate",
+          "reftarget": "/a/grafana-k8s-app/configuration",
+          "verify": "on-page:/a/grafana-k8s-app/configuration",
+          "tooltip": "Takes you to the Kubernetes app's configuration page.",
+          "doIt": true,
+          "content": "Everything below happens on one page: **Kubernetes** in the left-hand nav, then **Configuration**. If you're already there, this will just keep you there."
+        }
+      ],
+      "requirements": [
+        "has-permission:grafana-k8s-app.configuration:read"
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "You're on the Cluster configuration tab, at step one of four."
     },
     {
       "type": "section",
@@ -45,7 +72,7 @@
         },
         {
           "type": "interactive",
-          "action": "button",
+          "action": "highlight",
           "reftarget": "[data-testid='platform-card-kubernetes']",
           "content": "Pick the card that matches where your cluster runs. **Kubernetes** covers EKS on EC2, GKE and anything self-managed, and it's already selected. Worth being accurate here: managed platforms like GKE Autopilot and EKS on Fargate don't give anyone access to the underlying nodes, so choosing one of those quietly removes a few collectors on the next step.",
           "doIt": true,
@@ -57,7 +84,7 @@
         },
         {
           "type": "interactive",
-          "action": "button",
+          "action": "highlight",
           "reftarget": "[data-testid='config-next-button']",
           "content": "That's the cluster identified. On to what you want to collect from it.",
           "doIt": true,
@@ -88,7 +115,7 @@
       "blocks": [
         {
           "type": "interactive",
-          "action": "button",
+          "action": "highlight",
           "reftarget": "[data-testid='monitoring-type-kubernetes-monitoring']",
           "targetstate": "true",
           "content": "**Kubernetes Monitoring** is what you want for a first cluster. It brings in the metrics, events and pod logs behind every dashboard in this app. Leave it ticked.",
@@ -101,7 +128,7 @@
         },
         {
           "type": "interactive",
-          "action": "button",
+          "action": "highlight",
           "reftarget": "[data-testid='config-details-toggle']",
           "content": "Behind that single tick sit a dozen or so individual collectors. You don't have to look \u2014 the defaults are sensible \u2014 but it's worth seeing once, because this is the panel you'll come back to when someone asks why the bill went up.",
           "doIt": true,
@@ -113,7 +140,7 @@
         },
         {
           "type": "interactive",
-          "action": "button",
+          "action": "highlight",
           "reftarget": "[data-testid='feature-toggle-clusterMetrics']",
           "targetstate": "true",
           "content": "**Cluster Metrics** is the CPU, memory and storage of every node and pod. It's the backbone of the whole app, and it's already on \u2014 this is just so you know where it lives.",
@@ -126,7 +153,7 @@
         },
         {
           "type": "interactive",
-          "action": "button",
+          "action": "highlight",
           "reftarget": "[data-testid='feature-toggle-clusterEvents']",
           "targetstate": "true",
           "content": "**Cluster Events** is the one people forget to check and then miss. It captures Kubernetes' own account of what happened \u2014 why a pod was evicted, why a deployment stalled \u2014 which is usually the answer you're hunting for at 3am. Also already on.",
@@ -139,7 +166,7 @@
         },
         {
           "type": "interactive",
-          "action": "button",
+          "action": "highlight",
           "reftarget": "[data-testid='config-next-button']",
           "content": "Everything else can wait. Each extra collector costs something, and you can turn them on later once you know what you're missing.",
           "doIt": true,
@@ -297,7 +324,7 @@
       "blocks": [
         {
           "type": "interactive",
-          "action": "button",
+          "action": "highlight",
           "reftarget": "[data-testid='data-testid Tab Metrics status']",
           "tooltip": "Where you find out whether it worked.",
           "doIt": true,

--- a/k8s-connect-first-cluster/content.json
+++ b/k8s-connect-first-cluster/content.json
@@ -4,192 +4,44 @@
   "blocks": [
     {
       "type": "markdown",
-      "content": "Connecting a cluster takes four steps, and the wizard won't let you skip ahead \u2014 each one unlocks the next. You'll name the cluster, choose what to collect, set up a credential, and walk away with a command to run."
+      "content": "Connecting a cluster runs through five steps, and the wizard won't let you skip ahead. You'll install the backend, create a credential, pick how much of Alloy to run, choose what to collect, and leave with a command to run against your cluster."
     },
     {
       "type": "markdown",
-      "content": "First, get to the right screen \u2014 the rest of the guide assumes you're on it."
+      "content": "First, get to the right screen."
     },
     {
       "type": "section",
       "id": "open-configuration",
       "title": "Open the configuration page",
+      "requirements": [
+        "has-permission:grafana-k8s-app.configuration:read"
+      ],
       "blocks": [
         {
           "type": "interactive",
           "action": "navigate",
           "reftarget": "/a/grafana-k8s-app/configuration",
-          "verify": "on-page:/a/grafana-k8s-app/configuration",
           "tooltip": "Takes you to the Kubernetes app's configuration page.",
           "doIt": true,
-          "content": "Everything below happens on one page: **Kubernetes** in the left-hand nav, then **Configuration**. If you're already there, this will just keep you there."
-        }
-      ],
-      "requirements": [
-        "has-permission:grafana-k8s-app.configuration:read"
-      ]
-    },
-    {
-      "type": "markdown",
-      "content": "You're on the Cluster configuration tab, at step one of four."
-    },
-    {
-      "type": "section",
-      "id": "stack-and-platform",
-      "title": "Stack and platform",
-      "requirements": [
-        "has-permission:grafana-k8s-app.configuration:read",
-        "on-page:/a/grafana-k8s-app/configuration"
-      ],
-      "blocks": [
-        {
-          "type": "interactive",
-          "action": "formfill",
-          "reftarget": "[data-testid='cluster-name-input']",
-          "targetvalue": "production-eu-west",
-          "formHint": "An example \u2014 replace it with the name your team already uses",
-          "content": "Start with a name. Whatever you put here is stamped on every metric, log and trace this cluster produces, so use the name your team already says out loud \u2014 `production-eu-west` below is only an example. It's worth getting right now: changing it later means everything you've already collected is filed under the old name.",
-          "doIt": false,
-          "requirements": [
-            "exists-reftarget",
-            "on-page:/a/grafana-k8s-app/configuration"
-          ],
-          "tooltip": "Use the name your team already calls this cluster."
-        },
-        {
-          "type": "interactive",
-          "action": "formfill",
-          "reftarget": "[data-testid='namespace-input']",
-          "targetvalue": "monitoring",
-          "formHint": "Lowercase, alphanumeric, dashes allowed inside",
-          "content": "This is where the collector itself runs, not what it watches \u2014 it sees the whole cluster either way. `monitoring` is the default and there's no reason to change it unless your team has a convention of its own. Lowercase and alphanumeric, dashes allowed in the middle.",
-          "doIt": true,
-          "requirements": [
-            "exists-reftarget",
-            "on-page:/a/grafana-k8s-app/configuration"
-          ],
-          "tooltip": "Where the collector runs. `monitoring` is fine."
-        },
-        {
-          "type": "interactive",
-          "action": "highlight",
-          "reftarget": "[data-testid='platform-card-kubernetes']",
-          "content": "Pick the card that matches where your cluster runs. **Kubernetes** covers EKS on EC2, GKE and anything self-managed, and it's already selected. Worth being accurate here: managed platforms like GKE Autopilot and EKS on Fargate don't give anyone access to the underlying nodes, so choosing one of those quietly removes a few collectors on the next step.",
-          "doIt": true,
-          "requirements": [
-            "exists-reftarget",
-            "on-page:/a/grafana-k8s-app/configuration"
-          ],
-          "tooltip": "Pick where your cluster actually runs."
-        },
-        {
-          "type": "interactive",
-          "action": "highlight",
-          "reftarget": "[data-testid='config-next-button']",
-          "content": "That's the cluster identified. On to what you want to collect from it.",
-          "doIt": true,
-          "requirements": [
-            "exists-reftarget",
-            "on-page:/a/grafana-k8s-app/configuration"
-          ],
-          "tooltip": "That's the cluster identified."
+          "requirements": [],
+          "content": "Everything up to the last step happens on one page: **Kubernetes** in the left-hand nav, then **Configuration**. If you're already there this keeps you where you are.",
+          "verify": "on-page:/a/grafana-k8s-app/configuration"
         }
       ]
     },
     {
       "type": "markdown",
-      "content": "Your cluster has a name, somewhere to run the collector, and a platform."
+      "content": "You're on the Cluster configuration tab, at step one of five."
     },
     {
       "type": "markdown",
-      "content": "Next you decide how much to collect. This is the step that shapes your bill as well as your dashboards, so it's worth a minute rather than a click."
+      "content": "Step one does two things: it installs what Grafana needs to make sense of your data, and it asks where your cluster runs."
     },
     {
       "type": "section",
-      "id": "monitoring-type",
-      "title": "Monitoring type",
-      "requirements": [
-        "has-permission:grafana-k8s-app.configuration:read",
-        "on-page:/a/grafana-k8s-app/configuration"
-      ],
-      "blocks": [
-        {
-          "type": "interactive",
-          "action": "highlight",
-          "reftarget": "[data-testid='monitoring-type-kubernetes-monitoring']",
-          "targetstate": "true",
-          "content": "**Kubernetes Monitoring** is what you want for a first cluster. It brings in the metrics, events and pod logs behind every dashboard in this app. Leave it ticked.",
-          "doIt": true,
-          "requirements": [
-            "exists-reftarget",
-            "on-page:/a/grafana-k8s-app/configuration"
-          ],
-          "tooltip": "Leave this ticked \u2014 it's the core of the app."
-        },
-        {
-          "type": "interactive",
-          "action": "highlight",
-          "reftarget": "[data-testid='config-details-toggle']",
-          "content": "Behind that single tick sit a dozen or so individual collectors. You don't have to look \u2014 the defaults are sensible \u2014 but it's worth seeing once, because this is the panel you'll come back to when someone asks why the bill went up.",
-          "doIt": true,
-          "requirements": [
-            "exists-reftarget",
-            "on-page:/a/grafana-k8s-app/configuration"
-          ],
-          "tooltip": "Open this once to see what you're collecting."
-        },
-        {
-          "type": "interactive",
-          "action": "highlight",
-          "reftarget": "[data-testid='feature-toggle-clusterMetrics']",
-          "targetstate": "true",
-          "content": "**Cluster Metrics** is the CPU, memory and storage of every node and pod. It's the backbone of the whole app, and it's already on \u2014 this is just so you know where it lives.",
-          "doIt": true,
-          "requirements": [
-            "exists-reftarget",
-            "on-page:/a/grafana-k8s-app/configuration"
-          ],
-          "tooltip": "CPU, memory and storage per node and pod."
-        },
-        {
-          "type": "interactive",
-          "action": "highlight",
-          "reftarget": "[data-testid='feature-toggle-clusterEvents']",
-          "targetstate": "true",
-          "content": "**Cluster Events** is the one people forget to check and then miss. It captures Kubernetes' own account of what happened \u2014 why a pod was evicted, why a deployment stalled \u2014 which is usually the answer you're hunting for at 3am. Also already on.",
-          "doIt": true,
-          "requirements": [
-            "exists-reftarget",
-            "on-page:/a/grafana-k8s-app/configuration"
-          ],
-          "tooltip": "Kubernetes' own account of what went wrong."
-        },
-        {
-          "type": "interactive",
-          "action": "highlight",
-          "reftarget": "[data-testid='config-next-button']",
-          "content": "Everything else can wait. Each extra collector costs something, and you can turn them on later once you know what you're missing.",
-          "doIt": true,
-          "requirements": [
-            "exists-reftarget",
-            "on-page:/a/grafana-k8s-app/configuration"
-          ],
-          "tooltip": "Defaults are sensible \u2014 move on."
-        }
-      ]
-    },
-    {
-      "type": "markdown",
-      "content": "You're collecting the essentials: resource usage, cluster events and pod logs."
-    },
-    {
-      "type": "markdown",
-      "content": "Two things have to be in place before Grafana can do anything with your cluster's data: the rules that turn raw metrics into the dashboards and alerts you'll actually look at, and a credential that lets the collector send data in. You'll set up both here."
-    },
-    {
-      "type": "section",
-      "id": "backend-and-token",
-      "title": "Backend and token",
+      "id": "backend-and-distribution",
+      "title": "Backend and distribution",
       "requirements": [
         "has-permission:grafana-k8s-app.configuration:read",
         "on-page:/a/grafana-k8s-app/configuration"
@@ -205,63 +57,216 @@
             "exists-reftarget",
             "on-page:/a/grafana-k8s-app/configuration"
           ],
-          "content": "Start by installing the backend. This adds the alerting and recording rules that every Kubernetes dashboard in this app is built on \u2014 without them the dashboards load but stay empty. It takes a few seconds, and you can't move on until it finishes."
+          "content": "Start by installing the backend. This adds the alerting and recording rules that every Kubernetes dashboard in this app is built on \u2014 without them the dashboards load but stay empty. It takes a few seconds, and **Next** stays disabled until it finishes."
         },
         {
           "type": "interactive",
-          "action": "formfill",
-          "reftarget": "[data-testid='generate-token-name-input']",
-          "targetvalue": "k8s-monitoring-alloy",
-          "formHint": "A name you'll recognise later",
+          "action": "highlight",
+          "reftarget": "[data-testid='platform-card-kubernetes']",
+          "tooltip": "Pick where your cluster actually runs.",
           "doIt": true,
           "requirements": [
             "exists-reftarget",
             "on-page:/a/grafana-k8s-app/configuration"
           ],
-          "content": "Now the credential. Give it a name you'll recognise months from now, when you're looking at a list of tokens and trying to work out which one you can safely revoke. Something that says where it's used beats something that says when you made it.",
-          "tooltip": "Name it for where it's used, not when you made it."
-        },
-        {
-          "type": "interactive",
-          "action": "highlight",
-          "reftarget": "[data-testid='generate-token-scopes-field']",
-          "doIt": false,
-          "requirements": [
-            "exists-reftarget",
-            "on-page:/a/grafana-k8s-app/configuration"
-          ],
-          "content": "You don't need to touch the permissions. These two let the collector send your cluster's data and read back what it sent, and nothing else \u2014 Grafana picks them for you so you can't accidentally hand out more access than the job needs.",
-          "tooltip": "Nothing to change \u2014 Grafana sets these for you."
-        },
-        {
-          "type": "interactive",
-          "action": "highlight",
-          "reftarget": "[data-testid='generate-token-submit-button']",
-          "doIt": false,
-          "requirements": [
-            "exists-reftarget",
-            "on-page:/a/grafana-k8s-app/configuration"
-          ],
-          "content": "Go ahead and select **Create token** yourself. This one's left to you on purpose: it creates a real credential on your Grafana Cloud account, and that's your call to make, not this guide's.\n\n**Copy the token as soon as it appears.** You won't be shown it a second time, and the next step needs it.",
-          "tooltip": "Your call to make. Copy the token when it appears."
+          "content": "Then tell it where your cluster runs. **Kubernetes** covers EKS on EC2, GKE and anything self-managed. Be accurate here: managed platforms like GKE Autopilot and EKS on Fargate give nobody access to the underlying nodes, so picking one of those quietly removes a few collectors later on."
         },
         {
           "type": "interactive",
           "action": "highlight",
           "reftarget": "[data-testid='config-next-button']",
-          "doIt": false,
+          "tooltip": "That's the groundwork done.",
+          "doIt": true,
           "requirements": [
             "exists-reftarget",
             "on-page:/a/grafana-k8s-app/configuration"
           ],
-          "content": "**Next** wakes up once the backend is installed and your token exists. If it's still greyed out, hover over it \u2014 it'll tell you which of the two is holding things up.",
-          "tooltip": "Waits for the backend and your token."
+          "content": "Backend installed and platform chosen. Next up is the credential."
         }
       ]
     },
     {
       "type": "markdown",
-      "content": "That's the fiddly part behind you. Grafana can make sense of the data now, and the collector has permission to send it."
+      "content": "Grafana can interpret your data now, and knows what kind of cluster it's coming from."
+    },
+    {
+      "type": "markdown",
+      "content": "Alloy needs permission to send data to Grafana Cloud. That's an access policy token, and you create it here."
+    },
+    {
+      "type": "section",
+      "id": "access-token",
+      "title": "Access token",
+      "requirements": [
+        "has-permission:grafana-k8s-app.configuration:read",
+        "on-page:/a/grafana-k8s-app/configuration"
+      ],
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "formfill",
+          "reftarget": "[data-testid='generate-token-name-input']",
+          "tooltip": "Name it for where it's used, not when you made it.",
+          "doIt": true,
+          "requirements": [
+            "exists-reftarget",
+            "on-page:/a/grafana-k8s-app/configuration"
+          ],
+          "content": "Give the token a name you'll recognise months from now, when you're looking at a list of tokens and working out which one is safe to revoke. Something that says where it's used beats something that says when you made it.",
+          "targetvalue": "k8s-monitoring-alloy",
+          "formHint": "A name you'll recognise later"
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='generate-token-scopes-field']",
+          "tooltip": "Nothing to change \u2014 Grafana sets these for you.",
+          "doIt": false,
+          "requirements": [
+            "exists-reftarget",
+            "on-page:/a/grafana-k8s-app/configuration"
+          ],
+          "content": "You don't need to touch the permissions. These let the collector send your cluster's data and read back what it sent, and nothing else."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='generate-token-submit-button']",
+          "tooltip": "Your call. Copy the token when it appears.",
+          "doIt": false,
+          "requirements": [
+            "exists-reftarget",
+            "on-page:/a/grafana-k8s-app/configuration"
+          ],
+          "content": "Select **Create token** yourself. This one's left to you on purpose: it creates a real credential on your Grafana Cloud account, and that's your decision to make.\n\n**Copy it as soon as it appears.** You won't be shown it again, and the command at the end needs it."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='config-next-button']",
+          "tooltip": "Enables once the token exists.",
+          "doIt": true,
+          "requirements": [
+            "exists-reftarget",
+            "on-page:/a/grafana-k8s-app/configuration"
+          ],
+          "content": "With the token in place, **Next** wakes up."
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "Alloy has permission to write to your stack."
+    },
+    {
+      "type": "markdown",
+      "content": "Now the size of the thing. This is about how much Alloy you run, not what it collects."
+    },
+    {
+      "type": "section",
+      "id": "choose-setup",
+      "title": "Choose setup",
+      "requirements": [
+        "has-permission:grafana-k8s-app.configuration:read",
+        "on-page:/a/grafana-k8s-app/configuration"
+      ],
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='install-alloy-unified-helm-choose-setup-deployment-standard']",
+          "tooltip": "Standard suits most first clusters.",
+          "doIt": true,
+          "requirements": [
+            "exists-reftarget",
+            "on-page:/a/grafana-k8s-app/configuration"
+          ],
+          "content": "**Standard** is the right starting point for almost any first cluster. **Lightweight** trims resource use for small or edge clusters; **Scalable** splits collection across several Alloy instances for large ones. You can change this later by re-running the chart, so it isn't a decision to agonise over."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='install-alloy-unified-helm-choose-setup-learn-scalable-trigger']",
+          "tooltip": "Expands what a tier actually changes.",
+          "doIt": false,
+          "requirements": [
+            "exists-reftarget",
+            "on-page:/a/grafana-k8s-app/configuration"
+          ],
+          "content": "Each card can explain itself if you want the detail behind the choice \u2014 worth a look if your cluster is unusually large or unusually constrained."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='config-next-button']",
+          "tooltip": "On to what gets collected.",
+          "doIt": true,
+          "requirements": [
+            "exists-reftarget",
+            "on-page:/a/grafana-k8s-app/configuration"
+          ],
+          "content": "That's the shape of the deployment settled."
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "You've chosen how much collector to run."
+    },
+    {
+      "type": "markdown",
+      "content": "This step is the one that shapes your bill as well as your dashboards, so it's worth a minute rather than a click."
+    },
+    {
+      "type": "section",
+      "id": "monitoring",
+      "title": "Monitoring",
+      "requirements": [
+        "has-permission:grafana-k8s-app.configuration:read",
+        "on-page:/a/grafana-k8s-app/configuration"
+      ],
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='enable-k8s-monitoring-card']",
+          "tooltip": "The metrics, events and logs behind every dashboard.",
+          "doIt": false,
+          "requirements": [
+            "exists-reftarget",
+            "on-page:/a/grafana-k8s-app/configuration"
+          ],
+          "content": "**Kubernetes monitoring** is the core of the app: node and pod resource usage, Kubernetes' own events, and pod logs. It's on and required here, since this page exists to configure exactly that. The menu on the card is where you'd tune individual collectors once you know what you're missing."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='auto-discover-services-card']",
+          "tooltip": "Optional \u2014 leave it off for a first cluster.",
+          "doIt": false,
+          "requirements": [
+            "exists-reftarget",
+            "on-page:/a/grafana-k8s-app/configuration"
+          ],
+          "content": "**Auto-discover services** picks up anything in the cluster already exposing Prometheus metrics or OpenTelemetry annotations. Useful later; leave it off for a first cluster so you can see what the baseline costs before adding to it."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='config-next-button']",
+          "tooltip": "Last step generates the command.",
+          "doIt": true,
+          "requirements": [
+            "exists-reftarget",
+            "on-page:/a/grafana-k8s-app/configuration"
+          ],
+          "content": "Everything else can wait \u2014 each extra collector costs something, and you can turn them on once you know what you're missing."
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "You're collecting the essentials and nothing you'll be surprised by."
     },
     {
       "type": "markdown",
@@ -278,48 +283,65 @@
       "blocks": [
         {
           "type": "interactive",
-          "action": "highlight",
-          "reftarget": "[data-testid='platform-card-helm']",
-          "content": "**Helm** is the right answer if you don't already have an opinion \u2014 it's selected for you. The other two are here for teams who deploy everything through Terraform or ArgoCD and want this to match. Your choice changes the shape of what's generated below, not what ends up collected.",
+          "action": "formfill",
+          "reftarget": "[data-testid='install-alloy-unified-helm-cluster-name-input']",
+          "tooltip": "Use the name your team already calls this cluster.",
           "doIt": false,
-          "skippable": true,
           "requirements": [
             "exists-reftarget",
             "on-page:/a/grafana-k8s-app/configuration"
           ],
-          "tooltip": "Helm unless your team deploys another way."
+          "content": "Name the cluster. Whatever goes here is stamped on every metric, log and trace it produces, so use the name your team already says out loud \u2014 `production-eu-west` is only an example. Worth getting right now: change it later and everything you've already collected stays filed under the old name.",
+          "targetvalue": "production-eu-west",
+          "formHint": "An example \u2014 replace it with your own"
+        },
+        {
+          "type": "interactive",
+          "action": "formfill",
+          "reftarget": "[data-testid='install-alloy-unified-helm-namespace-input']",
+          "tooltip": "Where the collector runs. `monitoring` is fine.",
+          "doIt": true,
+          "requirements": [
+            "exists-reftarget",
+            "on-page:/a/grafana-k8s-app/configuration"
+          ],
+          "content": "This is where Alloy itself gets deployed, not what it watches \u2014 it sees the whole cluster either way. `monitoring` is a fine choice unless your team has a convention of its own.",
+          "targetvalue": "monitoring",
+          "formHint": "Lowercase, alphanumeric, dashes inside"
         },
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "[data-testid='clipboard-content']",
-          "content": "Here's your command, with the cluster name, namespace, collectors and token already filled in. One thing to check before you paste it anywhere: make sure `kubectl` is pointed at the cluster you think it is. It's the mistake everyone makes once.",
-          "doIt": false,
-          "skippable": true,
+          "reftarget": "[data-testid='install-alloy-unified-helm-copy-command']",
+          "tooltip": "Copies the command with your choices baked in.",
+          "doIt": true,
           "requirements": [
             "exists-reftarget",
             "on-page:/a/grafana-k8s-app/configuration"
           ],
-          "tooltip": "Check kubectl points at the right cluster first."
+          "content": "Copy the command. It carries the cluster name, namespace, tier, collectors and token already filled in. One thing to check before you paste it: make sure `kubectl` is pointed at the cluster you think it is. It's the mistake everyone makes once."
         },
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "[data-testid='config-back-button']",
-          "content": "Changed your mind about something? Go **Back**. The command is rebuilt from your choices every time, so flip a toggle, return here, and you'll get an updated one to copy.",
+          "reftarget": "[data-testid='install-alloy-unified-helm-test-connection']",
+          "tooltip": "Checks Grafana can see the cluster.",
           "doIt": false,
-          "skippable": true,
           "requirements": [
             "exists-reftarget",
             "on-page:/a/grafana-k8s-app/configuration"
           ],
-          "tooltip": "Change anything and the command rebuilds itself."
+          "content": "Once the command has run, **Test connection** checks whether anything is actually arriving. Give the pods a minute to start before you press it \u2014 an immediate failure usually just means Alloy hasn't finished coming up."
         }
       ]
     },
     {
       "type": "markdown",
-      "content": "Run that command and the cluster starts reporting. The last thing worth knowing is where to watch for it."
+      "content": "The command is on your clipboard and the wizard can tell you when it lands."
+    },
+    {
+      "type": "markdown",
+      "content": "Run it, then watch for the data."
     },
     {
       "type": "section",
@@ -339,7 +361,7 @@
             "exists-reftarget",
             "on-page:/a/grafana-k8s-app/configuration"
           ],
-          "content": "Once you've run the command, come back here and open **Metrics status**. This is the page that answers the only question that matters in the next five minutes: is anything actually arriving?"
+          "content": "Open **Metrics status**. This is the page that answers the only question that matters in the next five minutes: is anything actually arriving?"
         },
         {
           "type": "interactive",
@@ -351,13 +373,13 @@
             "exists-reftarget",
             "on-page:/a/grafana-k8s-app/configuration"
           ],
-          "content": "Each panel is one collector, and each turns green when Grafana has seen data from it. Give it a minute or two \u2014 they don't all light up at once, and a couple staying dark usually means that collector was switched off back on step 2 rather than anything being broken."
+          "content": "Each panel is one collector, and each turns green when Grafana has seen data from it. Give it a minute or two \u2014 they don't all light up at once, and a couple staying dark usually means that collector wasn't part of what you enabled rather than anything being broken."
         }
       ]
     },
     {
       "type": "markdown",
-      "content": "That's a cluster connected: named, collecting, authorised, deployed, and reporting. From here the rest of the app \u2014 nodes, workloads, cost \u2014 is populated with your own data."
+      "content": "That's a cluster connected: installed, authorised, sized, collecting and reporting. From here the rest of the app \u2014 nodes, workloads, cost \u2014 is populated with your own data."
     }
   ]
 }

--- a/k8s-connect-first-cluster/content.json
+++ b/k8s-connect-first-cluster/content.json
@@ -4,7 +4,7 @@
   "blocks": [
     {
       "type": "markdown",
-      "content": "This wizard collects everything the Helm chart needs across four steps, starting here with the cluster's name and platform."
+      "content": "This wizard collects everything the Helm chart needs across four steps \u2014 **Stack and platform**, **Monitoring type**, **Backend and token** and **Deployment** \u2014 and each unlocks only once the one before it is complete. You start here, with the cluster's name and platform."
     },
     {
       "type": "section",
@@ -17,24 +17,12 @@
       "blocks": [
         {
           "type": "interactive",
-          "action": "highlight",
-          "reftarget": "[data-testid='config-step-nav-1']",
-          "content": "The configuration wizard has four steps: **Stack and platform**, **Monitoring type**, **Backend and token**, and **Deployment**. Each step unlocks only once the one before it is complete, so there's no jumping ahead.",
-          "tooltip": "Progress through the wizard is tracked here, and each step unlocks only once the one before it is complete.",
-          "doIt": false,
-          "requirements": [
-            "exists-reftarget",
-            "on-page:/a/grafana-k8s-app/configuration"
-          ]
-        },
-        {
-          "type": "interactive",
           "action": "formfill",
           "reftarget": "[data-testid='cluster-name-input']",
-          "targetvalue": "production-us-east",
-          "formHint": "The name this cluster appears under in Grafana",
-          "content": "The **Cluster name** field is pre-filled with my-cluster. Every metric, log and trace from this cluster is labeled with this name, so set it to match what your team already calls the cluster.",
-          "doIt": true,
+          "targetvalue": "production-eu-west",
+          "formHint": "An example \u2014 replace it with the name your team already uses",
+          "content": "The **Cluster name** field starts as `my-cluster`. Every metric, log and trace from this cluster is labelled with it, so set it to whatever your team already calls the cluster \u2014 `production-eu-west` here is only an example. Nothing else in the wizard depends on the value, but changing it later means relabelling everything you have already collected.",
+          "doIt": false,
           "requirements": [
             "exists-reftarget",
             "on-page:/a/grafana-k8s-app/configuration"
@@ -46,7 +34,7 @@
           "reftarget": "[data-testid='namespace-input']",
           "targetvalue": "monitoring",
           "formHint": "Lowercase, alphanumeric, dashes allowed inside",
-          "content": "Set the **Namespace** the collector deploys into. It must be lowercase and alphanumeric, with dashes allowed inside the name but not at either end.",
+          "content": "The **Namespace** is where the collector itself is deployed, not what it watches \u2014 it collects from the whole cluster either way. `monitoring` is the default and is a fine choice. It must be lowercase and alphanumeric, with dashes allowed inside the name but not at either end.",
           "doIt": true,
           "requirements": [
             "exists-reftarget",
@@ -55,9 +43,9 @@
         },
         {
           "type": "interactive",
-          "action": "highlight",
+          "action": "button",
           "reftarget": "[data-testid='platform-card-kubernetes']",
-          "content": "The **Kubernetes** card is already selected by default. The platform you pick decides which features are available \u2014 GKE Autopilot and EKS on Fargate disable node-level collection \u2014 so confirm Kubernetes to continue.",
+          "content": "Pick the card matching your cluster. **Kubernetes** covers EKS on EC2, GKE and self-managed, and is selected by default. The choice is not cosmetic: GKE Autopilot and EKS on Fargate have no node-level access, so picking those disables energy metrics and node logs on the next step.",
           "doIt": true,
           "requirements": [
             "exists-reftarget",
@@ -174,43 +162,64 @@
         {
           "type": "callout",
           "title": "Install the backend integration",
-          "content": "The panel at the top of this step has a button to install the Kubernetes Monitoring backend integration, which comes from a separate plugin. Installation may take a moment, and if the panel is missing entirely, that plugin isn't present on this stack."
+          "content": "**Backend Installation** at the top of this step installs the alert and recording rules that the Kubernetes Monitoring dashboards query. The panel is contributed by a different plugin \u2014 `grafana-easystart-app` \u2014 through an extension point, so on a stack where that plugin is absent the panel reads *Failed to load integration management extension* and **Next** never enables. That is a missing plugin, not a mistake you made."
         },
         {
           "type": "interactive",
           "action": "highlight",
           "reftarget": "[data-testid='access-policy-token-type']",
-          "content": "Choose how to supply the token: **Create a new token**, **Use an existing token**, or **Use a stored Kubernetes Secret** \u2014 **Create a new token** is selected by default. Pick whichever matches how your org issues credentials.",
           "doIt": false,
-          "skippable": true,
           "requirements": [
             "exists-reftarget",
             "on-page:/a/grafana-k8s-app/configuration"
-          ]
+          ],
+          "content": "Alloy needs a Grafana Cloud access policy token to write data. Three ways to supply one: **Create a new token**, **Use an existing token**, or **Use a stored Kubernetes Secret**. **Create a new token** is selected by default and is the path below; the stored-secret option is the one to use if your org keeps credentials in the cluster rather than pasting them into a browser."
+        },
+        {
+          "type": "interactive",
+          "action": "formfill",
+          "reftarget": "[data-testid='generate-token-name-input']",
+          "targetvalue": "k8s-monitoring-alloy",
+          "formHint": "The name this token appears under in grafana.com",
+          "doIt": true,
+          "requirements": [
+            "exists-reftarget",
+            "on-page:/a/grafana-k8s-app/configuration"
+          ],
+          "content": "Name the token. This is the name you will look for in grafana.com when you need to audit or revoke it, so make it say where the token is used rather than when it was made."
         },
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "[data-testid='access-policy-existing-token-input']",
-          "content": "This field appears once **Use an existing token** is chosen. Paste in a token with permission to publish metrics, logs and traces \u2014 Grafana does not store it.",
+          "reftarget": "[data-testid='generate-token-scopes-field']",
           "doIt": false,
-          "skippable": true,
           "requirements": [
             "exists-reftarget",
             "on-page:/a/grafana-k8s-app/configuration"
-          ]
+          ],
+          "content": "The scopes are fixed: `metrics:read` and `set:alloy-data-write`. That is the minimum Alloy needs to ship data and read back what it wrote \u2014 you cannot widen them here, which is deliberate."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='generate-token-submit-button']",
+          "doIt": false,
+          "requirements": [
+            "exists-reftarget",
+            "on-page:/a/grafana-k8s-app/configuration"
+          ],
+          "content": "Select **Create token** yourself. This guide will not press it: it mints a real credential against your Grafana Cloud account, and that is not something a tutorial should do on your behalf. The token is shown once \u2014 copy it before leaving the page."
         },
         {
           "type": "interactive",
           "action": "highlight",
           "reftarget": "[data-testid='config-next-button']",
-          "content": "**Next** stays disabled until the backend is installed and a token is supplied \u2014 hover over it to see which of the two is still missing.",
           "doIt": false,
-          "skippable": true,
           "requirements": [
             "exists-reftarget",
             "on-page:/a/grafana-k8s-app/configuration"
-          ]
+          ],
+          "content": "**Next** needs both the backend installed and a token in place. Hovering it says which of the two is still missing."
         }
       ]
     },

--- a/k8s-connect-first-cluster/content.json
+++ b/k8s-connect-first-cluster/content.json
@@ -198,7 +198,7 @@
         {
           "type": "callout",
           "title": "Install the backend first",
-          "content": "The panel at the top of this step installs the alerting and recording rules that the Kubernetes dashboards are built on. Skip it and the dashboards will load but stay empty. Select **Install** and give it a moment to finish.\n\nIf you see an error here instead of an install button, this Grafana stack is missing the Integrations plugin. That's something whoever administers the stack needs to sort out \u2014 it isn't anything you've done."
+          "content": "The panel at the top of this step installs the alerting and recording rules that every Kubernetes dashboard in this app is built on. Skip it and the dashboards will load but stay empty. Select **Install** and give it a moment to finish before moving on."
         },
         {
           "type": "interactive",
@@ -258,7 +258,7 @@
     },
     {
       "type": "markdown",
-      "content": "Last step. Everything you've chosen becomes a command you run against the cluster.\n\nYou'll only reach this screen once the backend is installed, so if you're stuck on step 3 the rest of this is a preview of where you're heading."
+      "content": "Last step. Everything you've chosen becomes a single command to run against the cluster."
     },
     {
       "type": "section",

--- a/k8s-connect-first-cluster/content.json
+++ b/k8s-connect-first-cluster/content.json
@@ -196,9 +196,16 @@
       ],
       "blocks": [
         {
-          "type": "callout",
-          "title": "Install the backend first",
-          "content": "The panel at the top of this step installs the alerting and recording rules that every Kubernetes dashboard in this app is built on. Skip it and the dashboards will load but stay empty. Select **Install** and give it a moment to finish before moving on."
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "div[data-testid='install-alloy-unified-helm-prepare-deploy-panel'] button",
+          "tooltip": "Installs the rules the dashboards are built on.",
+          "doIt": true,
+          "requirements": [
+            "exists-reftarget",
+            "on-page:/a/grafana-k8s-app/configuration"
+          ],
+          "content": "Start by installing the backend. This adds the alerting and recording rules that every Kubernetes dashboard in this app is built on \u2014 without them the dashboards load but stay empty. It takes a few seconds, and you can't move on until it finishes."
         },
         {
           "type": "interactive",

--- a/k8s-connect-first-cluster/content.json
+++ b/k8s-connect-first-cluster/content.json
@@ -51,13 +51,14 @@
           "type": "interactive",
           "action": "highlight",
           "reftarget": "div[data-testid='install-alloy-unified-helm-prepare-deploy-panel'] button",
-          "tooltip": "Installs the rules the dashboards are built on.",
-          "doIt": true,
+          "tooltip": "Already installed? Skip this step.",
+          "doIt": false,
           "requirements": [
             "exists-reftarget",
             "on-page:/a/grafana-k8s-app/configuration"
           ],
-          "content": "Start by installing the backend. This adds the alerting and recording rules that every Kubernetes dashboard in this app is built on \u2014 without them the dashboards load but stay empty. It takes a few seconds, and **Next** stays disabled until it finishes."
+          "content": "Start by installing the backend \u2014 the alerting and recording rules that every Kubernetes dashboard in this app is built on. Without them the dashboards load but stay empty, and **Next** stays disabled until it finishes.\n\n**If the panel already says the rules are installed, skip this step.** The guide won't press the button for you here: once the backend is in place that same spot becomes **Uninstall**, and clicking it blind would tear out the rules you already have.",
+          "skippable": true
         },
         {
           "type": "interactive",
@@ -112,9 +113,10 @@
             "exists-reftarget",
             "on-page:/a/grafana-k8s-app/configuration"
           ],
-          "content": "Give the token a name you'll recognise months from now, when you're looking at a list of tokens and working out which one is safe to revoke. Something that says where it's used beats something that says when you made it.",
+          "content": "Give the token a name you'll recognise months from now, when you're looking at a list of tokens and working out which one is safe to revoke. Something that says where it's used beats something that says when you made it.\n\nAlready have a token you'd rather use? Switch to **Use an existing token** and skip the next three steps.",
           "targetvalue": "k8s-monitoring-alloy",
-          "formHint": "A name you'll recognise later"
+          "formHint": "A name you'll recognise later",
+          "skippable": true
         },
         {
           "type": "interactive",
@@ -126,7 +128,8 @@
             "exists-reftarget",
             "on-page:/a/grafana-k8s-app/configuration"
           ],
-          "content": "You don't need to touch the permissions. These let the collector send your cluster's data and read back what it sent, and nothing else."
+          "content": "You don't need to touch the permissions. These let the collector send your cluster's data and read back what it sent, and nothing else.",
+          "skippable": true
         },
         {
           "type": "interactive",
@@ -138,7 +141,8 @@
             "exists-reftarget",
             "on-page:/a/grafana-k8s-app/configuration"
           ],
-          "content": "Select **Create token** yourself. This one's left to you on purpose: it creates a real credential on your Grafana Cloud account, and that's your decision to make.\n\n**Copy it as soon as it appears.** You won't be shown it again, and the command at the end needs it."
+          "content": "Select **Create token** yourself. This one's left to you on purpose: it creates a real credential on your Grafana Cloud account, and that's your decision to make.\n\n**Copy it as soon as it appears.** You won't be shown it again, and the command at the end needs it.",
+          "skippable": true
         },
         {
           "type": "interactive",

--- a/k8s-connect-first-cluster/manifest.json
+++ b/k8s-connect-first-cluster/manifest.json
@@ -1,0 +1,29 @@
+{
+  "id": "k8s-connect-first-cluster",
+  "type": "guide",
+  "description": "Walk the four-step cluster configuration wizard: name the cluster, pick a platform and monitoring type, supply an access policy token, and copy the generated Helm command.",
+  "category": "kubernetes",
+  "author": {
+    "name": "Pathfinder Factory",
+    "team": "interactive-learning"
+  },
+  "startingLocation": "/a/grafana-k8s-app/configuration",
+  "recommends": [],
+  "testEnvironment": {
+    "tier": "cloud",
+    "minVersion": "12.3.0"
+  },
+  "targeting": {
+    "match": {
+      "or": [
+        {
+          "urlPrefixIn": [
+            "/a/grafana-k8s-app/configuration",
+            "/a/grafana-k8s-app/home",
+            "/a/grafana-k8s-app/navigation/cluster"
+          ]
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Walks the four-step cluster configuration wizard at `/a/grafana-k8s-app/configuration` and actually drives it — this is the first guide for this app that operates the UI rather than describing it.

| | |
|---|---|
| Guide | `k8s-connect-first-cluster` |
| Files | `content.json`, `manifest.json` |
| Steps | 16 across 4 sections |
| Verified | Live Grafana 12.3.0, grafana-k8s-app 2.38.0 |

## What it does

Walks the five-step unified Helm wizard — the one Grafana Cloud shows, switched on by the `unifiedHelmChartEnabled` feature toggle:

1. **Backend and distribution** — install the backend, pick the platform
2. **Access token** — name and create the access policy token
3. **Choose setup** — Standard / Lightweight / Scalable
4. **Monitoring** — what gets collected
5. **Deployment** — cluster name, namespace, copy the command, test the connection

Then a sixth section that opens **Metrics status** so the reader can see the collectors turn green, rather than ending at a command with no way to tell whether it worked.

`Create token` is deliberately `doIt: false` — it mints a real credential on the reader's Cloud account, which is their call, not a tutorial's.

## Why this is not a duplicate of `kubernetes-lp`

`kubernetes-lp` covers the same journey across `select-features-cluster-info`, `create-token`, `install-rules` and `deploy-helm-chart`. Every step in all four is markdown behind `conditional: renderer:website` — there is not one `reftarget` in the path. It tells a reader what to do; this lets them do it.

## Verification

Walked against a local build with the unified toggle patched on, stepping through all five: **18 of 19 selectors resolve to exactly one element** on the step they belong to.

The one that does not is the backend **Install** button, which only renders where the Integrations plugin is present — it is there on Cloud (which this guide targets) and absent on a local stack. The sequential walk stops at step 2 by design, since the guide does not press Create token.

`scripts/lint-targeting.py` reports nothing against this guide.

## Depends on

Test ids added in grafana/grafana-k8s-plugin#3345 — the wizard had no stable anchor on Next, Back, the step rail, the cluster name and namespace fields, the platform cards, the monitoring-type checkboxes or the feature toggles. **This guide cannot drive the wizard until that lands.**

## Targeting

Covers the wizard plus the app home and cluster views, so someone who has not connected a cluster yet meets the guide where they are rather than only on the page they have not found.

## Provenance

Generated by the Pathfinder Factory (`grafana/ai-kit`), seeded by the human-written walk in `e2e/config.spec.ts`. Nobody has yet opened this in Pathfinder and walked it as a reader — worth doing before this leaves draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
