### PR TITLE
feat(transformations): teach transformations on a data source every Grafana has

### DIFF
--- a/transform-testdata-query/content.json
+++ b/transform-testdata-query/content.json
@@ -100,34 +100,18 @@
           ]
         },
         {
-          "type": "multistep",
+          "type": "interactive",
           "id": "choose-testdata",
-          "content": "Point the query at **TestData**.",
-          "steps": [
-            {
-              "id": "filter-datasources",
-              "action": "formfill",
-              "reftarget": "{grafana:components.DataSourcePicker.inputV2}",
-              "targetvalue": "testdata",
-              "requirements": [
-                "exists-reftarget",
-                "has-datasource:grafana-testdata-datasource"
-              ],
-              "formHint": "testdata",
-              "tooltip": "Typing narrows the list to one entry, so the next click cannot land on the wrong data source.",
-              "description": "Filter the data source list."
-            },
-            {
-              "id": "select-testdata",
-              "action": "highlight",
-              "reftarget": "{grafana:components.DataSourcePicker.dataSourceList} [data-testid='data-source-card'] button",
-              "requirements": [
-                "exists-reftarget"
-              ],
-              "tooltip": "One entry is left after filtering, and this selects it.",
-              "description": "Choose TestData."
-            }
-          ]
+          "action": "formfill",
+          "reftarget": "{grafana:components.DataSourcePicker.inputV2}",
+          "targetvalue": "TestData",
+          "requirements": [
+            "exists-reftarget",
+            "has-datasource:grafana-testdata-datasource"
+          ],
+          "formHint": "TestData",
+          "content": "Set the panel's **Data source** to **TestData**.",
+          "tooltip": "Typing filters the list and picks the match, so there is nothing left to click afterwards."
         },
         {
           "type": "multistep",

--- a/transform-testdata-query/content.json
+++ b/transform-testdata-query/content.json
@@ -11,7 +11,7 @@
       "type": "callout",
       "id": "before-you-start",
       "title": "Before you start",
-      "content": "You need edit rights on a dashboard. The first section adds a TestData data source if you have not got one, which needs an administrator \u2014 skip it if one already exists."
+      "content": "You need edit rights on a dashboard. The first section adds a TestData data source and completes on its own if you already have one; creating it needs an administrator."
     },
     {
       "type": "markdown",
@@ -49,6 +49,9 @@
           "tooltip": "Grafana creates the data source as soon as you choose a type, with no separate save step.",
           "skippable": true
         }
+      ],
+      "objectives": [
+        "has-datasource:grafana-testdata-datasource"
       ]
     },
     {
@@ -164,8 +167,9 @@
             "exists-reftarget",
             "on-page:/dashboard/new"
           ],
-          "content": "Next to **Queries**, open the **Transformations** tab.",
-          "tooltip": "The number beside the name counts how many are applied, and it reads zero right now."
+          "content": "Next to **Queries**, open the **Transformations** tab. If your panel editor shows a sidebar with a **Transformations** section instead of tabs, you are on the new query editor and there is nothing to open here \u2014 skip this step.",
+          "tooltip": "The number beside the name counts how many are applied, and it reads zero right now.",
+          "skippable": true
         },
         {
           "type": "multistep",
@@ -175,7 +179,7 @@
             {
               "id": "open-transform-drawer",
               "action": "highlight",
-              "reftarget": "{grafana:components.Transforms.addTransformationButton}",
+              "reftarget": "[data-testid='data-testid add transformation button'], [aria-label='Add transformation']",
               "requirements": [
                 "exists-reftarget"
               ],
@@ -239,7 +243,7 @@
             {
               "id": "open-drawer-again",
               "action": "highlight",
-              "reftarget": "{grafana:components.Transforms.addTransformationButton}",
+              "reftarget": "[data-testid='data-testid add transformation button'], [aria-label='Add transformation']",
               "requirements": [
                 "exists-reftarget",
                 "on-page:/dashboard/new"

--- a/transform-testdata-query/content.json
+++ b/transform-testdata-query/content.json
@@ -11,7 +11,7 @@
       "type": "callout",
       "id": "before-you-start",
       "title": "Before you start",
-      "content": "You need edit rights on a dashboard. The first section adds a TestData data source if you have not got one, which needs an administrator — skip it if one already exists."
+      "content": "You need edit rights on a dashboard. The first section adds a TestData data source if you have not got one, which needs an administrator \u2014 skip it if one already exists."
     },
     {
       "type": "markdown",
@@ -22,7 +22,9 @@
       "type": "section",
       "id": "add-testdata",
       "title": "Add the TestData data source",
-      "requirements": ["is-admin"],
+      "requirements": [
+        "is-admin"
+      ],
       "blocks": [
         {
           "type": "interactive",
@@ -39,8 +41,11 @@
           "action": "button",
           "reftarget": "TestData",
           "content": "Choose **TestData** from the list.",
-          "requirements": ["exists-reftarget", "on-page:/connections/datasources/new"],
-          "verify": "[data-testid='data-testid Data source settings page Save and Test button']",
+          "requirements": [
+            "exists-reftarget",
+            "on-page:/connections/datasources/new"
+          ],
+          "verify": "on-page:/connections/datasources/edit",
           "tooltip": "Grafana creates the data source as soon as you choose a type, with no separate save step.",
           "skippable": true
         }
@@ -72,7 +77,11 @@
               "id": "add-panel",
               "action": "highlight",
               "reftarget": "{grafana:components.Sidebar.newPanelButton}",
-              "requirements": ["exists-reftarget", "on-page:/dashboard/new", "min-version:13.1.0"],
+              "requirements": [
+                "exists-reftarget",
+                "on-page:/dashboard/new",
+                "min-version:13.1.0"
+              ],
               "tooltip": "The Add pane opens with the dashboard, and this drops an empty panel onto the canvas.",
               "description": "Add a panel."
             },
@@ -80,7 +89,11 @@
               "id": "open-editor",
               "action": "highlight",
               "reftarget": "{grafana:components.Sidebar.configurePanelButton}",
-              "requirements": ["exists-reftarget", "on-page:/dashboard/new", "min-version:13.1.0"],
+              "requirements": [
+                "exists-reftarget",
+                "on-page:/dashboard/new",
+                "min-version:13.1.0"
+              ],
               "tooltip": "This opens the editor, where the Queries and Transformations tabs live.",
               "description": "Open the panel editor."
             }
@@ -96,7 +109,10 @@
               "action": "formfill",
               "reftarget": "{grafana:components.DataSourcePicker.inputV2}",
               "targetvalue": "testdata",
-              "requirements": ["exists-reftarget", "has-datasource:grafana-testdata-datasource"],
+              "requirements": [
+                "exists-reftarget",
+                "has-datasource:grafana-testdata-datasource"
+              ],
               "formHint": "testdata",
               "tooltip": "Typing narrows the list to one entry, so the next click cannot land on the wrong data source.",
               "description": "Filter the data source list."
@@ -105,7 +121,9 @@
               "id": "select-testdata",
               "action": "highlight",
               "reftarget": "{grafana:components.DataSourcePicker.dataSourceList} [data-testid='data-source-card'] button",
-              "requirements": ["exists-reftarget"],
+              "requirements": [
+                "exists-reftarget"
+              ],
               "tooltip": "One entry is left after filtering, and this selects it.",
               "description": "Choose TestData."
             }
@@ -121,7 +139,10 @@
               "action": "formfill",
               "reftarget": "input[name='seriesCount']",
               "targetvalue": "3",
-              "requirements": ["exists-reftarget", "on-page:/dashboard/new"],
+              "requirements": [
+                "exists-reftarget",
+                "on-page:/dashboard/new"
+              ],
               "formHint": "3",
               "tooltip": "The default Random Walk scenario returns one series, and three makes a transformation's effect visible.",
               "description": "Set Series count to 3."
@@ -130,7 +151,9 @@
               "id": "run-the-query",
               "action": "highlight",
               "reftarget": "{grafana:components.RefreshPicker.runButtonV2}",
-              "requirements": ["exists-reftarget"],
+              "requirements": [
+                "exists-reftarget"
+              ],
               "tooltip": "Three random walks should appear in the panel above.",
               "description": "Run the query."
             }
@@ -153,7 +176,10 @@
           "id": "open-transform-tab",
           "action": "highlight",
           "reftarget": "{grafana:components.Tab.title:Transformations}",
-          "requirements": ["exists-reftarget", "on-page:/dashboard/new"],
+          "requirements": [
+            "exists-reftarget",
+            "on-page:/dashboard/new"
+          ],
           "content": "Next to **Queries**, open the **Transformations** tab.",
           "tooltip": "The number beside the name counts how many are applied, and it reads zero right now."
         },
@@ -166,7 +192,9 @@
               "id": "open-transform-drawer",
               "action": "highlight",
               "reftarget": "{grafana:components.Transforms.addTransformationButton}",
-              "requirements": ["exists-reftarget"],
+              "requirements": [
+                "exists-reftarget"
+              ],
               "tooltip": "A drawer opens listing every transformation Grafana ships.",
               "description": "Open the transformation list."
             },
@@ -175,7 +203,9 @@
               "action": "formfill",
               "reftarget": "{grafana:components.Transforms.searchInput}",
               "targetvalue": "Reduce",
-              "requirements": ["exists-reftarget"],
+              "requirements": [
+                "exists-reftarget"
+              ],
               "formHint": "Reduce",
               "tooltip": "There are more than thirty to choose from, so searching beats scrolling.",
               "description": "Search for Reduce."
@@ -184,7 +214,9 @@
               "id": "pick-reduce",
               "action": "highlight",
               "reftarget": "{grafana:components.Transforms.card:Reduce} button",
-              "requirements": ["exists-reftarget"],
+              "requirements": [
+                "exists-reftarget"
+              ],
               "tooltip": "Reduce collapses every series to one row per field, using a calculation you choose.",
               "description": "Select Reduce."
             }
@@ -196,7 +228,10 @@
           "action": "highlight",
           "reftarget": "{grafana:components.PanelEditor.toggleTableView}",
           "targetstate": "true",
-          "requirements": ["exists-reftarget", "on-page:/dashboard/new"],
+          "requirements": [
+            "exists-reftarget",
+            "on-page:/dashboard/new"
+          ],
           "content": "Turn on **Table view** to read the frame the transformation produced.",
           "tooltip": "Three time series have become three rows, each with a name and one calculated value."
         }
@@ -221,7 +256,10 @@
               "id": "open-drawer-again",
               "action": "highlight",
               "reftarget": "{grafana:components.Transforms.addTransformationButton}",
-              "requirements": ["exists-reftarget", "on-page:/dashboard/new"],
+              "requirements": [
+                "exists-reftarget",
+                "on-page:/dashboard/new"
+              ],
               "tooltip": "The same control, now reading Add another transformation.",
               "description": "Open the transformation list again."
             },
@@ -230,7 +268,9 @@
               "action": "formfill",
               "reftarget": "{grafana:components.Transforms.searchInput}",
               "targetvalue": "Organize",
-              "requirements": ["exists-reftarget"],
+              "requirements": [
+                "exists-reftarget"
+              ],
               "formHint": "Organize",
               "tooltip": "Organize fields by name renames, reorders and hides fields.",
               "description": "Search for Organize."
@@ -239,7 +279,9 @@
               "id": "pick-organize",
               "action": "highlight",
               "reftarget": "{grafana:components.Transforms.card:Organize fields by name} button",
-              "requirements": ["exists-reftarget"],
+              "requirements": [
+                "exists-reftarget"
+              ],
               "tooltip": "It operates on the fields Reduce produced, not on the ones the query returned.",
               "description": "Select Organize fields by name."
             }
@@ -250,7 +292,7 @@
     {
       "type": "markdown",
       "id": "outro",
-      "content": "This is the point of the exercise. **Organize fields by name** lists the columns Reduce produced. Put Organize first instead and it would list the three series, and its renames would be thrown away by Reduce a moment later. Each transformation is numbered, so you can drag one above another to reorder the pipeline, or use the eye icon to disable a step without deleting it.\n\nWorth trying next, on the same panel:\n\n- **Filter data by values** — drop rows by a condition instead of filtering in the query.\n- **Add field from calculation** — a new field from arithmetic across existing ones.\n- **Join by field** — add a second query and line the two frames up on a shared field.\n\nWhen a transformation is greyed out, that is Grafana saying it cannot apply to the shape of data you currently have. Change the scenario in the **Queries** tab and the list changes with it."
+      "content": "This is the point of the exercise. **Organize fields by name** lists the columns Reduce produced. Put Organize first instead and it would list the three series, and its renames would be thrown away by Reduce a moment later. Each transformation is numbered, so you can drag one above another to reorder the pipeline, or use the eye icon to disable a step without deleting it.\n\nWorth trying next, on the same panel:\n\n- **Filter data by values** \u2014 drop rows by a condition instead of filtering in the query.\n- **Add field from calculation** \u2014 a new field from arithmetic across existing ones.\n- **Join by field** \u2014 add a second query and line the two frames up on a shared field.\n\nWhen a transformation is greyed out, that is Grafana saying it cannot apply to the shape of data you currently have. Change the scenario in the **Queries** tab and the list changes with it."
     }
   ]
 }

--- a/transform-testdata-query/content.json
+++ b/transform-testdata-query/content.json
@@ -1,0 +1,256 @@
+{
+  "id": "transform-testdata-query",
+  "title": "Transform query results with the TestData data source",
+  "blocks": [
+    {
+      "type": "markdown",
+      "id": "intro",
+      "content": "A transformation runs **after** your query returns and **before** the visualization draws. Instead of rewriting the query, you reshape the frame it produced: reduce a series to a single number, rename and reorder fields, drop rows, join two queries together.\n\nMost transformation tutorials need Prometheus. This one does not. The **TestData** data source ships with every Grafana, so the query half behaves the same everywhere and you can concentrate on the transformation half."
+    },
+    {
+      "type": "callout",
+      "id": "before-you-start",
+      "title": "Before you start",
+      "content": "You need edit rights on a dashboard. The first section adds a TestData data source if you have not got one, which needs an administrator — skip it if one already exists."
+    },
+    {
+      "type": "markdown",
+      "id": "before-setup",
+      "content": "First, make sure there is something to query."
+    },
+    {
+      "type": "section",
+      "id": "add-testdata",
+      "title": "Add the TestData data source",
+      "requirements": ["is-admin"],
+      "blocks": [
+        {
+          "type": "interactive",
+          "id": "open-datasource-types",
+          "action": "navigate",
+          "reftarget": "/connections/datasources/new",
+          "content": "Open the list of data source types under **Connections**.",
+          "tooltip": "TestData generates its own data, so there is nothing to connect and no credentials to enter.",
+          "skippable": true
+        },
+        {
+          "type": "interactive",
+          "id": "pick-testdata",
+          "action": "button",
+          "reftarget": "TestData",
+          "content": "Choose **TestData** from the list.",
+          "requirements": ["exists-reftarget", "on-page:/connections/datasources/new"],
+          "verify": "[data-testid='data-testid Data source settings page Save and Test button']",
+          "tooltip": "Grafana creates the data source as soon as you choose a type, with no separate save step.",
+          "skippable": true
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "id": "after-setup",
+      "content": "With a data source in place, build a panel whose results are worth reshaping."
+    },
+    {
+      "type": "section",
+      "id": "build-query",
+      "title": "Build a query worth transforming",
+      "blocks": [
+        {
+          "type": "multistep",
+          "id": "open-panel-editor",
+          "content": "Create a panel and open the panel editor.",
+          "steps": [
+            {
+              "id": "goto-new-dashboard",
+              "action": "navigate",
+              "reftarget": "/dashboard/new",
+              "tooltip": "An unsaved dashboard is enough; nothing here needs saving.",
+              "description": "Start a new dashboard."
+            },
+            {
+              "id": "add-panel",
+              "action": "highlight",
+              "reftarget": "{grafana:components.Sidebar.newPanelButton}",
+              "requirements": ["exists-reftarget", "on-page:/dashboard/new", "min-version:13.1.0"],
+              "tooltip": "The Add pane opens with the dashboard, and this drops an empty panel onto the canvas.",
+              "description": "Add a panel."
+            },
+            {
+              "id": "open-editor",
+              "action": "highlight",
+              "reftarget": "{grafana:components.Sidebar.configurePanelButton}",
+              "requirements": ["exists-reftarget", "on-page:/dashboard/new", "min-version:13.1.0"],
+              "tooltip": "This opens the editor, where the Queries and Transformations tabs live.",
+              "description": "Open the panel editor."
+            }
+          ]
+        },
+        {
+          "type": "multistep",
+          "id": "choose-testdata",
+          "content": "Point the query at **TestData**.",
+          "steps": [
+            {
+              "id": "filter-datasources",
+              "action": "formfill",
+              "reftarget": "{grafana:components.DataSourcePicker.inputV2}",
+              "targetvalue": "testdata",
+              "requirements": ["exists-reftarget", "has-datasource:grafana-testdata-datasource"],
+              "formHint": "testdata",
+              "tooltip": "Typing narrows the list to one entry, so the next click cannot land on the wrong data source.",
+              "description": "Filter the data source list."
+            },
+            {
+              "id": "select-testdata",
+              "action": "highlight",
+              "reftarget": "{grafana:components.DataSourcePicker.dataSourceList} [data-testid='data-source-card'] button",
+              "requirements": ["exists-reftarget"],
+              "tooltip": "One entry is left after filtering, and this selects it.",
+              "description": "Choose TestData."
+            }
+          ]
+        },
+        {
+          "type": "multistep",
+          "id": "shape-the-query",
+          "content": "Ask for three series, so there is something to reduce.",
+          "steps": [
+            {
+              "id": "set-series-count",
+              "action": "formfill",
+              "reftarget": "input[name='seriesCount']",
+              "targetvalue": "3",
+              "requirements": ["exists-reftarget", "on-page:/dashboard/new"],
+              "formHint": "3",
+              "tooltip": "The default Random Walk scenario returns one series, and three makes a transformation's effect visible.",
+              "description": "Set Series count to 3."
+            },
+            {
+              "id": "run-the-query",
+              "action": "highlight",
+              "reftarget": "{grafana:components.RefreshPicker.runButtonV2}",
+              "requirements": ["exists-reftarget"],
+              "tooltip": "Three random walks should appear in the panel above.",
+              "description": "Run the query."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "id": "after-query",
+      "content": "Three series, one query. The tabs below the panel run in the order they are listed: the query fetches, transformations rewrite what it returned, and the visualization draws whatever comes out the end. Nothing you do next changes what Grafana asked the data source for."
+    },
+    {
+      "type": "section",
+      "id": "first-transformation",
+      "title": "Add your first transformation",
+      "blocks": [
+        {
+          "type": "interactive",
+          "id": "open-transform-tab",
+          "action": "highlight",
+          "reftarget": "{grafana:components.Tab.title:Transformations}",
+          "requirements": ["exists-reftarget", "on-page:/dashboard/new"],
+          "content": "Next to **Queries**, open the **Transformations** tab.",
+          "tooltip": "The number beside the name counts how many are applied, and it reads zero right now."
+        },
+        {
+          "type": "multistep",
+          "id": "add-reduce",
+          "content": "Apply the **Reduce** transformation.",
+          "steps": [
+            {
+              "id": "open-transform-drawer",
+              "action": "highlight",
+              "reftarget": "{grafana:components.Transforms.addTransformationButton}",
+              "requirements": ["exists-reftarget"],
+              "tooltip": "A drawer opens listing every transformation Grafana ships.",
+              "description": "Open the transformation list."
+            },
+            {
+              "id": "search-reduce",
+              "action": "formfill",
+              "reftarget": "{grafana:components.Transforms.searchInput}",
+              "targetvalue": "Reduce",
+              "requirements": ["exists-reftarget"],
+              "formHint": "Reduce",
+              "tooltip": "There are more than thirty to choose from, so searching beats scrolling.",
+              "description": "Search for Reduce."
+            },
+            {
+              "id": "pick-reduce",
+              "action": "highlight",
+              "reftarget": "{grafana:components.Transforms.card:Reduce} button",
+              "requirements": ["exists-reftarget"],
+              "tooltip": "Reduce collapses every series to one row per field, using a calculation you choose.",
+              "description": "Select Reduce."
+            }
+          ]
+        },
+        {
+          "type": "interactive",
+          "id": "see-the-result",
+          "action": "highlight",
+          "reftarget": "{grafana:components.PanelEditor.toggleTableView}",
+          "targetstate": "true",
+          "requirements": ["exists-reftarget", "on-page:/dashboard/new"],
+          "content": "Turn on **Table view** to read the frame the transformation produced.",
+          "tooltip": "Three time series have become three rows, each with a name and one calculated value."
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "id": "after-first",
+      "content": "The **Mode** and **Calculations** fields are the two that matter here. *Series to rows* gives one row per series; *Reduce fields* keeps the frame's shape and replaces each field with its calculated value. Change **Calculations** from Max to Mean and the numbers change without the query re-running, because nothing about the query changed.\n\nOne transformation is a calculation. Two make a pipeline, and then order starts to matter."
+    },
+    {
+      "type": "section",
+      "id": "chain-a-second",
+      "title": "Chain a second transformation",
+      "blocks": [
+        {
+          "type": "multistep",
+          "id": "add-organize",
+          "content": "Add **Organize fields by name** after Reduce.",
+          "steps": [
+            {
+              "id": "open-drawer-again",
+              "action": "highlight",
+              "reftarget": "{grafana:components.Transforms.addTransformationButton}",
+              "requirements": ["exists-reftarget", "on-page:/dashboard/new"],
+              "tooltip": "The same control, now reading Add another transformation.",
+              "description": "Open the transformation list again."
+            },
+            {
+              "id": "search-organize",
+              "action": "formfill",
+              "reftarget": "{grafana:components.Transforms.searchInput}",
+              "targetvalue": "Organize",
+              "requirements": ["exists-reftarget"],
+              "formHint": "Organize",
+              "tooltip": "Organize fields by name renames, reorders and hides fields.",
+              "description": "Search for Organize."
+            },
+            {
+              "id": "pick-organize",
+              "action": "highlight",
+              "reftarget": "{grafana:components.Transforms.card:Organize fields by name} button",
+              "requirements": ["exists-reftarget"],
+              "tooltip": "It operates on the fields Reduce produced, not on the ones the query returned.",
+              "description": "Select Organize fields by name."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "id": "outro",
+      "content": "This is the point of the exercise. **Organize fields by name** lists the columns Reduce produced. Put Organize first instead and it would list the three series, and its renames would be thrown away by Reduce a moment later. Each transformation is numbered, so you can drag one above another to reorder the pipeline, or use the eye icon to disable a step without deleting it.\n\nWorth trying next, on the same panel:\n\n- **Filter data by values** — drop rows by a condition instead of filtering in the query.\n- **Add field from calculation** — a new field from arithmetic across existing ones.\n- **Join by field** — add a second query and line the two frames up on a shared field.\n\nWhen a transformation is greyed out, that is Grafana saying it cannot apply to the shape of data you currently have. Change the scenario in the **Queries** tab and the list changes with it."
+    }
+  ]
+}

--- a/transform-testdata-query/manifest.json
+++ b/transform-testdata-query/manifest.json
@@ -1,0 +1,23 @@
+{
+  "id": "transform-testdata-query",
+  "type": "guide",
+  "description": "Hands-on guide: shape query results with transformations, using the TestData data source that ships with every Grafana.",
+  "category": "general",
+  "author": { "name": "Grafana Pathfinder", "team": "interactive-learning" },
+  "startingLocation": "/dashboard/new",
+  "targeting": {
+    "match": {
+      "or": [
+        { "urlPrefixIn": ["/dashboard/new", "/d/"] }
+      ]
+    }
+  },
+  "testEnvironment": {
+    "minVersion": "13.1.0",
+    "datasources": ["grafana-testdata-datasource"]
+  },
+  "depends": [],
+  "recommends": [],
+  "suggests": [],
+  "provides": []
+}


### PR DESCRIPTION
## What this adds

`transform-testdata-query` — a four-section guide teaching data transformations on the **TestData**
data source: add TestData, build a three-series Random Walk query, apply **Reduce**, then chain
**Organize fields by name** so the reader sees that pipeline order is what matters.

## Why another transformations guide

The two that exist are both Cloud-only, and not by accident of wording — by targeting:

| guide | targeting | reachable on OSS/local? |
|---|---|---|
| `find-transformations` | `source: .*\.grafana\.net` | no — `source` is in the OSS matcher's unsupported set, so the whole entry is discarded |
| `data-transformation-lp` | `targetPlatform: cloud` | no |
| this one | bare `urlPrefixIn: ["/dashboard/new", "/d/"]` | yes, any tier |

TestData ships with every Grafana, so the query half of the lesson behaves identically everywhere
and no Prometheus is needed. The first section creates the data source if the reader has not got
one, gated on `is-admin` and skippable.

## Selectors

Reftargets are `{grafana:...}` paths wherever `@grafana/e2e-selectors` has a correct entry, so they
resolve against the reader's own Grafana instead of pinning the guide to the version it was authored
against. Three exceptions, each measured against a running instance rather than assumed:

- **The TestData card** on `/connections/datasources/new` uses the `button` action on visible text.
  `pages.AddDataSource.dataSourcePluginsV2` looks like the right anchor and *is* set in
  `DataSourceTypeCard.tsx`, but `Card.Heading` does not forward the caller's `data-testid` — all 52
  cards render `data-testid Card heading` instead, so the declared selector never reaches the DOM.
  Worth a separate fix in grafana/grafana; flagging it here rather than working around it silently.
- **`input[name='seriesCount']`** has no entry in the selector package.
- **`{grafana:components.Transforms.card:Reduce} button`** — the path resolves to a wrapper `div`
  and the click has to land on the `button` inside it, so the reftarget keeps a descendant
  combinator. Same for the datasource picker card.

## Verification

On a clean `grafana/grafana:13.1.3` container with **zero** data sources, so the first section ran
as a first-time reader meets it:

- Schema-valid against the Pathfinder MCP (schema 1.1.0), 11 top-level blocks.
- `scripts/lint-targeting.py` — not flagged.
- Walked **in order**: all 17 steps matched exactly one element at the moment their own step ran.
  End state: two transformations applied, three series reduced to three rows, and the Organize
  editor listing Reduce's output columns — which is the claim the last markdown block makes.
- `verify` on the data-source step resolves on the page the step lands on.

`minVersion: 13.1.0`, because it uses the new dashboard edit experience. Nothing here claims to work
on 12.x — it was not tested there.

## Rules checked

Against `AGENTS.md`: `exists-reftarget` on every targeting step, `on-page:` on page-specific steps,
`verify` after the create, one-sentence tooltips under 250 characters that do not name the
highlighted element, section bookends outside the sections, no markdown inside a section, no
multistep singletons, GUI names bolded and nothing else. The transformation drawer and the data
source list are both fully rendered rather than virtualised — checked by counting DOM nodes — so no
`guided`/`lazyRender` is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
